### PR TITLE
Expo App (iOS / Android)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -384,7 +384,7 @@ When `Chat.modeId === 'reef'`, assistant markdown with complete ` ```reef-widget
 
 **Tests:** `test/chat/reef/*.test.mts` (21 tests, happy-dom).
 
-**Widget library (snippets):** Six composable `snippet-*.md` files â€” `snippet-chart-line`, `snippet-chart-bar` (Recharts), `snippet-table`, `snippet-stat-card`, `snippet-input-row`, `snippet-sparkline` (SVG, embed in stat card `.rw-spark`). Full templates (15) cover end-to-end UIs including `qa-callllm` (`callLLM` + `onChunk` streaming). Conventions: description + bullets above one ` ```reef-widget ` fence; theme tokens only; snippets omit title chrome.
+**Widget library (snippets):** Six composable `snippet-*.md` files â€” `snippet-chart-line`, `snippet-chart-bar` (Recharts), `snippet-table`, `snippet-stat-card`, `snippet-input-row`, `snippet-sparkline` (SVG, embed in stat card `.rw-spark`). Full templates (15) cover end-to-end UIs including `qa-callllm` (`callLLM` + `onChunk` streaming). Conventions: description + bullets above one ` ```reef-widget ` fence; **no hex colors** (use `var(--*)` and `color-mix` with forwarded tokens for charts/heatmaps); snippets omit title chrome.
 
 ### Expert system (Step 06)
 

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -38,7 +38,7 @@ Assignable pack: [`documentation/plans/product_backlog_agents_48a41af9.plan.md`]
 | 29 | all-full-permissions | Shipped | `1cf8c45` |
 | 31 | ask-question-cards | Shipped | [`documentation/plans/feature-31-ask-question-cards.md`](plans/feature-31-ask-question-cards.md) |
 
-**Integration QA (2026-05-20):** `npm run build` PASS; `npm test` **459** tests, **457** pass (**2** fail: `messages-stream-row` session init â€” unrelated to Reef); all **63** reef tests pass (paths, conventions, prompts catalog, iframe/bridge).
+**Integration QA (2026-05-21):** Reef widget chart templates/snippets use theme tokens only (`var(--accent)`, `color-mix(in oklch, var(--accent) …)` for multi-series/heatmap levels — no hex). `node --test test/chat/reef/*.test.mjs` convention suites pass (24 tests). Full `npm test` may still report unrelated failures (e.g. `messages-stream-row` session init).
 
 ## What it is
 

--- a/src/chat/reef/widgets/calculator-with-chart.md
+++ b/src/chat/reef/widgets/calculator-with-chart.md
@@ -40,12 +40,19 @@ function App() {
     return { taxAmt, tipAmt, total, each: total / Math.max(1, split) };
   }, [bill, tipPct, taxPct, split]);
 
+  const barColors = [
+    'var(--accent)',
+    'color-mix(in oklch, var(--accent) 65%, var(--text-muted))',
+    'color-mix(in oklch, var(--accent) 40%, var(--surface-elevated))',
+    'var(--text-muted)',
+  ];
+
   const data = useMemo(
     () => [
-      { name: 'Subtotal', value: bill, color: '#4f8ef7' },
-      { name: 'Tax', value: calc.taxAmt, color: '#f97316' },
-      { name: 'Tip', value: calc.tipAmt, color: '#22c55e' },
-      { name: 'Total', value: calc.total, color: '#a855f7' },
+      { name: 'Subtotal', value: bill },
+      { name: 'Tax', value: calc.taxAmt },
+      { name: 'Tip', value: calc.tipAmt },
+      { name: 'Total', value: calc.total },
     ],
     [bill, calc.taxAmt, calc.tipAmt, calc.total],
   );
@@ -125,7 +132,7 @@ function App() {
             />
             <Bar dataKey="value" radius={[4, 4, 0, 0]}>
               {data.map((d, i) => (
-                <Cell key={i} fill={d.color} />
+                <Cell key={i} fill={barColors[i % barColors.length]} />
               ))}
             </Bar>
           </BarChart>

--- a/src/chat/reef/widgets/heatmap.md
+++ b/src/chat/reef/widgets/heatmap.md
@@ -14,10 +14,10 @@ GitHub-style contribution calendar (7 day rows × 14 week columns) with hover co
   width: 12px; height: 12px; border-radius: 2px; border: 0.5px solid var(--border);
   background: var(--surface); cursor: default;
 }
-.rw-cell[data-l="1"] { background: #93c5fd; }
-.rw-cell[data-l="2"] { background: #60a5fa; }
-.rw-cell[data-l="3"] { background: #3b82f6; }
-.rw-cell[data-l="4"] { background: #1d4ed8; border-color: #1e40af; }
+.rw-cell[data-l="1"] { background: color-mix(in oklch, var(--accent) 25%, var(--surface)); }
+.rw-cell[data-l="2"] { background: color-mix(in oklch, var(--accent) 50%, var(--surface)); }
+.rw-cell[data-l="3"] { background: color-mix(in oklch, var(--accent) 75%, var(--surface)); }
+.rw-cell[data-l="4"] { background: var(--accent); border-color: color-mix(in oklch, var(--accent) 70%, var(--border-strong)); }
 .rw-legend-row { display: flex; align-items: center; gap: 6px; margin-top: 10px; font-size: 0.75rem; color: var(--text-muted); }
 .rw-legend-row .rw-heat { grid-auto-flow: row; grid-template-rows: none; grid-template-columns: repeat(5, 12px); gap: 3px; }
 </style>

--- a/src/chat/reef/widgets/pie-chart.md
+++ b/src/chat/reef/widgets/pie-chart.md
@@ -19,7 +19,12 @@ import React, { useLayoutEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
-const SLICE_COLORS = ['#4f8ef7', '#f97316', '#22c55e', '#a855f7'];
+const SLICE_COLORS = [
+  'var(--accent)',
+  'color-mix(in oklch, var(--accent) 65%, var(--text-muted))',
+  'color-mix(in oklch, var(--accent) 40%, var(--surface-elevated))',
+  'var(--text-muted)',
+];
 const LABELS = ['Alpha', 'Beta', 'Gamma', 'Delta'];
 
 function App() {

--- a/src/chat/reef/widgets/slider-graph.md
+++ b/src/chat/reef/widgets/slider-graph.md
@@ -37,7 +37,7 @@ function App() {
             <XAxis dataKey="x" stroke="var(--text-muted)" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} />
             <YAxis stroke="var(--text-muted)" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} />
             <Tooltip contentStyle={{ background: 'var(--surface)', border: '0.5px solid var(--border)', borderRadius: 'var(--radius-sm)', color: 'var(--text)' }} />
-            <Line type="monotone" dataKey="y" stroke="#4f8ef7" strokeWidth={2} dot={{ fill: '#4f8ef7', r: 3 }} />
+            <Line type="monotone" dataKey="y" stroke="var(--accent)" strokeWidth={2} dot={{ fill: 'var(--accent)', r: 3 }} />
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/src/chat/reef/widgets/snippet-chart-bar.md
+++ b/src/chat/reef/widgets/snippet-chart-bar.md
@@ -1,7 +1,7 @@
 Minimal bar chart inside `.rw-chart`. Same axis/tooltip/resize pattern as the line snippet; `BarChart` / `Bar` from Recharts.
 
 - Replace `DATA` with `{ name, value }` rows (or change `dataKey`s).
-- Set `fill` on `<Bar>` or per-row `fill` for multi-series palettes using actual colors (not theme tokens).
+- Set `fill` on `<Bar>` to `var(--accent)` or per-row `fill` with `color-mix(in oklch, var(--accent) …)` for multi-series palettes.
 
 ```reef-widget
 <style>
@@ -37,7 +37,7 @@ function App() {
             <XAxis dataKey="name" stroke="var(--text-muted)" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} />
             <YAxis stroke="var(--text-muted)" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} />
             <Tooltip contentStyle={{ background: 'var(--surface)', border: '0.5px solid var(--border)', borderRadius: 'var(--radius-sm)', color: 'var(--text)' }} />
-            <Bar dataKey="value" fill="#4f8ef7" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="value" fill="var(--accent)" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/chat/reef/widgets/snippet-chart-line.md
+++ b/src/chat/reef/widgets/snippet-chart-line.md
@@ -39,7 +39,7 @@ function App() {
             <XAxis dataKey="x" stroke="var(--text-muted)" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} />
             <YAxis stroke="var(--text-muted)" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} />
             <Tooltip contentStyle={{ background: 'var(--surface)', border: '0.5px solid var(--border)', borderRadius: 'var(--radius-sm)', color: 'var(--text)' }} />
-            <Line type="monotone" dataKey="y" stroke="#4f8ef7" strokeWidth={2} dot={{ fill: '#4f8ef7', r: 3 }} />
+            <Line type="monotone" dataKey="y" stroke="var(--accent)" strokeWidth={2} dot={{ fill: 'var(--accent)', r: 3 }} />
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/src/chat/reef/widgets/snippet-sparkline.md
+++ b/src/chat/reef/widgets/snippet-sparkline.md
@@ -1,4 +1,4 @@
-Pure SVG sparkline (~80×24px, `stroke: #4f8ef7`). No chart library.
+Pure SVG sparkline (~80×24px, `stroke: var(--accent)`). No chart library.
 
 **Embed in a stat card:** copy the `<svg class="rw-sparkline">` into the `.rw-spark` slot on `snippet-stat-card.md` (replace the placeholder). Keep the card’s `.rw-spark { margin-top: 8px; height: 36px; … }` wrapper so the line centers in the reserved band.
 
@@ -9,10 +9,11 @@ Pure SVG sparkline (~80×24px, `stroke: #4f8ef7`). No chart library.
 <style>
 .rw { max-width: 680px; font-family: var(--font-ui); color: var(--text); }
 .rw-sparkline { display: block; width: 80px; height: 24px; }
+.rw-sparkline polyline { stroke: var(--accent); }
 </style>
 <div class="rw">
   <svg class="rw-sparkline" viewBox="0 0 80 24" width="80" height="24" aria-hidden="true">
-    <polyline id="spark" fill="none" stroke="#4f8ef7" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <polyline id="spark" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
   </svg>
 </div>
 <script>


### PR DESCRIPTION
**Goal:** Native iOS/Android app for the Vinea dashboard via Expo, while the existing desktop web view keeps working, and one unified development surface (one workspace, shared logic packages, shared design tokens).

**Architecture decision (hybrid):**
- ❌ WebView wrapper of the PWA — rejected: iOS WKWebView does not run service workers (offline shell dies on iOS), Google/Apple/Microsoft OAuth is blocked in embedded WebViews (Clerk Google sign-in breaks), and it unifies nothing.
- ❌ Full React Native + react-native-web rewrite — rejected for now: the finished desktop PWA (Mapbox terrain, tokens, offline, Clerk prebuilt) would be rebuilt on a second renderer with no desktop gain; the map has no cross-platform library (mapbox-gl is web-only, @rnmapbox/maps is native-only).
- ✅ **Chosen:** new Expo SDK 57 app at `web/apps/mobile` (iOS/Android) + existing Vite web app untouched. Unification lives in the workspace: `packages/core` (portable logic moved from `web/app/src`: units, clock, geo, terrain, declutter, plotScale, series, insights presentation, profile/session, setup), `packages/theme` (tokens.ts generated from tokens.css), one dev command. `@vinea/api` already imports unchanged.

**Native map:** @rnmapbox/maps for pixel parity (satellite-v9 + DEM terrain + fill-extrusion prisms) — requires Mapbox billing enabled on the account and a dev build (no Expo Go).

**Phases:**
1. Scaffold + unification — Expo app boots on iOS/Android, shared packages extracted, web stays green, proof screen (Clerk → API → shared domain → Today-lite).
2. Screen port in grower-value order — Today → Alerts → Readings (+Plot) → Sources → Settings → connect flows → Estate/Profile/Vineyards/Team → Setup/Onboarding.
3. Map on native — rnmapbox dev build, terrain/block/draft layers, scene state shared with web.
4. Hardening & release — push notifications (backend `push` channel is not implemented yet — provider decision needed), offline caching, EAS builds, TestFlight/Play.

**Prerequisites:** Mapbox billing-enabled account; Clerk mobile config (scheme redirects, native OAuth vs JS-only); iOS/Android bundle IDs; push provider decision.


Full plan: `documentation/plans/vin-10-expo-app.md`