### PR TITLE
🐛 Fix settings page FOUC after loading screen

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,6 +100,10 @@ body {
   scrollbar-gutter: stable;
 }
 
+/* Hide settings page until its lazy CSS chunk loads (settings-page.css sets display:none too,
+   but that chunk loads ~1s after markAppReady — this prevents FOUC during that window). */
+.settings-page { display: none; }
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;


### PR DESCRIPTION
## Summary

- Diagnosed a ~1085ms flash of unstyled content after the loading screen using a HAR trace
- `settings-page.css` (the lazy chunk from MIN-20) loads at ~1271ms, but `markAppReady()` fires at ~186ms — leaving `<main id="settingsView" class="settings-page">` as `display: block` for the entire window
- Fix: add `.settings-page { display: none }` to `src/styles/global.css` (eagerly loaded at ~85ms), eliminating the FOUC with zero JS changes

## Root cause

When `settings-page.ts` was lazy-loaded (MIN-20 to shrink the main bundle), its CSS chunk was deferred too. The base `display: none` rule that hides the settings view only existed in `settings-page.css`, which the browser doesn't fetch until `await import('./ui/settings-page')` fires inside `initApp()`.

The `.settings-page.is-open { display: flex }` override in `settings-page.css` still works correctly — it has higher specificity (2 classes) than the new rule (1 class).

## Test plan

- [ ] `npm run dev` — reload page, confirm no large unstyled settings block appears after loader fades
- [ ] Open Settings → confirm page renders correctly
- [ ] Close Settings → confirm it hides correctly
- [ ] `npm run build && npm start` — confirm same behaviour in production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)