### PR TITLE
Stop orchestrate auto-resume when all plan tasks are complete (MIN-34)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -289,8 +289,12 @@ Unified **Orchestrate supervisor** in [`src/agents/supervisor/`](../src/agents/s
 | `src/agents/supervisor/rules.ts` | Priority chain â†’ `SupervisorDecision` |
 | `src/agents/supervisor/actions.ts` | Resume toast + `sendMessage`, sub-agent restart/respawn, `ask_question` on budget |
 | `src/agents/supervisor/loop.ts` | `startSupervisor` / `stopSupervisor`, board + run listeners |
+| `src/chat/orchestrate/plan-complete.ts` | **MIN-34:** `isOrchestratePlanComplete`, resume gating, completion summary copy |
+| `src/chat/orchestrate/plan-complete-ui.ts` | One-shot assistant completion message + toast when board goes all `complete` |
 
-**Tests:** `test/supervisor/**/*.test.mts`, `test/orchestrate/watchdog.test.mts` (shim). `mergeSupervisorConfig` covered in `test/supervisor/config-merge.test.mts`.
+When every board task is `complete`, supervisor tick skips R4/R6/R7/R8 (`inject_resume`), sets `planCompletedAt`, and does not auto-resume. Board play control is disabled with “Plan complete” hint; manual resume uses `resolveOrchestrateResumeMessage()`.
+
+**Tests:** `test/supervisor/**/*.test.mts`, `test/orchestrate/watchdog.test.mts` (shim), `test/orchestrate/plan-complete.test.mts`. `mergeSupervisorConfig` covered in `test/supervisor/config-merge.test.mts`.
 
 ### Settings page (Step 20)
 

--- a/src/agents/supervisor/actions.ts
+++ b/src/agents/supervisor/actions.ts
@@ -2,6 +2,7 @@
  * Side effects for supervisor recovery (resume, sub-agents, board, ask_question).
  */
 
+import { canOrchestrateResume } from '../../chat/orchestrate/plan-complete.ts';
 import { ORCHESTRATE_RESUME_MESSAGE } from '../../chat/orchestrate/resume-message.ts';
 import { isActiveChatStreaming } from '../../chat/streaming-state.ts';
 import { emitBoardChange } from '../../state/orchestrate-board-events.ts';
@@ -71,6 +72,7 @@ export async function executeSupervisorDecision(
       return;
     }
     case 'inject_resume': {
+      if (!canOrchestrateResume(board)) return;
       if (isActiveChatStreaming() || resumeInFlight) return;
       const taskId =
         typeof decision.payload?.blockingTaskId === 'string'

--- a/src/agents/supervisor/detector.ts
+++ b/src/agents/supervisor/detector.ts
@@ -4,6 +4,7 @@
 
 import type { SubAgentRun } from '../types.ts';
 import type { BoardTask, Chat, OrchestrateBoardState } from '../../types.ts';
+import { hasIncompleteOrchestrateWork } from '../../chat/orchestrate/plan-complete.ts';
 import { detectRepetition, type ToolCallLogEntry } from '../self-healing/detector.ts';
 import { isSubAgentRunSuccessful } from '../sub-agent-outcome.ts';
 import { getSupervisorConfigSnapshot } from './config.ts';
@@ -44,9 +45,7 @@ function activeRunsForChat(chatId: string, runs: SubAgentRun[]): SubAgentRun[] {
   );
 }
 
-function hasIncompleteTasks(board: OrchestrateBoardState): boolean {
-  return board.tasks.some((t) => t.status !== 'complete');
-}
+const hasIncompleteTasks = hasIncompleteOrchestrateWork;
 
 function findBlockingTask(board: OrchestrateBoardState): BoardTask | null {
   const order = ['failed', 'blocked', 'in_progress', 'testing', 'planned'] as const;

--- a/src/agents/supervisor/escalation.ts
+++ b/src/agents/supervisor/escalation.ts
@@ -4,6 +4,7 @@
 
 import { pathsForProvider } from '../../providers/paths.ts';
 import { getActiveProvider } from '../../providers/store.ts';
+import { isOrchestratePlanComplete } from '../../chat/orchestrate/plan-complete.ts';
 import type { Chat, OrchestrateBoardState } from '../../types.ts';
 import { getSupervisorConfigSnapshot } from './config.ts';
 import type { SupervisorDecision } from './rules.ts';
@@ -43,6 +44,9 @@ export async function runLlmEscalationJudgement(
   board: OrchestrateBoardState,
   sup: SupervisorChatState,
 ): Promise<SupervisorDecision | null> {
+  if (isOrchestratePlanComplete(board) || sup.planCompletedAt != null) {
+    return { action: 'none' };
+  }
   const cfg = getSupervisorConfigSnapshot();
   const fp = stableBundleFingerprint(chat, board, sup);
   const last = fingerprintAt.get(fp) ?? 0;

--- a/src/agents/supervisor/loop.ts
+++ b/src/agents/supervisor/loop.ts
@@ -14,6 +14,8 @@ import { executeSupervisorDecision } from './actions.ts';
 import { loadSupervisorConfig, getSupervisorConfigSnapshot } from './config.ts';
 import { detectEmptyCompletedSummary, type DetectorContext } from './detector.ts';
 import { bumpOrchestratorProgress, recordParentStreamEnded } from './progress.ts';
+import { isOrchestratePlanComplete } from '../../chat/orchestrate/plan-complete.ts';
+import { maybeEmitOrchestratePlanComplete } from '../../chat/orchestrate/plan-complete-ui.ts';
 import { pickSupervisorDecision, scanTickDetectors, boardFingerprint } from './rules.ts';
 import {
   deleteRunHealth,
@@ -47,6 +49,9 @@ function ensureBoardListener(chatId: string): void {
       lastBoardFp.set(chatId, fp);
       for (const t of board.tasks) {
         touchInProgressNoRunTracking(chatId, t.id, t.status, t.assignedRunId, now);
+      }
+      if (isOrchestratePlanComplete(board)) {
+        void maybeEmitOrchestratePlanComplete(chatId);
       }
     }
   });
@@ -125,6 +130,10 @@ async function tickSupervisor(): Promise<void> {
         const h = getRunHealth(r.runId);
         h.queuedSinceAt ??= nowMs;
       }
+    }
+
+    if (isOrchestratePlanComplete(board)) {
+      void maybeEmitOrchestratePlanComplete(chat.id);
     }
 
     if (!cfg.enabled) continue;

--- a/src/agents/supervisor/rules.ts
+++ b/src/agents/supervisor/rules.ts
@@ -2,6 +2,7 @@
  * Priority rule chain: first matching detector wins (unless flags block evaluation).
  */
 
+import { isOrchestratePlanComplete } from '../../chat/orchestrate/plan-complete.ts';
 import type { DetectorContext, DetectorHit } from './detector.ts';
 import {
   detectAmbiguousReport,
@@ -81,6 +82,13 @@ export function pickSupervisorDecision(
     return { action: 'none' };
   }
 
+  if (
+    isOrchestratePlanComplete(ctx.board) &&
+    (rule === 'R4' || rule === 'R6' || rule === 'R7' || rule === 'R8')
+  ) {
+    return { action: 'none' };
+  }
+
   switch (rule) {
     case 'R9': {
       if (!ctx.cfg.askUserOnBudgetExhausted) {
@@ -110,6 +118,9 @@ export function pickSupervisorDecision(
 export function scanTickDetectors(ctx: DetectorContext): DetectorHit | null {
   if (ctx.sup.awaitingUserDecision || ctx.sup.recoveryInFlight) return null;
   if (!ctx.cfg.enabled) return null;
+  if (isOrchestratePlanComplete(ctx.board) || ctx.sup.planCompletedAt != null) {
+    return null;
+  }
 
   for (const fn of TICK_RULE_ORDER) {
     const hit = fn(ctx);

--- a/src/agents/supervisor/state.ts
+++ b/src/agents/supervisor/state.ts
@@ -38,6 +38,10 @@ export interface SupervisorChatState {
   spawnCountByTaskId: Map<string, number>;
   /** R5: one respawn attempt per task per stuck episode. */
   spawnRetryIssuedForTaskId: Set<string>;
+  /** Set when every board task reaches `complete` (suppresses auto-resume). */
+  planCompletedAt?: number;
+  /** Completion summary was appended to chat history (once per chat). */
+  completionMessageShown?: boolean;
 }
 
 const chatStates = new Map<string, SupervisorChatState>();

--- a/src/chat/orchestrate/plan-complete-ui.ts
+++ b/src/chat/orchestrate/plan-complete-ui.ts
@@ -1,0 +1,56 @@
+/**
+ * UI side effects when an Orchestrate plan reaches all-complete (chat + toast).
+ */
+
+import {
+  buildOrchestrateCompletionMessage,
+  isOrchestratePlanComplete,
+} from './plan-complete.ts';
+import { getSupervisorChatState, markChatStalledForUi } from '../../agents/supervisor/state.ts';
+import { emitBoardChange } from '../../state/orchestrate-board-events.ts';
+import { findChatById, getActiveChat, scheduleSaveSessions, touchChat } from '../../state/sessions.ts';
+import type { Chat } from '../../types.ts';
+
+function showPlanCompleteToast(message: string): void {
+  const el = document.createElement('div');
+  el.className = 'orchestrate-watchdog-toast orchestrate-watchdog-toast--complete';
+  el.setAttribute('role', 'status');
+  el.textContent = message;
+  document.body.appendChild(el);
+  requestAnimationFrame(() => el.classList.add('orchestrate-watchdog-toast--visible'));
+  window.setTimeout(() => {
+    el.classList.remove('orchestrate-watchdog-toast--visible');
+    window.setTimeout(() => el.remove(), 300);
+  }, 6000);
+}
+
+/**
+ * Mark supervisor state and surface completion once per chat when the board is all green.
+ */
+export async function maybeEmitOrchestratePlanComplete(chatId: string): Promise<void> {
+  const chat = findChatById(chatId);
+  const board = chat?.orchestrateBoard;
+  if (!chat || !board || !isOrchestratePlanComplete(board)) return;
+
+  const sup = getSupervisorChatState(chatId);
+  const now = Date.now();
+  if (sup.planCompletedAt == null) {
+    sup.planCompletedAt = now;
+    markChatStalledForUi(chatId, false);
+    emitBoardChange(chatId);
+  }
+
+  if (sup.completionMessageShown) return;
+  sup.completionMessageShown = true;
+
+  const text = buildOrchestrateCompletionMessage(chat, board, now);
+  chat.history.push({ role: 'assistant', content: text });
+  touchChat(chat);
+  scheduleSaveSessions();
+
+  if (getActiveChat().id === chat.id) {
+    const { renderChatFromHistory } = await import('../../ui/messages.ts');
+    renderChatFromHistory(chat);
+    showPlanCompleteToast('Orchestrate plan complete');
+  }
+}

--- a/src/chat/orchestrate/plan-complete.ts
+++ b/src/chat/orchestrate/plan-complete.ts
@@ -1,0 +1,68 @@
+/**
+ * Orchestrate plan completion helpers (supervisor gating, resume, completion copy).
+ */
+
+import type { Chat, OrchestrateBoardState } from '../../types.ts';
+
+/** True when the board has at least one task and every task is `complete`. */
+export function isOrchestratePlanComplete(board: OrchestrateBoardState): boolean {
+  const tasks = board.tasks;
+  return tasks.length > 0 && tasks.every((t) => t.status === 'complete');
+}
+
+/** True when orchestration still has work that can be resumed. */
+export function hasIncompleteOrchestrateWork(board: OrchestrateBoardState): boolean {
+  return board.tasks.some((t) => t.status !== 'complete');
+}
+
+/** Manual/auto resume is allowed only while incomplete work remains. */
+export function canOrchestrateResume(board: OrchestrateBoardState): boolean {
+  return hasIncompleteOrchestrateWork(board);
+}
+
+function shortPlanLabel(planPath: string): string {
+  const trimmed = planPath.trim();
+  if (!trimmed) return 'Orchestrate plan';
+  const base = trimmed.split('/').pop() ?? trimmed;
+  return base.replace(/\.md$/i, '') || trimmed;
+}
+
+function formatElapsedMs(startedAt: number, endedAt: number): string {
+  const ms = Math.max(0, endedAt - startedAt);
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  const rem = sec % 60;
+  if (min < 60) return rem > 0 ? `${min}m ${rem}s` : `${min}m`;
+  const hr = Math.floor(min / 60);
+  const mRem = min % 60;
+  return mRem > 0 ? `${hr}h ${mRem}m` : `${hr}h`;
+}
+
+/**
+ * User-facing summary when every board task is complete (chat + board header).
+ */
+export function buildOrchestrateCompletionMessage(
+  chat: Chat,
+  board: OrchestrateBoardState,
+  endedAtMs: number,
+): string {
+  const planPath = chat.orchestratePlanPath?.trim() || board.planPath?.trim() || '';
+  const planName = shortPlanLabel(planPath);
+  const total = board.tasks.length;
+  const elapsed = formatElapsedMs(board.startedAt, endedAtMs);
+
+  return [
+    `**Orchestrate plan complete** — ${planName}`,
+    '',
+    `- **Tasks:** ${total}/${total} complete`,
+    `- **Elapsed:** ${elapsed}`,
+    '',
+    'All board tasks are finished. Auto-resume is off for this chat.',
+    '',
+    '**Next steps:** review results in the board, start a new chat, or export/share the plan if needed.',
+  ].join('\n');
+}
+
+export const ORCHESTRATE_PLAN_COMPLETE_RESUME_HINT =
+  'Plan complete — all board tasks are finished. Start a new chat or review results in the board.';

--- a/src/chat/orchestrate/resume-message.ts
+++ b/src/chat/orchestrate/resume-message.ts
@@ -2,5 +2,21 @@
  * Shared resume copy for Orchestrate board Resume and stall watchdog auto-recovery.
  */
 
+import type { OrchestrateBoardState } from '../../types.ts';
+import {
+  canOrchestrateResume,
+  ORCHESTRATE_PLAN_COMPLETE_RESUME_HINT,
+} from './plan-complete.ts';
+
 export const ORCHESTRATE_RESUME_MESSAGE =
   "Resume the plan. Call board_get_state and continue from the first task whose status is not 'complete'.";
+
+/** Resume message when work remains; null when the plan is already complete. */
+export function resolveOrchestrateResumeMessage(
+  board: OrchestrateBoardState | null | undefined,
+): string | null {
+  if (!board || !canOrchestrateResume(board)) return null;
+  return ORCHESTRATE_RESUME_MESSAGE;
+}
+
+export { ORCHESTRATE_PLAN_COMPLETE_RESUME_HINT };

--- a/src/ui/orchestrate-board.ts
+++ b/src/ui/orchestrate-board.ts
@@ -7,7 +7,11 @@ import {
   type OrchestratorActivity,
 } from '../chat/orchestrate/last-activity';
 import { isOrchestrateWatchdogStalled } from '../chat/orchestrate/watchdog';
-import { ORCHESTRATE_RESUME_MESSAGE } from '../chat/orchestrate/resume-message';
+import {
+  ORCHESTRATE_PLAN_COMPLETE_RESUME_HINT,
+  resolveOrchestrateResumeMessage,
+} from '../chat/orchestrate/resume-message';
+import { isOrchestratePlanComplete } from '../chat/orchestrate/plan-complete';
 import { stopGeneration } from '../chat/stop-generation';
 import { isActiveChatStreaming } from '../chat/streaming-state';
 import {
@@ -353,6 +357,7 @@ function syncBoardHeaderActivity(
 
 /** Start vs Resume copy for the board header play control (idle state). */
 function playPauseIdleLabel(status: BoardHeaderStatus): string {
+  if (status.variant === 'complete') return 'Plan complete';
   if (status.variant === 'stopped' || status.variant === 'ready') return 'Start';
   return 'Resume';
 }
@@ -417,11 +422,12 @@ function syncBoardPlayPauseButton(
     btn.disabled = false;
     btn.classList.add('board-header__icon-btn--danger');
   } else {
+    const planComplete = isOrchestratePlanComplete(board);
     const idleLabel = playPauseIdleLabel(headerStatus);
     btn.setAttribute('aria-label', idleLabel);
-    btn.title = idleLabel;
+    btn.title = planComplete ? ORCHESTRATE_PLAN_COMPLETE_RESUME_HINT : idleLabel;
     btn.setAttribute('aria-pressed', 'false');
-    btn.disabled = isStreaming;
+    btn.disabled = isStreaming || planComplete;
     btn.classList.remove('board-header__icon-btn--danger');
   }
 }
@@ -458,7 +464,9 @@ function createBoardPlayPauseButton(
       refreshActiveBoardIfMounted();
       return;
     }
-    sendBoardMessage(ORCHESTRATE_RESUME_MESSAGE);
+    const message = resolveOrchestrateResumeMessage(activeBoard);
+    if (!message) return;
+    sendBoardMessage(message);
     refreshActiveBoardIfMounted();
   });
 

--- a/test/orchestrate/plan-complete.test.mts
+++ b/test/orchestrate/plan-complete.test.mts
@@ -1,0 +1,66 @@
+/**
+ * Orchestrate plan completion helpers.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  buildOrchestrateCompletionMessage,
+  canOrchestrateResume,
+  isOrchestratePlanComplete,
+} from '../../src/chat/orchestrate/plan-complete.ts';
+import type { Chat, OrchestrateBoardState } from '../../src/types.ts';
+
+const END = 2_000_000_000_000;
+const START = END - 125_000;
+
+function board(tasks: OrchestrateBoardState['tasks']): OrchestrateBoardState {
+  return {
+    planPath: 'documentation/plans/demo-plan.md',
+    startedAt: START,
+    lastUpdatedAt: END,
+    waves: [{ id: 'W1', status: 'complete' }],
+    tasks,
+  };
+}
+
+describe('isOrchestratePlanComplete', () => {
+  test('false for empty task list', () => {
+    assert.equal(isOrchestratePlanComplete(board([])), false);
+  });
+
+  test('true when every task is complete', () => {
+    const b = board([
+      { id: 'A', title: 'a', wave: 'W1', category: 'build', status: 'complete' },
+      { id: 'B', title: 'b', wave: 'W1', category: 'test', status: 'complete' },
+    ]);
+    assert.equal(isOrchestratePlanComplete(b), true);
+    assert.equal(canOrchestrateResume(b), false);
+  });
+
+  test('false when any task is not complete', () => {
+    const b = board([
+      { id: 'A', title: 'a', wave: 'W1', category: 'build', status: 'complete' },
+      { id: 'B', title: 'b', wave: 'W1', category: 'build', status: 'planned' },
+    ]);
+    assert.equal(isOrchestratePlanComplete(b), false);
+    assert.equal(canOrchestrateResume(b), true);
+  });
+});
+
+describe('buildOrchestrateCompletionMessage', () => {
+  test('includes plan name, task count, and elapsed time', () => {
+    const chat = {
+      id: '11111111-1111-1111-1111-111111111111',
+      orchestratePlanPath: 'documentation/plans/demo-plan.md',
+    } as Chat;
+    const b = board([
+      { id: 'A', title: 'a', wave: 'W1', category: 'build', status: 'complete' },
+    ]);
+    const text = buildOrchestrateCompletionMessage(chat, b, END);
+    assert.match(text, /demo-plan/);
+    assert.match(text, /1\/1 complete/);
+    assert.match(text, /2m 5s/);
+    assert.match(text, /Auto-resume is off/);
+  });
+});

--- a/test/supervisor/rules.test.mts
+++ b/test/supervisor/rules.test.mts
@@ -7,6 +7,10 @@ import { describe, test } from 'node:test';
 import type { Chat, OrchestrateBoardState } from '../../src/types.ts';
 import type { SubAgentRun } from '../../src/agents/types.ts';
 import { DEFAULT_SUPERVISOR_CONFIG } from '../../src/agents/supervisor/defaults.ts';
+import {
+  detectMissedOrchestratorHeartbeat,
+  detectParentSilenceAfterTool,
+} from '../../src/agents/supervisor/detector.ts';
 import { pickSupervisorDecision, scanTickDetectors } from '../../src/agents/supervisor/rules.ts';
 import type { DetectorContext } from '../../src/agents/supervisor/detector.ts';
 import { getSupervisorChatState } from '../../src/agents/supervisor/state.ts';
@@ -56,6 +60,50 @@ describe('scanTickDetectors + pickSupervisorDecision', () => {
     assert.equal(hit?.rule, 'R9');
     const decision = pickSupervisorDecision(c, hit);
     assert.equal(decision.action, 'escalate_user');
+  });
+
+  test('all-complete board does not tick inject_resume when R7 would match', () => {
+    const board: OrchestrateBoardState = {
+      planPath: 'p.md',
+      startedAt: NOW - 600_000,
+      lastUpdatedAt: NOW,
+      waves: [{ id: 'W1', status: 'complete' }],
+      tasks: [
+        { id: 'T1', title: 'a', wave: 'W1', category: 'build', status: 'complete' },
+        { id: 'T2', title: 'b', wave: 'W1', category: 'test', status: 'complete' },
+      ],
+    };
+    const sup = getSupervisorChatState(CHAT_ID);
+    sup.awaitingUserDecision = false;
+    sup.recoveryInFlight = false;
+    sup.lastReportAt = NOW - 600_000;
+    sup.lastOrchestratorProgressAt = NOW - 600_000;
+    const c = ctx({ board, sup });
+    assert.equal(detectMissedOrchestratorHeartbeat(c)?.rule, 'R7');
+    assert.equal(scanTickDetectors(c), null);
+    const silence = detectParentSilenceAfterTool({
+      ...c,
+      sup: {
+        ...sup,
+        lastParentStreamEndedAt: NOW - 120_000,
+        lastParentToolResultAt: NOW - 130_000,
+      },
+    });
+    assert.equal(silence?.rule, 'R4');
+    assert.equal(scanTickDetectors({ ...c, sup: { ...sup, lastParentStreamEndedAt: NOW - 120_000, lastParentToolResultAt: NOW - 130_000 } }), null);
+  });
+
+  test('pickSupervisorDecision downgrades inject_resume when board is complete', () => {
+    const board: OrchestrateBoardState = {
+      planPath: 'p.md',
+      startedAt: NOW - 120_000,
+      lastUpdatedAt: NOW,
+      waves: [{ id: 'W1', status: 'complete' }],
+      tasks: [{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'complete' }],
+    };
+    const c = ctx({ board, sup: getSupervisorChatState(CHAT_ID) });
+    const decision = pickSupervisorDecision(c, { rule: 'R7' });
+    assert.equal(decision.action, 'none');
   });
 
   test('flags block tick evaluation', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes MIN-34: when every task on the orchestrate board is `complete`, the supervisor no longer auto-injects resume messages (R4/R6/R7/R8), and the user gets a clear plan-finished state.

## Changes

- **`isOrchestratePlanComplete`** shared helper gates `scanTickDetectors`, `pickSupervisorDecision`, `executeSupervisorDecision` (`inject_resume`), and LLM escalation resume
- **Completion UX:** `planCompletedAt` supervisor flag, one-shot assistant summary in chat (plan name, task count, elapsed time, next steps), and toast when the active chat completes
- **Board controls:** play/resume button disabled with “Plan complete” hint; manual resume is a no-op via `resolveOrchestrateResumeMessage()`

## Tests

- `test/supervisor/rules.test.mts` — all-complete board does not tick `inject_resume` when R4/R7 would otherwise match
- `test/orchestrate/plan-complete.test.mts` — helper + completion copy
- Existing `test/orchestrate/watchdog.test.mts` stall tests still pass

## Linear

Closes MIN-34
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-34](https://linear.app/minnowai/issue/MIN-34/stop-auto-resume-and-show-completion-message-when-all-orchestrate-plan)

<div><a href="https://cursor.com/agents/bc-f5efaea2-57ac-4a7b-9ec2-41bc8d06aeb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5efaea2-57ac-4a7b-9ec2-41bc8d06aeb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

