### PR TITLE
Fix orchestrator board: premature auto-complete, stuck in-progress, Resume button while active

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Minnow Full-Stack",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["server.js"],
+      "port": 5173
+    },
+    {
+      "name": "Vite Dev (frontend only)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -206,8 +206,9 @@ function syncBoardTaskOnSettle(
   };
 
   if (status === 'completed' && !maxTurnFailure) {
+    // Don't auto-complete: orchestrator controls task status via board_update_task.
+    // Only clear the assignment and record end time so the UI reflects the run ended.
     updateTask(chat, taskId, {
-      status: 'complete',
       endedAt,
       ...settlePatch,
     });

--- a/src/chat/prompts/modes/orchestrate.full.md
+++ b/src/chat/prompts/modes/orchestrate.full.md
@@ -161,20 +161,20 @@ Every **`spawn_sub_agent`** must include **`category`** and **`board_task_id`** 
 For each task in the current wave (parallelized up to the concurrency limit):
 
 ```
-1. board_update_task — mark in_progress (optional if spawn hook sets it)
+1. board_update_task — mark in_progress (the spawn hook also sets this when board_task_id is passed)
 2. Spawn a Builder sub-agent
    - spawn_sub_agent: category build, board_task_id <task id>
    - Pass the task's full Build spec as the prompt
    - wait: true OR wait: false + list_sub_agents / get_sub_agent_status
 
 3. On Builder DONE (`success: true`, not max tool turns):
-   - board_update_task — status testing (before verifier)
+   - board_update_task — status testing (before verifier; sub-agents do NOT auto-complete tasks)
    - Spawn a Verifier sub-agent
    - spawn_sub_agent: category test, board_task_id <task id>
    - Pass the task's full Test spec + the Builder's reported file list
 
 4. On Verifier PASS:
-   - board_update_task — status complete, files_changed, notes
+   - board_update_task — status complete, files_changed, notes  ← YOU MUST call this; no auto-complete
    - Next task in the wave (or next wave if last)
 
 5. On Verifier FAIL, Builder ERROR, or **`terminalReason: "max_tool_turns"`**:

--- a/src/chat/prompts/modes/orchestrate.lite.md
+++ b/src/chat/prompts/modes/orchestrate.lite.md
@@ -31,7 +31,7 @@ Loop per task (parallel within a wave, sequential between waves, max `globalMaxC
 1. **`board_update_task`** — `{ "task_id": "W1-A", "status": "in_progress" }` when starting build.
 2. Spawn **Builder** — **`spawn_sub_agent`** with **`category`** `build` and **`board_task_id`**; task Build spec; `wait: true` or `wait: false` + **`list_sub_agents`** / **`get_sub_agent_status`**.
 3. **`board_update_task`** — `testing`; spawn **Verifier** with **`category`** `test` and **`board_task_id`**; same wait/poll pattern.
-4. PASS → **`board_update_task`** `complete` (+ `files_changed` / `notes`), next task.
+4. PASS → **`board_update_task`** `complete` (+ `files_changed` / `notes`), next task. (**Required** — tasks are not auto-completed.)
 5. FAIL → **`board_update_task`** `failed` or `blocked`, surface error, ask user retry/skip/abort.
 
 **Check-in tools:** `list_sub_agents`; `get_sub_agent_status({ run_id })` — includes `success` and `terminalReason` when terminal; if `success: false` or `terminalReason: "max_tool_turns"`, retry **`spawn_sub_agent`** or mark `failed`; never `complete`.

--- a/src/ui/orchestrate-board.ts
+++ b/src/ui/orchestrate-board.ts
@@ -395,6 +395,7 @@ function syncBoardHeaderActivity(
 /** Start vs Resume copy for the board header play control (idle state). */
 function playPauseIdleLabel(status: BoardHeaderStatus): string {
   if (status.variant === 'complete') return 'Plan complete';
+  if (status.variant === 'active') return 'Active';
   if (status.variant === 'stopped' || status.variant === 'ready') return 'Start';
   return 'Resume';
 }
@@ -460,11 +461,12 @@ function syncBoardPlayPauseButton(
     btn.classList.add('board-header__icon-btn--danger');
   } else {
     const planComplete = isOrchestratePlanComplete(board);
+    const agentsActive = headerStatus.variant === 'active';
     const idleLabel = playPauseIdleLabel(headerStatus);
     btn.setAttribute('aria-label', idleLabel);
     btn.title = planComplete ? ORCHESTRATE_PLAN_COMPLETE_RESUME_HINT : idleLabel;
     btn.setAttribute('aria-pressed', 'false');
-    btn.disabled = isStreaming || planComplete;
+    btn.disabled = isStreaming || planComplete || agentsActive;
     btn.classList.remove('board-header__icon-btn--danger');
   }
 }


### PR DESCRIPTION
## Summary

- **Tasks flashing Complete too early** — `syncBoardTaskOnSettle` was auto-setting a board task to `complete` the moment its linked sub-agent settled successfully. This caused tasks to jump to Complete after the *builder* finished, before the verifier even spawned.
- **Tasks not moving to In Progress** — same root cause: the auto-complete after the builder meant the task never visibly stayed in-progress through the builder→verifier handoff.
- **Resume button showed "Resume" while agents were running** — `isBoardPlayPauseRunning` only returned `true` when `isStreaming && activeParentTurnId`. When sub-agents were running independently (parent not streaming), the button stayed enabled with the label "Resume", which would send another message into an already-active orchestration.

## Changes

### `src/agents/orchestrator.ts`
Removed the auto-complete from `syncBoardTaskOnSettle`. On a successful sub-agent completion, only `lastRunId`, `assignedRunId`, and `endedAt` are updated — status is intentionally left unchanged. The orchestrator model already explicitly calls `board_update_task: complete` per its prompt, so it now fully owns that transition. Failure/cancel paths are unchanged (still auto-mark `failed`).

### `src/ui/orchestrate-board.ts`
- `playPauseIdleLabel`: added `'active'` variant → returns `'Active'`
- `syncBoardPlayPauseButton`: button is now disabled when `headerStatus.variant === 'active'` (sub-agents running, parent not streaming), preventing a spurious Resume message

### `src/chat/prompts/modes/orchestrate.full.md` + `orchestrate.lite.md`
Clarified that tasks are **not** auto-completed — the model **must** call `board_update_task: complete` explicitly on verifier PASS. Added inline callouts to both the full and lite prompts.

### `.claude/launch.json`
Added dev server launch configurations for the project.

## Reviewer notes

- No new tests needed: the removed auto-complete was never covered by a dedicated test (existing tests only checked the `in_progress`-on-spawn path and the `failed`-on-max-tool-turns path, both of which are unaffected).
- All 169 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)