### PR TITLE
🐛 fix(orchestrate): do not mark board tasks complete on max tool turns (MIN-10)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -510,7 +510,7 @@ Parent tool loop can spawn **isolated sub-agents** (separate messages, model, to
 
 **Built-in types:** `generalPurpose`, `explore`, `shell`, `explorer` (Step 19 self-heal stub, `maxConcurrent: 1`).
 
-**Config (`sub-agents.json`):** root `enabled`, `globalMaxConcurrent`, `defaultTimeoutMs`, `defaultMaxToolTurns`; per-type `providerId`, `modelId`, `maxConcurrent`, `timeoutMs`, `maxToolTurns`, `allowedTools` (whitelist or null), `deniedTools`, optional `workAgentId`. Hitting the cap sets run status **`failed`** (not `completed`) and linked board tasks **`failed`** (MIN-15 / MIN-10).
+**Config (`sub-agents.json`):** root `enabled`, `globalMaxConcurrent`, `defaultTimeoutMs`, `defaultMaxToolTurns`; per-type `providerId`, `modelId`, `maxConcurrent`, `timeoutMs`, `maxToolTurns`, `allowedTools` (whitelist or null), `deniedTools`, optional `workAgentId`. Hitting the cap sets run status **`failed`** (not `completed`), `get_sub_agent_status` exposes **`success: false`**, and linked board tasks **`failed`** — never **`complete`** (`src/agents/sub-agent-outcome.ts`, `syncBoardTaskOnSettle`, `board_update_task` guard when `assignedRunId` run did not succeed) (MIN-15 / MIN-10).
 
 **Concurrency:** Over-cap spawns stay **`queued`** until a slot frees (FIFO global queue).
 

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -10,6 +10,10 @@ import { loadSubAgentConfig } from './sub-agent-config';
 import { buildSubAgentSystemPrompt } from './sub-agent-prompt';
 import { createSubAgentRunId } from './sub-agent-run-id';
 import { DEFAULT_SUB_AGENT_MAX_TOOL_TURNS } from './sub-agent-config';
+import {
+  isMaxToolTurnFailure,
+  SUB_AGENT_MAX_TOOL_TURNS_ERROR,
+} from './sub-agent-outcome';
 import { getSubAgentRunner } from './sub-agent-runner';
 import { resolveSubAgentTools } from './sub-agent-tools';
 import { observeSubAgentToolCall } from './self-healing/controller';
@@ -157,7 +161,10 @@ function syncBoardTaskOnSettle(
   if (!chat?.orchestrateBoard) return;
 
   const endedAt = Date.now();
-  if (status === 'completed') {
+  const maxTurnFailure =
+    status === 'completed' && isMaxToolTurnFailure(run.summary, error);
+
+  if (status === 'completed' && !maxTurnFailure) {
     updateTask(chat, taskId, {
       status: 'complete',
       endedAt,
@@ -165,11 +172,17 @@ function syncBoardTaskOnSettle(
     });
     return;
   }
-  if (status === 'failed' || status === 'cancelled') {
+  if (status === 'failed' || status === 'cancelled' || maxTurnFailure) {
     updateTask(chat, taskId, {
       status: 'failed',
       endedAt,
-      error: error || (status === 'cancelled' ? 'cancelled' : 'failed'),
+      error:
+        error ||
+        (maxTurnFailure
+          ? SUB_AGENT_MAX_TOOL_TURNS_ERROR
+          : status === 'cancelled'
+            ? 'cancelled'
+            : 'failed'),
       assignedRunId: null,
     });
   }
@@ -240,7 +253,7 @@ async function executeRun(internals: RunInternals, modeId: string): Promise<void
         internals,
         'failed',
         output.summary,
-        'maximum tool turns reached',
+        SUB_AGENT_MAX_TOOL_TURNS_ERROR,
       );
       return;
     }
@@ -620,10 +633,13 @@ export function formatSubAgentListToolResult(parentTurnId: string | null | undef
 
 /** Serializable snapshot for `get_sub_agent_status`. */
 export function buildSubAgentStatusPayload(run: SubAgentRun): Record<string, unknown> {
+  const success =
+    run.status === 'completed' && !isMaxToolTurnFailure(run.summary, run.error);
   const payload: Record<string, unknown> = {
     runId: run.runId,
     type: run.type,
     status: run.status,
+    success,
     summary: run.summary,
     startedAt: run.startedAt,
     endedAt: run.endedAt,

--- a/src/agents/sub-agent-outcome.ts
+++ b/src/agents/sub-agent-outcome.ts
@@ -1,0 +1,25 @@
+/**
+ * Sub-agent terminal outcome helpers (max tool turns vs real success).
+ */
+
+import type { SubAgentRun } from './types';
+
+/** Settled run `error` when the tool loop hits maxToolTurns without a final answer. */
+export const SUB_AGENT_MAX_TOOL_TURNS_ERROR = 'maximum tool turns reached';
+
+/** True when summary text indicates the runner hit the tool-turn cap. */
+export function isMaxToolTurnSummary(summary: string): boolean {
+  return /maximum tool turns/i.test(summary);
+}
+
+/** True when a settled run failed because of tool-turn exhaustion (not real completion). */
+export function isMaxToolTurnFailure(summary: string, error: string | null): boolean {
+  if (error === SUB_AGENT_MAX_TOOL_TURNS_ERROR) return true;
+  return isMaxToolTurnSummary(summary);
+}
+
+/** True only for a genuine completed sub-agent run (excludes max-turn false positives). */
+export function isSubAgentRunSuccessful(run: SubAgentRun): boolean {
+  if (run.status !== 'completed') return false;
+  return !isMaxToolTurnFailure(run.summary, run.error);
+}

--- a/src/chat/prompts/modes/orchestrate.full.md
+++ b/src/chat/prompts/modes/orchestrate.full.md
@@ -129,9 +129,11 @@ Every **`spawn_sub_agent`** must include **`category`** and **`board_task_id`** 
 
 - **`spawn_sub_agent`** with **`wait: false`** returns immediately with a `runId` while the sub-agent keeps working.
 - **`list_sub_agents`** — all runs for this **parent user-message turn** (queued / running / finished) with short `taskPreview` rows.
-- **`get_sub_agent_status`** with **`run_id`** — live `status`, `summary` when complete, `lastMessagePreview`, and `error` when failed.
+- **`get_sub_agent_status`** with **`run_id`** — live `status`, `success` (false when max tool turns or failed), `summary`, `lastMessagePreview`, and `error` when failed.
 
 **Parallel wave pattern:** spawn up to the concurrency cap with `wait: false`, record `runId`s, then call `list_sub_agents` until every run in that batch is terminal (`completed` / `failed` / `cancelled`). Use `get_sub_agent_status` on any non-success run before updating the board.
+
+**Max tool turns:** If `get_sub_agent_status` shows `success: false`, `status: failed`, or a summary containing **maximum tool turns**, the sub-agent did **not** finish the task. Do **not** call `board_update_task` with `complete`. Mark the task `failed` (or leave `in_progress` and restart via `restart_sub_agent` / a new spawn). `board_update_task` with `complete` is rejected server-side when the linked `assignedRunId` run failed or hit the cap.
 
 **Sequential pattern (simpler):** use `spawn_sub_agent` with default **`wait: true`** (or explicit `wait: true`) to block until the aggregate JSON returns — no polling needed.
 
@@ -148,7 +150,7 @@ For each task in the current wave (parallelized up to the concurrency limit):
    - Pass the task's full Build spec as the prompt
    - wait: true OR wait: false + list_sub_agents / get_sub_agent_status
 
-3. On Builder DONE:
+3. On Builder DONE (`success: true`, not max tool turns):
    - board_update_task — status testing (before verifier)
    - Spawn a Verifier sub-agent
    - spawn_sub_agent: category test, board_task_id <task id>

--- a/src/chat/prompts/modes/orchestrate.lite.md
+++ b/src/chat/prompts/modes/orchestrate.lite.md
@@ -34,7 +34,7 @@ Loop per task (parallel within a wave, sequential between waves, max `globalMaxC
 4. PASS → **`board_update_task`** `complete` (+ `files_changed` / `notes`), next task.
 5. FAIL → **`board_update_task`** `failed` or `blocked`, surface error, ask user retry/skip/abort.
 
-**Check-in tools:** `list_sub_agents`; `get_sub_agent_status({ run_id })`.
+**Check-in tools:** `list_sub_agents`; `get_sub_agent_status({ run_id })` — if `success: false` or summary mentions **maximum tool turns**, do not mark the task `complete`; use `failed` or restart the sub-agent.
 
 Rules:
 - You write no application code. Only **`board_*`** tools + sub-agent spawns.

--- a/src/tools/board-tools.ts
+++ b/src/tools/board-tools.ts
@@ -2,6 +2,11 @@
  * Orchestrate board tools: board_init, board_update_task, board_get_state.
  */
 
+import { getSubAgentRun } from '../agents/orchestrator.ts';
+import {
+  isMaxToolTurnSummary,
+  isSubAgentRunSuccessful,
+} from '../agents/sub-agent-outcome.ts';
 import { normalizeModeId } from '../chat/modes/types.ts';
 import {
   getBoardState,
@@ -209,6 +214,29 @@ export async function executeBoardTool(
       return 'Error: orchestrate board is not initialized';
     }
     try {
+      if (validated.args.status === 'complete') {
+        const task = chat.orchestrateBoard.tasks.find(
+          (t) => t.id === validated.args.task_id,
+        );
+        if (task?.error && isMaxToolTurnSummary(task.error)) {
+          return (
+            'Error: cannot mark task complete — task failed with max tool turns. ' +
+            'Restart or spawn a new sub-agent.'
+          );
+        }
+        const linkedRunId =
+          validated.args.run_id?.trim() || task?.assignedRunId?.trim() || '';
+        if (linkedRunId) {
+          const run = getSubAgentRun(linkedRunId);
+          if (run && !isSubAgentRunSuccessful(run)) {
+            return (
+              'Error: cannot mark task complete — linked sub-agent run did not succeed ' +
+              '(failed, cancelled, or hit max tool turns). Restart or spawn a new sub-agent.'
+            );
+          }
+        }
+      }
+
       const patch: Parameters<typeof updateTask>[2] = { status: validated.args.status };
       if (validated.args.run_id) patch.assignedRunId = validated.args.run_id;
       if (validated.args.files_changed !== undefined) {

--- a/test/agents/sub-agent-outcome.test.mts
+++ b/test/agents/sub-agent-outcome.test.mts
@@ -1,0 +1,75 @@
+/**
+ * Sub-agent max tool turn outcome detection.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  isMaxToolTurnFailure,
+  isMaxToolTurnSummary,
+  isSubAgentRunSuccessful,
+  SUB_AGENT_MAX_TOOL_TURNS_ERROR,
+} from '../../src/agents/sub-agent-outcome.ts';
+import type { SubAgentRun } from '../../src/agents/types.ts';
+
+function minimalRun(overrides: Partial<SubAgentRun>): SubAgentRun {
+  return {
+    runId: 'run-1',
+    type: 'explore',
+    task: 't',
+    status: 'completed',
+    parentChatId: null,
+    parentToolCallId: null,
+    parentTurnId: null,
+    summary: '',
+    error: null,
+    startedAt: null,
+    endedAt: null,
+    toolTurns: 0,
+    maxToolTurns: 8,
+    cancelled: false,
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe('sub-agent-outcome', () => {
+  test('isMaxToolTurnSummary matches exhaustion summary', () => {
+    assert.equal(
+      isMaxToolTurnSummary('Sub-agent reached maximum tool turns (8).'),
+      true,
+    );
+    assert.equal(isMaxToolTurnSummary('FIXED_SUMMARY'), false);
+  });
+
+  test('isMaxToolTurnFailure uses error and summary', () => {
+    assert.equal(isMaxToolTurnFailure('', SUB_AGENT_MAX_TOOL_TURNS_ERROR), true);
+    assert.equal(
+      isMaxToolTurnFailure('Sub-agent reached maximum tool turns (4).', null),
+      true,
+    );
+    assert.equal(isMaxToolTurnFailure('done', null), false);
+  });
+
+  test('isSubAgentRunSuccessful rejects completed max-turn runs', () => {
+    assert.equal(
+      isSubAgentRunSuccessful(
+        minimalRun({
+          status: 'completed',
+          summary: 'Sub-agent reached maximum tool turns (8).',
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      isSubAgentRunSuccessful(
+        minimalRun({ status: 'failed', summary: 'Sub-agent reached maximum tool turns (8).' }),
+      ),
+      false,
+    );
+    assert.equal(
+      isSubAgentRunSuccessful(minimalRun({ status: 'completed', summary: 'All done.' })),
+      true,
+    );
+  });
+});

--- a/test/sub-agents/sub-agent-tool-turn-exhaustion.test.mts
+++ b/test/sub-agents/sub-agent-tool-turn-exhaustion.test.mts
@@ -15,7 +15,12 @@ import {
   setSubAgentRunnerFactory,
 } from '../../src/agents/sub-agent-runner.ts';
 import type { SubAgentRunner } from '../../src/agents/types.ts';
+import { buildSubAgentStatusPayload } from '../../src/agents/orchestrator.ts';
 import { initBoard } from '../../src/state/orchestrate-board-store.ts';
+import {
+  executeSubAgentTool,
+  setSubAgentExecutorContext,
+} from '../../src/tools/sub-agent-executor.ts';
 import {
   createEmptyChatObject,
   findChatById,
@@ -88,5 +93,56 @@ describe('sub-agent tool turn exhaustion', () => {
     const task = chat?.orchestrateBoard?.tasks.find((t) => t.id === TASK_ID);
     assert.equal(task?.status, 'failed');
     assert.notEqual(task?.status, 'complete');
+  });
+
+  test('get_sub_agent_status reports success false after max turns', async () => {
+    await spawnSubAgent({
+      type: 'explore',
+      task: 'scaffold many files',
+      wait: true,
+      parentChatId: FIXED_CHAT_ID,
+      parentTurnId: 'turn-status',
+      modeId: 'orchestrate',
+      boardTaskId: TASK_ID,
+    });
+
+    setSubAgentExecutorContext({
+      parentTurnId: 'turn-status',
+      modeId: 'orchestrate',
+      parentChatId: FIXED_CHAT_ID,
+    });
+
+    const statusOut = await executeSubAgentTool('get_sub_agent_status', {
+      run_id: FIXED_RUN_ID,
+    });
+    const body = JSON.parse(statusOut) as {
+      status: string;
+      success: boolean;
+      error?: string;
+      summary: string;
+    };
+    assert.equal(body.status, 'failed');
+    assert.equal(body.success, false);
+    assert.match(body.summary, /maximum tool turns/i);
+    if (body.error) {
+      assert.match(body.error, /maximum tool turns/i);
+    }
+  });
+
+  test('buildSubAgentStatusPayload never marks max-turn summary as success', async () => {
+    const { getSubAgentRun } = await import('../../src/agents/orchestrator.ts');
+    await spawnSubAgent({
+      type: 'explore',
+      task: 'scaffold',
+      wait: true,
+      parentChatId: FIXED_CHAT_ID,
+      parentTurnId: 'turn-payload',
+      modeId: 'orchestrate',
+    });
+    const run = getSubAgentRun(FIXED_RUN_ID);
+    assert.ok(run);
+    const payload = buildSubAgentStatusPayload(run);
+    assert.equal(payload.success, false);
+    assert.equal(payload.status, 'failed');
   });
 });

--- a/test/tools/board-tools.test.mts
+++ b/test/tools/board-tools.test.mts
@@ -4,6 +4,17 @@
 
 import assert from 'node:assert/strict';
 import { beforeEach, describe, test } from 'node:test';
+import { spawnSubAgent, resetSubAgentOrchestrator } from '../../src/agents/orchestrator.ts';
+import { resetSubAgentConfigCache } from '../../src/agents/sub-agent-config.ts';
+import {
+  resetSubAgentRunIdFactory,
+  setSubAgentRunIdFactory,
+} from '../../src/agents/sub-agent-run-id.ts';
+import {
+  resetSubAgentRunnerFactory,
+  setSubAgentRunnerFactory,
+} from '../../src/agents/sub-agent-runner.ts';
+import type { SubAgentRunner } from '../../src/agents/types.ts';
 import { setBoardNowForTests } from '../../src/state/orchestrate-board-store.ts';
 import {
   setSessionStateForTests,
@@ -254,5 +265,61 @@ describe('executeBoardTool', () => {
     withBoardContext();
     const out = await executeBoardTool('board_get_state', {});
     assert.equal(out, 'Error: orchestrate board is not initialized');
+  });
+
+  test('board_update_task rejects complete when linked run hit max tool turns', async () => {
+    const FIXED_RUN_ID = '11111111-1111-1111-1111-111111111111';
+    const exhaustingRunner: SubAgentRunner = {
+      async run(input) {
+        return {
+          summary: `Sub-agent reached maximum tool turns (${input.maxToolTurns}).`,
+          toolTurns: input.maxToolTurns,
+          messages: [],
+          toolTurnLimitExhausted: true,
+        };
+      },
+    };
+
+    resetSubAgentOrchestrator();
+    resetSubAgentConfigCache();
+    resetSubAgentRunnerFactory();
+    resetSubAgentRunIdFactory();
+    setSubAgentRunnerFactory(() => exhaustingRunner);
+    setSubAgentRunIdFactory(() => FIXED_RUN_ID);
+
+    seedOrchestrateChat();
+    withBoardContext();
+
+    await executeBoardTool('board_init', {
+      plan_path: PLAN_PATH,
+      tasks: [
+        { id: 'W1-A', title: 'Implement board store', wave: 'W1', category: 'build' },
+      ],
+      waves: [{ id: 'W1' }],
+    });
+
+    await spawnSubAgent({
+      type: 'explore',
+      task: 'long work',
+      wait: true,
+      parentChatId: CHAT_ID,
+      parentTurnId: 'turn-board-guard',
+      modeId: 'orchestrate',
+      boardTaskId: 'W1-A',
+    });
+
+    const denied = await executeBoardTool('board_update_task', {
+      task_id: 'W1-A',
+      status: 'complete',
+    });
+    assert.match(
+      denied,
+      /cannot mark task complete.*max tool turns/i,
+    );
+
+    resetSubAgentOrchestrator();
+    resetSubAgentConfigCache();
+    resetSubAgentRunnerFactory();
+    resetSubAgentRunIdFactory();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a sub-agent hits the max tool-turn cap, the orchestrator and board must treat that as **failure**, not success.

MIN-15 already mapped `toolTurnLimitExhausted` → `failed` run status; this PR adds defense-in-depth so board tasks and parent polling cannot still show completion.

## Changes

- **`src/agents/sub-agent-outcome.ts`** — shared detection for max-turn summaries/errors and `isSubAgentRunSuccessful()`
- **`syncBoardTaskOnSettle`** — never sets board task `complete` if settlement summary/error indicates max tool turns
- **`buildSubAgentStatusPayload`** — exposes `success: false` for failed/max-turn runs so `get_sub_agent_status` is reliable for parent prompts
- **`board_update_task`** — rejects `status: complete` when the linked run did not succeed or the task already has a max-turn error
- **Orchestrate prompts** — instruct the parent not to mark tasks complete on max-turn outcomes
- **Tests** — `test/agents/sub-agent-outcome.test.mts`, extended exhaustion + board-tools coverage

## Acceptance

- Max-turn sub-agent → persisted run `failed`
- Board task stays `failed` (never `complete`)
- `get_sub_agent_status` reports `success: false`
- `board_update_task` cannot force `complete` after max-turn failure

## Test plan

- `npx tsx --import ./test/test-loader.mjs --test test/agents/sub-agent-outcome.test.mts test/sub-agents/sub-agent-tool-turn-exhaustion.test.mts test/tools/board-tools.test.mts`
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-10](https://linear.app/minnowai/issue/MIN-10/orchistrator-is-marking-todos-done-when-a-sub-is-interupted)

<div><a href="https://cursor.com/agents/bc-00828a5d-d985-4810-aef0-c3f9f59d9a9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00828a5d-d985-4810-aef0-c3f9f59d9a9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

