### PR TITLE
Fix orchestrate resume toast appearing on new chats

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -294,6 +294,7 @@ Unified **Orchestrate supervisor** in [`src/agents/supervisor/`](../src/agents/s
 | `src/agents/supervisor/rules.ts` | Priority chain → `SupervisorDecision` |
 | `src/agents/supervisor/actions.ts` | Resume toast + `sendMessage` only for **active** chat; sub-agent restart/respawn, `ask_question` on budget; **MIN-35:** one resume toast per stall episode (`shouldShowOrchestrateWatchdogToast`) |
 | `src/chat/orchestrate/plan-complete.ts` | `hasOrchestrateSupervisorSessionStarted` — gates R7 so idle/new boards are not auto-resumed on `startedAt` alone |
+| `src/chat/orchestrate/user-stopped.ts` | `isUserStoppedChat` — blocks supervisor tick recovery (`inject_resume`, restarts, respawns) after manual Stop; board header Resume still allowed |
 | `src/agents/supervisor/state.ts` | **MIN-35:** `stalledChatIds` pruned when plan complete, streaming, or active subs (`pruneStaleStallUiFlag`); `shouldShowOrchestrateStallBadge` gates board header |
 | `src/agents/supervisor/loop.ts` | `startSupervisor` / `stopSupervisor`, board + run listeners; tick prunes stale stall UI |
 | `src/chat/orchestrate/plan-complete.ts` | **MIN-34:** `isOrchestratePlanComplete`, resume gating, completion summary copy |

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -292,7 +292,8 @@ Unified **Orchestrate supervisor** in [`src/agents/supervisor/`](../src/agents/s
 |--------|------|
 | `src/agents/supervisor/detector.ts` | Pure rules R1–R10 signals + verbatim stall evaluator |
 | `src/agents/supervisor/rules.ts` | Priority chain → `SupervisorDecision` |
-| `src/agents/supervisor/actions.ts` | Resume toast + `sendMessage`, sub-agent restart/respawn, `ask_question` on budget; **MIN-35:** one resume toast per stall episode (`shouldShowOrchestrateWatchdogToast`) |
+| `src/agents/supervisor/actions.ts` | Resume toast + `sendMessage` only for **active** chat; sub-agent restart/respawn, `ask_question` on budget; **MIN-35:** one resume toast per stall episode (`shouldShowOrchestrateWatchdogToast`) |
+| `src/chat/orchestrate/plan-complete.ts` | `hasOrchestrateSupervisorSessionStarted` — gates R7 so idle/new boards are not auto-resumed on `startedAt` alone |
 | `src/agents/supervisor/state.ts` | **MIN-35:** `stalledChatIds` pruned when plan complete, streaming, or active subs (`pruneStaleStallUiFlag`); `shouldShowOrchestrateStallBadge` gates board header |
 | `src/agents/supervisor/loop.ts` | `startSupervisor` / `stopSupervisor`, board + run listeners; tick prunes stale stall UI |
 | `src/chat/orchestrate/plan-complete.ts` | **MIN-34:** `isOrchestratePlanComplete`, resume gating, completion summary copy |

--- a/src/agents/supervisor/actions.ts
+++ b/src/agents/supervisor/actions.ts
@@ -89,6 +89,7 @@ export async function executeSupervisorDecision(
     case 'inject_resume': {
       if (!canOrchestrateResume(board)) return;
       if (isActiveChatStreaming() || resumeInFlight) return;
+      if (getActiveChat().id !== chatId) return;
       const taskId =
         typeof decision.payload?.blockingTaskId === 'string'
           ? decision.payload.blockingTaskId

--- a/src/agents/supervisor/actions.ts
+++ b/src/agents/supervisor/actions.ts
@@ -3,6 +3,7 @@
  */
 
 import { canOrchestrateResume } from '../../chat/orchestrate/plan-complete.ts';
+import { isUserStoppedChat } from '../../chat/orchestrate/user-stopped.ts';
 import { ORCHESTRATE_RESUME_MESSAGE } from '../../chat/orchestrate/resume-message.ts';
 import { isActiveChatStreaming } from '../../chat/streaming-state.ts';
 import { emitBoardChange } from '../../state/orchestrate-board-events.ts';
@@ -76,6 +77,7 @@ export async function executeSupervisorDecision(
   const sup = getSupervisorChatState(chatId);
   const board = chat.orchestrateBoard;
   const cfg = getSupervisorConfigSnapshot();
+  const userStopped = isUserStoppedChat(chat);
 
   switch (decision.action) {
     case 'none':
@@ -87,6 +89,7 @@ export async function executeSupervisorDecision(
       return;
     }
     case 'inject_resume': {
+      if (userStopped) return;
       if (!canOrchestrateResume(board)) return;
       if (isActiveChatStreaming() || resumeInFlight) return;
       if (getActiveChat().id !== chatId) return;
@@ -117,6 +120,7 @@ export async function executeSupervisorDecision(
       return;
     }
     case 'restart_run': {
+      if (userStopped) return;
       const runId = typeof decision.payload?.runId === 'string' ? decision.payload.runId : '';
       if (!runId) return;
       const h = getRunHealth(runId);
@@ -133,6 +137,7 @@ export async function executeSupervisorDecision(
       return;
     }
     case 'respawn_task': {
+      if (userStopped) return;
       if (decision.rule === 'R2') {
         const taskId =
           (typeof decision.payload?.boardTaskId === 'string' && decision.payload.boardTaskId.trim()
@@ -236,6 +241,7 @@ export async function executeSupervisorDecision(
       return;
     }
     case 'llm_escalate': {
+      if (userStopped) return;
       sup.recoveryInFlight = true;
       try {
         const sub = await runLlmEscalationJudgement(chat, board, sup);

--- a/src/agents/supervisor/detector.ts
+++ b/src/agents/supervisor/detector.ts
@@ -4,7 +4,10 @@
 
 import type { SubAgentRun } from '../types.ts';
 import type { BoardTask, Chat, OrchestrateBoardState } from '../../types.ts';
-import { hasIncompleteOrchestrateWork } from '../../chat/orchestrate/plan-complete.ts';
+import {
+  hasIncompleteOrchestrateWork,
+  hasOrchestrateSupervisorSessionStarted,
+} from '../../chat/orchestrate/plan-complete.ts';
 import { detectRepetition, type ToolCallLogEntry } from '../self-healing/detector.ts';
 import { isSubAgentRunSuccessful } from '../sub-agent-outcome.ts';
 import { getSupervisorConfigSnapshot } from './config.ts';
@@ -205,6 +208,7 @@ export function detectSpawnStuck(ctx: DetectorContext): DetectorHit | null {
 /** R7: no status report and no orchestrator progress within heartbeat window. */
 export function detectMissedOrchestratorHeartbeat(ctx: DetectorContext): DetectorHit | null {
   const { board, cfg, nowMs, sup } = ctx;
+  if (!hasOrchestrateSupervisorSessionStarted(sup, board)) return null;
   const reportRef = sup.lastReportAt ?? board.startedAt;
   const progressRef = Math.max(
     sup.lastOrchestratorProgressAt ?? board.startedAt,

--- a/src/agents/supervisor/loop.ts
+++ b/src/agents/supervisor/loop.ts
@@ -15,6 +15,7 @@ import { loadSupervisorConfig, getSupervisorConfigSnapshot } from './config.ts';
 import { detectEmptyCompletedSummary, type DetectorContext } from './detector.ts';
 import { bumpOrchestratorProgress, recordParentStreamEnded } from './progress.ts';
 import { isOrchestratePlanComplete } from '../../chat/orchestrate/plan-complete.ts';
+import { isUserStoppedChat } from '../../chat/orchestrate/user-stopped.ts';
 import { maybeEmitOrchestratePlanComplete } from '../../chat/orchestrate/plan-complete-ui.ts';
 import { pickSupervisorDecision, scanTickDetectors, boardFingerprint } from './rules.ts';
 import {
@@ -76,7 +77,8 @@ function recordSubAgentTerminal(run: SubAgentRun): void {
   markChatStalledForUi(chatId, false);
   bumpOrchestratorProgress(chatId, now);
   const hit = detectEmptyCompletedSummary(run);
-  if (hit && run.parentChatId) {
+  const parent = run.parentChatId ? findChatById(run.parentChatId) : undefined;
+  if (hit && run.parentChatId && parent && !isUserStoppedChat(parent)) {
     void executeSupervisorDecision(run.parentChatId, {
       action: 'respawn_task',
       rule: 'R2',

--- a/src/agents/supervisor/rules.ts
+++ b/src/agents/supervisor/rules.ts
@@ -3,6 +3,7 @@
  */
 
 import { isOrchestratePlanComplete } from '../../chat/orchestrate/plan-complete.ts';
+import { isUserStoppedChat } from '../../chat/orchestrate/user-stopped.ts';
 import type { DetectorContext, DetectorHit } from './detector.ts';
 import {
   detectAmbiguousReport,
@@ -118,6 +119,7 @@ export function pickSupervisorDecision(
 export function scanTickDetectors(ctx: DetectorContext): DetectorHit | null {
   if (ctx.sup.awaitingUserDecision || ctx.sup.recoveryInFlight) return null;
   if (!ctx.cfg.enabled) return null;
+  if (isUserStoppedChat(ctx.chat)) return null;
   if (isOrchestratePlanComplete(ctx.board) || ctx.sup.planCompletedAt != null) {
     return null;
   }

--- a/src/chat/orchestrate/plan-complete.ts
+++ b/src/chat/orchestrate/plan-complete.ts
@@ -2,6 +2,7 @@
  * Orchestrate plan completion helpers (supervisor gating, resume, completion copy).
  */
 
+import type { SupervisorChatState } from '../../agents/supervisor/state.ts';
 import type { Chat, OrchestrateBoardState } from '../../types.ts';
 
 /** True when the board has at least one task and every task is `complete`. */
@@ -18,6 +19,21 @@ export function hasIncompleteOrchestrateWork(board: OrchestrateBoardState): bool
 /** Manual/auto resume is allowed only while incomplete work remains. */
 export function canOrchestrateResume(board: OrchestrateBoardState): boolean {
   return hasIncompleteOrchestrateWork(board);
+}
+
+/**
+ * True once orchestration has actually run (not a fresh board with only `startedAt`).
+ * Gates supervisor auto-resume (R7) so new/idle chats are not treated as stalled.
+ */
+export function hasOrchestrateSupervisorSessionStarted(
+  sup: SupervisorChatState,
+  board: OrchestrateBoardState,
+): boolean {
+  if (sup.lastTerminalAt != null && sup.lastTerminalAt > 0) return true;
+  if (sup.lastReportAt != null && sup.lastReportAt > 0) return true;
+  if (sup.lastParentToolResultAt != null && sup.lastParentToolResultAt > 0) return true;
+  if (board.activeParentTurnId?.trim()) return true;
+  return board.tasks.some((t) => t.status !== 'planned');
 }
 
 function shortPlanLabel(planPath: string): string {

--- a/src/chat/orchestrate/user-stopped.ts
+++ b/src/chat/orchestrate/user-stopped.ts
@@ -1,0 +1,27 @@
+/**
+ * Detect when the user explicitly stopped the orchestrate parent stream.
+ */
+
+import { hasIncompleteOrchestrateWork } from './plan-complete.ts';
+import type { Chat } from '../../types.ts';
+
+/**
+ * True when the latest assistant turn was user-stopped and the board still has work.
+ * Manual board Resume is allowed; supervisor auto-resume must not run.
+ */
+export function isUserStoppedChat(chat: Chat): boolean {
+  const board = chat.orchestrateBoard;
+  if (!board || !hasIncompleteOrchestrateWork(board)) {
+    return false;
+  }
+  for (let i = chat.history.length - 1; i >= 0; i--) {
+    const msg = chat.history[i];
+    if (msg.role === 'assistant') {
+      return 'stopped' in msg && msg.stopped === true;
+    }
+    if (msg.role === 'user') {
+      return false;
+    }
+  }
+  return false;
+}

--- a/src/ui/orchestrate-board.ts
+++ b/src/ui/orchestrate-board.ts
@@ -14,6 +14,7 @@ import {
   hasIncompleteOrchestrateWork,
   isOrchestratePlanComplete,
 } from '../chat/orchestrate/plan-complete';
+import { isUserStoppedChat } from '../chat/orchestrate/user-stopped.ts';
 import { shouldShowOrchestrateStallBadge } from '../agents/supervisor/state.ts';
 import { stopGeneration } from '../chat/stop-generation';
 import { isActiveChatStreaming, isChatStreaming } from '../chat/streaming-state';
@@ -96,23 +97,7 @@ export function getBoardTaskRunIds(task: BoardTask): string[] {
   return ids;
 }
 
-/** True when the user stopped the latest assistant turn and work remains. */
-export function isUserStoppedChat(chat: Chat): boolean {
-  const board = chat.orchestrateBoard;
-  if (!board || !hasIncompleteOrchestrateWork(board)) {
-    return false;
-  }
-  for (let i = chat.history.length - 1; i >= 0; i--) {
-    const msg = chat.history[i];
-    if (msg.role === 'assistant') {
-      return 'stopped' in msg && msg.stopped === true;
-    }
-    if (msg.role === 'user') {
-      return false;
-    }
-  }
-  return false;
-}
+export { isUserStoppedChat };
 
 /** Badge copy for tasks linked to a sub-agent run (Active / Failed / Complete / Cancelled). */
 export function deriveTaskAgentBadge(

--- a/test/orchestrate/plan-complete-session.test.mts
+++ b/test/orchestrate/plan-complete-session.test.mts
@@ -1,0 +1,42 @@
+/**
+ * Orchestrate supervisor session gating (auto-resume on new/idle chats).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { hasOrchestrateSupervisorSessionStarted } from '../../src/chat/orchestrate/plan-complete.ts';
+import { getSupervisorChatState } from '../../src/agents/supervisor/state.ts';
+import type { OrchestrateBoardState } from '../../src/types.ts';
+
+const CHAT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+function board(tasks: OrchestrateBoardState['tasks']): OrchestrateBoardState {
+  return {
+    planPath: 'documentation/plans/test.md',
+    startedAt: 1_700_000_000_000,
+    lastUpdatedAt: 1_700_000_000_000,
+    waves: [{ id: 'W1', status: 'planned' }],
+    tasks,
+  };
+}
+
+describe('hasOrchestrateSupervisorSessionStarted', () => {
+  test('false for fresh board with only startedAt', () => {
+    const sup = getSupervisorChatState(CHAT_ID);
+    const b = board([{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'planned' }]);
+    assert.equal(hasOrchestrateSupervisorSessionStarted(sup, b), false);
+  });
+
+  test('true after a sub-agent terminal event', () => {
+    const sup = getSupervisorChatState(CHAT_ID);
+    sup.lastTerminalAt = 1_700_000_100_000;
+    const b = board([{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'planned' }]);
+    assert.equal(hasOrchestrateSupervisorSessionStarted(sup, b), true);
+  });
+
+  test('true when any task left planned', () => {
+    const sup = getSupervisorChatState(CHAT_ID);
+    const b = board([{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'in_progress' }]);
+    assert.equal(hasOrchestrateSupervisorSessionStarted(sup, b), true);
+  });
+});

--- a/test/orchestrate/user-stopped.test.mts
+++ b/test/orchestrate/user-stopped.test.mts
@@ -1,0 +1,57 @@
+/**
+ * User-stopped orchestrate session detection.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { isUserStoppedChat } from '../../src/chat/orchestrate/user-stopped.ts';
+import type { Chat, OrchestrateBoardState } from '../../src/types.ts';
+
+function board(): OrchestrateBoardState {
+  return {
+    planPath: 'p.md',
+    startedAt: 1_700_000_000_000,
+    lastUpdatedAt: 1_700_000_000_000,
+    waves: [{ id: 'W1', status: 'planned' }],
+    tasks: [{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'planned' }],
+  };
+}
+
+describe('isUserStoppedChat', () => {
+  test('true when latest assistant is stopped and work remains', () => {
+    const chat = {
+      id: '11111111-1111-1111-1111-111111111111',
+      orchestrateBoard: board(),
+      history: [
+        { role: 'user', content: 'start' },
+        { role: 'assistant', content: '…', stopped: true },
+      ],
+    } as Chat;
+    assert.equal(isUserStoppedChat(chat), true);
+  });
+
+  test('false after user sends a follow-up message', () => {
+    const chat = {
+      id: '11111111-1111-1111-1111-111111111111',
+      orchestrateBoard: board(),
+      history: [
+        { role: 'assistant', content: '…', stopped: true },
+        { role: 'user', content: 'resume manually' },
+      ],
+    } as Chat;
+    assert.equal(isUserStoppedChat(chat), false);
+  });
+
+  test('false when plan is complete', () => {
+    const completeBoard: OrchestrateBoardState = {
+      ...board(),
+      tasks: [{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'complete' }],
+    };
+    const chat = {
+      id: '11111111-1111-1111-1111-111111111111',
+      orchestrateBoard: completeBoard,
+      history: [{ role: 'assistant', content: 'done', stopped: true }],
+    } as Chat;
+    assert.equal(isUserStoppedChat(chat), false);
+  });
+});

--- a/test/supervisor/rules.test.mts
+++ b/test/supervisor/rules.test.mts
@@ -62,6 +62,22 @@ describe('scanTickDetectors + pickSupervisorDecision', () => {
     assert.equal(decision.action, 'escalate_user');
   });
 
+  test('R7 does not fire on idle board with only startedAt (new chat / reload)', () => {
+    const board: OrchestrateBoardState = {
+      planPath: 'p.md',
+      startedAt: NOW - 600_000,
+      lastUpdatedAt: NOW,
+      waves: [{ id: 'W1', status: 'planned' }],
+      tasks: [{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'planned' }],
+    };
+    const sup = getSupervisorChatState(CHAT_ID);
+    sup.awaitingUserDecision = false;
+    sup.recoveryInFlight = false;
+    const c = ctx({ board, sup });
+    assert.equal(detectMissedOrchestratorHeartbeat(c), null);
+    assert.equal(scanTickDetectors(c), null);
+  });
+
   test('all-complete board does not tick inject_resume when R7 would match', () => {
     const board: OrchestrateBoardState = {
       planPath: 'p.md',

--- a/test/supervisor/rules.test.mts
+++ b/test/supervisor/rules.test.mts
@@ -3,7 +3,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
+import { afterEach, describe, test } from 'node:test';
 import type { Chat, OrchestrateBoardState } from '../../src/types.ts';
 import type { SubAgentRun } from '../../src/agents/types.ts';
 import { DEFAULT_SUPERVISOR_CONFIG } from '../../src/agents/supervisor/defaults.ts';
@@ -13,10 +13,17 @@ import {
 } from '../../src/agents/supervisor/detector.ts';
 import { pickSupervisorDecision, scanTickDetectors } from '../../src/agents/supervisor/rules.ts';
 import type { DetectorContext } from '../../src/agents/supervisor/detector.ts';
-import { getSupervisorChatState } from '../../src/agents/supervisor/state.ts';
+import {
+  getSupervisorChatState,
+  resetSupervisorStateForTests,
+} from '../../src/agents/supervisor/state.ts';
 
 const CHAT_ID = '22222222-2222-2222-2222-222222222222';
 const NOW = 2_000_000_000_000;
+
+afterEach(() => {
+  resetSupervisorStateForTests();
+});
 
 function ctx(overrides: Partial<DetectorContext> & Pick<DetectorContext, 'board' | 'sup'>): DetectorContext {
   const chat = {
@@ -60,6 +67,33 @@ describe('scanTickDetectors + pickSupervisorDecision', () => {
     assert.equal(hit?.rule, 'R9');
     const decision = pickSupervisorDecision(c, hit);
     assert.equal(decision.action, 'escalate_user');
+  });
+
+  test('scanTickDetectors skips all rules when user stopped the orchestrator', () => {
+    const board: OrchestrateBoardState = {
+      planPath: 'p.md',
+      startedAt: NOW - 600_000,
+      lastUpdatedAt: NOW,
+      waves: [{ id: 'W1', status: 'in_progress' }],
+      tasks: [{ id: 'T1', title: 't', wave: 'W1', category: 'build', status: 'planned' }],
+    };
+    const sup = getSupervisorChatState(CHAT_ID);
+    sup.awaitingUserDecision = false;
+    sup.recoveryInFlight = false;
+    sup.lastTerminalAt = NOW - 120_000;
+    sup.lastOrchestratorProgressAt = NOW - 120_000;
+    const chat = {
+      id: CHAT_ID,
+      modeId: 'orchestrate',
+      orchestrateBoard: board,
+      history: [
+        { role: 'user', content: 'go' },
+        { role: 'assistant', content: 'partial', stopped: true },
+      ],
+    } as Chat;
+    const c = ctx({ board, sup, chat });
+    assert.equal(detectMissedOrchestratorHeartbeat(c)?.rule, 'R7');
+    assert.equal(scanTickDetectors(c), null);
   });
 
   test('R7 does not fire on idle board with only startedAt (new chat / reload)', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

1. **Resume toast on wrong chat** — stall recovery showed a global toast even when viewing a different (e.g. new) chat.
2. **R7 false positives** — idle boards could auto-resume based on `startedAt` alone.
3. **Auto-resume after manual Stop** — supervisor kept injecting resume / restarting work after the user explicitly stopped the orchestrator.

## Fix

- Gate `inject_resume` toast and message injection to the **active chat** only.
- Add `hasOrchestrateSupervisorSessionStarted()` so R7 only runs after orchestration has actually started.
- Add `isUserStoppedChat()` (shared module) and block supervisor tick recovery + `inject_resume` / restarts / respawns / LLM escalation while the latest assistant turn is user-stopped.
- Manual board **Resume** still works (sending a user message clears the stopped state).

## Testing

- `node --import tsx --test test/supervisor/rules.test.mts test/orchestrate/user-stopped.test.mts test/orchestrate/plan-complete-session.test.mts`
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed051eea-671e-4048-85bd-10ba5869fd6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed051eea-671e-4048-85bd-10ba5869fd6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

