### PR TITLE
Fix reef widgets always failing height validation (rAF throttled in hidden iframe)

### DIFF
--- a/src/chat/reef/widget-prelude.ts
+++ b/src/chat/reef/widget-prelude.ts
@@ -90,8 +90,13 @@ export const PRELUDE_SCRIPT = `(function () {
 
   /** Catch dynamic DOM (sync scripts, ESM, charts) that mount after the first measure. */
   function scheduleDelayedResizePasses() {
+    /* Direct call first: rAF can be throttled when the host hides the iframe with
+       visibility:hidden during validation, causing resize to arrive after validateResult.
+       postResizeToHost() deduplicates via lastPostedHeight so this is safe to call often. */
+    postResizeToHost();
     scheduleResizePost();
     setTimeout(scheduleResizePost, 0);
+    setTimeout(postResizeToHost, 0);
     setTimeout(scheduleResizePost, 100);
     setTimeout(scheduleResizePost, 400);
     setTimeout(emitValidateResult, 500);


### PR DESCRIPTION
## Summary

- The host sets `visibility: hidden` on the reef widget iframe during validation. Browsers can throttle or skip `requestAnimationFrame` callbacks in invisible iframes, so the rAF-based resize `postMessage` was arriving **after** the 500 ms `emitValidateResult` timer fired.
- This left `lastContentHeightPx = 0 < 24` every time, causing **all** reef widgets to show the "Widget did not produce visible content (height too small)" error panel immediately after mounting.
- Fix: call `postResizeToHost()` directly (no rAF dependency) at the top of `scheduleDelayedResizePasses` and once more via `setTimeout(..., 0)`. The `min-height: 120px` rule on `html, body` in the srcdoc guarantees a measurable height even before async content (React, charts) renders. `postResizeToHost` deduplicates via `lastPostedHeight`, so the extra calls are cheap no-ops once height is established.

## Test plan

- [ ] All existing `widget-bridge`, `widget-iframe`, and `widget-block-detector` tests continue to pass
- [ ] Open the app in Reef mode and ask for any widget (calculator, checklist, etc.) — should render without the error panel
- [ ] Verify the widget is hidden (validating spinner) then revealed after ~500 ms as before
- [ ] Confirm theme tokens still forward correctly (dark/light toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)