### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Minnow is a Vite + TypeScript SPA chat client for LM Studio. See `README.md` for
 - **`npm start`** is the recommended dev command — starts Vite + the Node tool server on port 5173 (or next free port). Set `BROWSER=none` to suppress auto-open.
 - **`npm run dev`** starts Vite only (no tool server) — useful for pure UI work but most tool-dependent features won't function.
 - The tool server exposes `/api/tools/ping`, `/api/config/ping`, `/api/memory/ping`, and other endpoints. Verify health with `curl http://localhost:5173/api/tools/ping`.
-- LM Studio is **not available** in Cloud Agent VMs, so the model dropdown will be empty and LLM chat will not function. All UI, tool server APIs, and tests work without it.
+- **LM Studio headless daemon** (`llmster`) can be installed via `curl -fsSL https://lmstudio.ai/install.sh | bash`. Start with `lms daemon up && lms server start`. Download a model with `lms get <model-name> -y` and load it with `lms load <model-name> -y`. The CLI is at `~/.lmstudio/bin/lms` (add to PATH: `export PATH="$HOME/.lmstudio/bin:$PATH"`).
+- **Known streaming issue**: The `llmster` headless daemon has a streaming SSE incompatibility with Minnow's browser-side parser — chat messages fail with a `ReadableStreamDefaultController` JSON parsing error. The server-side generation proxy works correctly (verified via curl). This does not affect the tool server APIs, tests, or builds — only live LLM chat in the browser UI.
 
 ### Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Minnow is a Vite + TypeScript SPA chat client for LM Studio. See `README.md` for setup/scripts and `documentation/context.md` for architecture details.
+
+### Running the app
+
+- **`npm start`** is the recommended dev command — starts Vite + the Node tool server on port 5173 (or next free port). Set `BROWSER=none` to suppress auto-open.
+- **`npm run dev`** starts Vite only (no tool server) — useful for pure UI work but most tool-dependent features won't function.
+- The tool server exposes `/api/tools/ping`, `/api/config/ping`, `/api/memory/ping`, and other endpoints. Verify health with `curl http://localhost:5173/api/tools/ping`.
+- LM Studio is **not available** in Cloud Agent VMs, so the model dropdown will be empty and LLM chat will not function. All UI, tool server APIs, and tests work without it.
+
+### Testing
+
+- **`npm test`** runs the full suite (~500 tests via `node --test` and `tsx`). Expect 5 pre-existing failures in reef widget convention tests — these are known and unrelated to general functionality.
+- **`npx tsc --noEmit`** for type checking (no separate ESLint config exists).
+- Subset test commands: `npm run test:memory`, `npm run test:lsp`, `npm run test:mcp`, `npm run test:browser`, `npm run test:skills`, `npm run test:attachments`. See `package.json` scripts for the full list.
+
+### Building
+
+- **`npm run build`** runs `tsc && vite build` and outputs to `dist/`. The `prebuild` step generates `src/skills/builtin-manifest.json`.
+
+### Key gotchas
+
+- The `postinstall` script runs `node scripts/sync-impeccable-skill.mjs` to vendor the Impeccable UI skill into `src/skills/impeccable/`. This is expected and idempotent.
+- `get_datetime` and `calculate` are **browser-only** tools — calling them via the `/api/tools` POST endpoint returns "Not implemented" since they run client-side in the browser.
+- The `[providers] fetch failed` log on startup is normal in environments without LM Studio — it simply means the provider discovery couldn't reach `localhost:1234`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions so future cloud agents can quickly set up and work with the Minnow codebase.

## What's included

- Overview of the codebase and pointers to existing docs (`README.md`, `documentation/context.md`)
- How to run the app (`npm start` vs `npm run dev`)
- How to install and run LM Studio headless daemon (`llmster`) for local LLM inference
- Known streaming SSE incompatibility between `llmster` and Minnow's browser-side parser
- How to run tests (`npm test`, subset commands, type checking)
- How to build (`npm run build`)
- Key gotchas discovered during setup (browser-only tools, `postinstall` vendor script, provider fetch warnings)

## Environment verification

All core development workflows were verified:

| Check | Result |
|-------|--------|
| `npm install` | Passes, 328 packages |
| `npx tsc --noEmit` | Passes, no errors |
| `npm test` | 498/503 pass (5 pre-existing reef widget convention failures) |
| `npm run build` | Passes |
| `npm start` (dev server) | Starts on port 5173, all API endpoints healthy |
| LM Studio `llmster` | Installed, server running on port 1234 |
| Model (gemma-3-1b) | Downloaded, loaded, generates responses via API |
| UI interaction | App loads, model detected, settings work, composer accepts input |

## LM Studio status

LM Studio's headless daemon (`llmster`) is installed and operational. The server-side generation proxy correctly streams SSE from LM Studio. However, there is a pre-existing streaming SSE parsing incompatibility in the browser client that prevents chat responses from rendering in the UI.

[Minnow main interface](https://cursor.com/agents/bc-0feae160-1369-472b-9620-151e8af46060/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fminnow_main_interface.webp)
[Gemma model loaded and ready](https://cursor.com/agents/bc-0feae160-1369-472b-9620-151e8af46060/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fminnow_gemma_model_ready.webp)
[Chat generating response](https://cursor.com/agents/bc-0feae160-1369-472b-9620-151e8af46060/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fminnow_generating_response.webp)

API test log:
[lmstudio_api_test.log](https://cursor.com/agents/bc-0feae160-1369-472b-9620-151e8af46060/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flmstudio_api_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0feae160-1369-472b-9620-151e8af46060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0feae160-1369-472b-9620-151e8af46060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

