### PR TITLE
Resolve workspace paths with realpath to block symlink escapes (MIN-19)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -464,9 +464,9 @@ The **workspace** is the directory where file/git/terminal tools and the file tr
 
 **Menu UX:** Click `#btnWorkspace` â†’ popover (right-aligned to the button, opens left) lists up to 10 recent paths (checkmark on current, muted + **Remove** when folder missing); selecting an existing path `PUT`s without the picker; divider then **Open new workspaceâ€¦** opens the centered folder browser (current folder pinned at top with **This folder**, indented subfolders with â€º chevrons, **Folders** section label, Up, double-click to drill down, **Open folder** / Cancel, Escape / overlay dismiss). Starts at the current workspace when set; browse roots show Home (+ drive letters on Windows). Offline (`npm run dev`): same error as before (no menu). `applyWorkspaceSwitch()` refreshes label, file tree, and calls `applyWorkspaceScopedSession()` when B2 workspace-scoped chats are enabled.
 
-**Server wiring:** `server.js` `resolveSafePath`, git, `execute_command`, terminal default cwd, and LSP path checks use `getWorkspaceRoot()`. Vite and built-in skills/prompts still resolve from the Minnow app root (`getAppRoot()`).
+**Server wiring:** `server.js` `resolveSafePath` (canonical boundary via [`server/workspace/safe-path.js`](../server/workspace/safe-path.js) `fs.realpathSync`), git, `execute_command`, terminal default cwd, and LSP path checks use `getWorkspaceRoot()`. Vite and built-in skills/prompts still resolve from the Minnow app root (`getAppRoot()`).
 
-**Tests:** `test/workspace/workspace-api.test.js`, `test/ui/workspace-recent-menu.test.mjs`. Verification: [`documentation/plans/verification/feature-04.md`](plans/verification/feature-04.md).
+**Tests:** `test/workspace/workspace-api.test.js`, `test/workspace/safe-path.test.js`, `test/ui/workspace-recent-menu.test.mjs`. Verification: [`documentation/plans/verification/feature-04.md`](plans/verification/feature-04.md).
 
 ### File panel (Step 11)
 
@@ -658,7 +658,7 @@ Before `POST /api/tools` or browser tools run, [`executeTool`](../src/tools/clie
 
 ### Path policy (server)
 
-- **Workspace-only (default):** [`server.js`](../server.js) `resolveSafePath()` keeps paths under `getWorkspaceRoot()` unless **`toolSecurity.filesystemAccess`** in `config.json` is **`full`** or **`TOOLS_ALLOW_ALL_PATHS=1`** (automation escape hatch). Read from disk per tool request via [`server/config/tool-security.js`](../server/config/tool-security.js) and `AsyncLocalStorage` so nested calls stay scoped.
+- **Workspace-only (default):** [`server.js`](../server.js) `resolveSafePath()` keeps paths under `getWorkspaceRoot()` using `path.resolve` plus [`server/workspace/safe-path.js`](../server/workspace/safe-path.js) `realpath` prefix checks (blocks symlink escapes). Full access when **`toolSecurity.filesystemAccess`** in `config.json` is **`full`** or **`TOOLS_ALLOW_ALL_PATHS=1`** (automation escape hatch). Read from disk per tool request via [`server/config/tool-security.js`](../server/config/tool-security.js) and `AsyncLocalStorage` so nested calls stay scoped.
 
 ## Persisted message types (`chat.history`)
 
@@ -798,7 +798,7 @@ Browser (same origin :5173)
 | `/api/terminal/cancel/:runId` | POST | `{ ok: true }` (SIGTERM when supported) |
 
 - **CORS:** `*` for local dev; **OPTIONS** â†’ 204.
-- **Path guard:** `resolveSafePath()` â€” paths under the workspace root unless `toolSecurity.filesystemAccess` is `full` in `config.json` or `TOOLS_ALLOW_ALL_PATHS=1`.
+- **Path guard:** `resolveSafePath()` â€” paths under the workspace root after `realpath` canonicalization (`server/workspace/safe-path.js`) unless `toolSecurity.filesystemAccess` is `full` in `config.json` or `TOOLS_ALLOW_ALL_PATHS=1`. Client approval UX uses string prefix rules in `src/tools/workspace-path-guard.ts` (server remains authoritative).
 - **Errors:** Handlers return **strings**; failures use `Error: â€¦` prefix (not thrown to the client).
 - **Browser-only tools on POST:** Names not in `SERVER_TOOL_HANDLERS` (e.g. `get_datetime`, `calculate`, `web_search`) return `Not implemented: {name}`. Expected â€” the client runs them via [`executeBrowserTool`](../src/tools/browser-executor.ts); only mistaken direct POSTs hit the stub.
 - **Timeouts:** `execute_command`, `run_javascript`, `run_python` â€” **30s**.

--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ import { createLspMiddleware, initLspConfig } from './server/lsp/middleware.js';
 import { createMcpMiddleware, initMcpApi } from './server/mcp/middleware.js';
 import { callMcpTool, isMcpToolName } from './server/mcp/registry.js';
 import { getAppRoot, getWorkspaceRoot, initWorkspaceRoot } from './server/workspace/root.js';
+import { isResolvedPathUnderRoot } from './server/workspace/safe-path.js';
 import { createWorkspaceMiddleware } from './server/workspace/middleware.js';
 import { getFilesystemAccessFromConfig } from './server/config/tool-security.js';
 import {
@@ -59,11 +60,6 @@ const MAX_DOCUMENT_BYTES = 10 * 1024 * 1024;
 
 /** Per-request flag: allow paths outside workspace when config grants full filesystem access. */
 const pathAccessStore = new AsyncLocalStorage();
-
-/** Normalize slashes for consistent prefix checks on Windows. */
-function normalizePath(p) {
-  return path.normalize(p).replace(/\\/g, '/');
-}
 
 /**
  * Resolve a user-supplied path under the workspace root unless full access is allowed
@@ -105,10 +101,7 @@ function resolveSafePath(userPath, options = {}) {
     return resolved;
   }
 
-  const rootNorm = normalizePath(workspaceRoot);
-  const resolvedNorm = normalizePath(resolved);
-
-  if (resolvedNorm === rootNorm || resolvedNorm.startsWith(`${rootNorm}/`)) {
+  if (isResolvedPathUnderRoot(resolved, workspaceRoot)) {
     return resolved;
   }
 

--- a/server/workspace/safe-path.js
+++ b/server/workspace/safe-path.js
@@ -1,0 +1,47 @@
+/**
+ * Canonical path resolution for workspace boundary checks (symlink-safe).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Normalize slashes for consistent prefix checks on Windows. */
+export function normalizePathForComparison(fsPath) {
+  return path.normalize(fsPath).replace(/\\/g, '/');
+}
+
+/**
+ * Resolve symlinks for boundary checks. Walks up the tree on ENOENT so
+ * create/write paths for not-yet-existing files still validate parent dirs.
+ * @param {string} resolvedAbs Absolute path from path.resolve
+ * @returns {string}
+ */
+export function realpathForBoundaryCheck(resolvedAbs) {
+  try {
+    return fs.realpathSync(resolvedAbs);
+  } catch (err) {
+    const code = err && typeof err === 'object' && 'code' in err ? err.code : null;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      const parent = path.dirname(resolvedAbs);
+      if (parent === resolvedAbs) {
+        throw err;
+      }
+      const realParent = realpathForBoundaryCheck(parent);
+      return path.join(realParent, path.basename(resolvedAbs));
+    }
+    throw err;
+  }
+}
+
+/**
+ * True when resolvedAbs lies under rootAbs after canonicalizing both via realpath.
+ * @param {string} resolvedAbs
+ * @param {string} rootAbs
+ */
+export function isResolvedPathUnderRoot(resolvedAbs, rootAbs) {
+  const rootReal = realpathForBoundaryCheck(rootAbs);
+  const targetReal = realpathForBoundaryCheck(resolvedAbs);
+  const rootNorm = normalizePathForComparison(rootReal);
+  const targetNorm = normalizePathForComparison(targetReal);
+  return targetNorm === rootNorm || targetNorm.startsWith(`${rootNorm}/`);
+}

--- a/src/tools/workspace-path-guard.ts
+++ b/src/tools/workspace-path-guard.ts
@@ -1,6 +1,10 @@
 /**
  * Client-side path normalization consistent with server resolveSafePath prefix rules.
  * Used only for approval UX; the server remains authoritative.
+ *
+ * The server also canonicalizes paths with fs.realpath before prefix checks so
+ * symlinks inside the workspace cannot escape the sandbox. The browser cannot
+ * replicate that here, so approval may prompt for paths the server later rejects.
  */
 
 /** Normalize a path for stable prefix comparison (slashes, drive letter casing on Windows). */

--- a/test/workspace/safe-path.test.js
+++ b/test/workspace/safe-path.test.js
@@ -1,0 +1,90 @@
+/**
+ * Symlink-safe workspace boundary checks (MIN-19).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import {
+  isResolvedPathUnderRoot,
+  realpathForBoundaryCheck,
+} from '../../server/workspace/safe-path.js';
+
+describe('realpathForBoundaryCheck', () => {
+  /** @type {string} */
+  let tmpDir;
+
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'minnow-safe-path-'));
+  });
+
+  after(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('resolves existing files through realpath', async () => {
+    const file = path.join(tmpDir, 'hello.txt');
+    await fs.writeFile(file, 'ok');
+    const real = realpathForBoundaryCheck(file);
+    assert.equal(real, await fs.realpath(file));
+  });
+
+  test('walks up for missing leaf paths (create operations)', async () => {
+    const missing = path.join(tmpDir, 'new', 'nested', 'file.txt');
+    const real = realpathForBoundaryCheck(missing);
+    const expectedParent = realpathForBoundaryCheck(path.join(tmpDir, 'new', 'nested'));
+    assert.equal(real, path.join(expectedParent, 'file.txt'));
+  });
+});
+
+describe('isResolvedPathUnderRoot', () => {
+  /** @type {string} */
+  let workspace;
+  /** @type {string} */
+  let outsideDir;
+
+  before(async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'minnow-safe-path-root-'));
+    workspace = path.join(base, 'workspace');
+    outsideDir = path.join(base, 'outside');
+    await fs.mkdir(workspace);
+    await fs.mkdir(outsideDir);
+    await fs.writeFile(path.join(outsideDir, 'secret.txt'), 'outside');
+  });
+
+  after(async () => {
+    await fs.rm(path.dirname(workspace), { recursive: true, force: true });
+  });
+
+  test('allows normal paths under workspace', async () => {
+    const inner = path.join(workspace, 'src', 'app.ts');
+    await fs.mkdir(path.dirname(inner), { recursive: true });
+    await fs.writeFile(inner, 'code');
+    assert.equal(isResolvedPathUnderRoot(inner, workspace), true);
+  });
+
+  test('allows non-existent create paths under workspace', () => {
+    const planned = path.join(workspace, 'new-dir', 'file.txt');
+    assert.equal(isResolvedPathUnderRoot(planned, workspace), true);
+  });
+
+  test('blocks symlink that points outside workspace', async () => {
+    const link = path.join(workspace, 'escape-link');
+    await fs.symlink(path.join(outsideDir, 'secret.txt'), link);
+    assert.equal(isResolvedPathUnderRoot(link, workspace), false);
+  });
+
+  test('blocks traversal that only passes string prefix check via symlink dir', async () => {
+    const linkDir = path.join(workspace, 'outside-via-dir');
+    await fs.symlink(outsideDir, linkDir);
+    const viaLink = path.join(linkDir, 'secret.txt');
+    assert.equal(isResolvedPathUnderRoot(viaLink, workspace), false);
+  });
+
+  test('rejects paths that resolve outside without symlinks', () => {
+    const escaped = path.resolve(workspace, '..', 'outside', 'secret.txt');
+    assert.equal(isResolvedPathUnderRoot(escaped, workspace), false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **MIN-19**: workspace tool paths could escape the sandbox when a symlink inside the workspace pointed outside but still passed the string prefix check in `resolveSafePath`.

## Changes

- Added `server/workspace/safe-path.js` with `realpathForBoundaryCheck` and `isResolvedPathUnderRoot`
  - Uses `fs.realpathSync` on existing paths
  - Walks up parents on `ENOENT` so create/write paths for not-yet-existing files still validate
- Updated `server.js` `resolveSafePath` to use realpath-based boundary checks (unchanged behavior for `TOOLS_ALLOW_ALL_PATHS` / full filesystem access)
- Documented client/server split in `src/tools/workspace-path-guard.ts` (browser approval UX stays prefix-based; server is authoritative)
- Added `test/workspace/safe-path.test.js` covering symlink escapes and create paths
- Updated `documentation/context.md`

## Testing

- `node --test test/workspace/safe-path.test.js` (7 tests, all pass)
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-19](https://linear.app/minnowai/issue/MIN-19/resolve-workspace-paths-with-realpath-to-block-symlink-escapes)

<div><a href="https://cursor.com/agents/bc-e11a60a9-a0ab-4f37-8905-4dcbf445b8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e11a60a9-a0ab-4f37-8905-4dcbf445b8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

