### PR TITLE
🐛 Fix skill picker hover text contrast (MIN-12)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -175,7 +175,7 @@ Cursor-compatible **SKILL.md** skills: YAML front matter + markdown body. Invoke
 | Enable/disable + persistence | `src/skills/config.ts`, `~/.minnow/skills.json`, `GET/PUT /api/config/skills` |
 | Settings UI (toggles, editor, add custom) | `src/ui/settings-skills.ts`, `src/skills/skill-settings-api.ts` |
 | Custom skill template | `src/skills/_template/SKILL.md` (copied on `POST /api/skills`) |
-| Slash picker UI | `src/ui/skill-picker.ts`, `src/styles/skill-picker.css` |
+| Slash picker UI | `src/ui/skill-picker.ts`, `src/styles/skill-picker.css` — row hover/`--active` set nested label, id, desc, and badge to `--elevated-fg` on `--surface-elevated` (same pattern as chat sidebar / file tree; MIN-12) |
 | Server scan + API | `server/skills/scan.js`, `server/skills/middleware.js`, `server/skills/user-skills.js` |
 
 **API** (same CORS as `/api/tools`; requires `npm start` for user skills):

--- a/src/styles/skill-picker.css
+++ b/src/styles/skill-picker.css
@@ -33,11 +33,47 @@
   align-items: baseline;
 }
 
+/* Keyboard highlight: elevated fill + readable nested text (not only on <li>). */
+.skill-picker__item--active {
+  background: var(--surface-elevated);
+  color: var(--elevated-fg);
+}
+
+.skill-picker__item--active .skill-picker__label {
+  color: var(--elevated-fg);
+}
+
+.skill-picker__item--active .skill-picker__id,
+.skill-picker__item--active .skill-picker__desc {
+  color: var(--elevated-fg);
+  opacity: 0.85;
+}
+
+.skill-picker__item--active .skill-picker__badge {
+  color: var(--elevated-fg);
+  border-color: color-mix(in oklch, var(--elevated-fg) 35%, transparent);
+}
+
+/* Fine-pointer hover: same nested colors as --active (chat sidebar / file tree pattern). */
 @media (hover: hover) and (pointer: fine) {
-  .skill-picker__item--active,
   .skill-picker__item:hover {
     background: var(--surface-elevated);
     color: var(--elevated-fg);
+  }
+
+  .skill-picker__item:hover .skill-picker__label {
+    color: var(--elevated-fg);
+  }
+
+  .skill-picker__item:hover .skill-picker__id,
+  .skill-picker__item:hover .skill-picker__desc {
+    color: var(--elevated-fg);
+    opacity: 0.85;
+  }
+
+  .skill-picker__item:hover .skill-picker__badge {
+    color: var(--elevated-fg);
+    border-color: color-mix(in oklch, var(--elevated-fg) 35%, transparent);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes slash skill picker contrast on hover and keyboard highlight: rows used `--surface-elevated` but child elements kept `--text` / `--text-muted`, so labels stayed hard to read (same pattern as the model picker fix in MIN-7).

## Changes

- **`src/styles/skill-picker.css`**: On `--active` and fine-pointer `:hover`, explicitly set nested `.skill-picker__label`, `.skill-picker__id`, `.skill-picker__desc`, and `.skill-picker__badge` to `--elevated-fg` (id/desc at 0.85 opacity; badge border via `color-mix` for legibility).
- **`documentation/context.md`**: Note slash picker hover/active styling pattern.

## Acceptance

- [x] Hovered skill row: title, id, and description readable on elevated background (dark theme).
- [x] Keyboard `--active` row matches hover nested colors (not gated behind hover media query).

## Test plan

- Manual: type `/` in composer, hover builtin + user skills and use ↑/↓ in light and dark themes.
- `npx tsc --noEmit` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-12](https://linear.app/minnowai/issue/MIN-12/skill-select-hover-over-text-display)

<div><a href="https://cursor.com/agents/bc-18adf52d-c45d-437e-9439-8b8ab5a87218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18adf52d-c45d-437e-9439-8b8ab5a87218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

