### PR TITLE
Fix Reef widget validation, mount timing, and corrupt fence handling

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -385,7 +385,7 @@ Closed ` ```reef-widget ` fences in assistant bubbles mount as sandboxed iframes
 
 | Concern | Location |
 |---------|----------|
-| Mount pipeline | `src/chat/reef/` (`widget-block-detector.ts`, `widget-pending-ui.ts`, `widget-iframe.ts`, `widget-error-ui.ts`, `widget-validation.ts`, `theme-forward.ts`, `widget-prelude.ts`, `widget-bridge.ts`, `run-widget-completion.ts`) |
+| Mount pipeline | `src/chat/reef/` (`widget-block-detector.ts`, `widget-fence-body.ts`, `widget-pending-ui.ts`, `widget-iframe.ts`, `widget-error-ui.ts`, `widget-validation.ts`, `theme-forward.ts`, `widget-prelude.ts`, `widget-bridge.ts`, `run-widget-completion.ts`) |
 | Renderer hook | `mountReefWidgets(bubble, { bubbleStreaming, modeId })` at end of `setAssistantBubbleContent` in `src/markdown/renderer.ts`; history render passes `chat.modeId` via `appendBubble` meta |
 | Bridge init | `initReefBridge()` in `src/main.ts` |
 | Styles | `src/styles/reef-widgets.css` |
@@ -401,7 +401,7 @@ Closed ` ```reef-widget ` fences in assistant bubbles mount as sandboxed iframes
 
 **JSX guard:** Before Babel, the iframe runner auto-quotes `color: var(--text)` → `color: 'var(--text)'` in widget scripts (`widget-jsx-guard.ts`); prompts tell models to quote tokens in `style={{ }}` (bare `var()` is valid only in `<style>` CSS).
 
-**Iframe sizing:** Host owns iframe width (100% of bubble) and height (from prelude `resize` messages). Widgets must not set outer iframe dimensions or `100vh`. Prelude posts resize on load plus delayed passes (0 / 100 / 400 ms), then `validateResult` (~500 ms) so the host can reveal or show errors before the user sees a broken iframe.
+**Iframe sizing / validation:** Host owns iframe width (100% of bubble) and height (from prelude `resize` messages). Widgets must not set outer iframe dimensions or `100vh`. Before mount, `prepareReefWidgetHtml` (`widget-fence-body.ts`) rejects empty bodies, nested `` ```reef-widget `` markers, stray backtick fences, and unclosed `<style>` / `<script>` tags (common when the model re-opens a fence mid-stream); shows an error panel instead of a blank iframe. `setSrcdoc` runs only after the host is in the document. Validation timeout starts after iframe `load` (5s). Prelude posts resize on load plus delayed passes (0 / 100 / 400 ms; extra passes for JSX), then `validateResult` after the first resize (600 ms HTML, ~2.8s JSX). Host accepts `postMessage` when `origin` is `null` or `''` and `source` is `null`. If the probe never reports in, the host still reveals at default height unless runtime errors were recorded.
 
 **Tests:** `test/chat/reef/*.test.mts`, `test/chat/reef/*.test.mjs` (template/snippet conventions, `reef-prompts-catalog.test.mjs`, `reef-save-prompt.test.mjs`). Plan: [`documentation/plans/feature-reef-mode-widgets.md`](plans/feature-reef-mode-widgets.md), expansion: [`documentation/plans/reef-widget-library-expansion.md`](plans/reef-widget-library-expansion.md). Verification: [`documentation/plans/verification/feature-reef.md`](plans/verification/feature-reef.md).
 

--- a/src/agents/prompts/sub-agents/reef-widget.full.md
+++ b/src/agents/prompts/sub-agents/reef-widget.full.md
@@ -3,7 +3,7 @@ You are a Reef widget sub-agent. Your only deliverable is one complete interacti
 ## Rules
 
 1. Read templates from `@minnow/reef/widgets/` via `read_file` (e.g. `@minnow/reef/widgets/calculator.md`). Do not search the user workspace for widget sources.
-2. Produce **one** fence: opening ` ```reef-widget `, fragment HTML/CSS/JS (no `<!DOCTYPE>`, `<html>`, `<head>`, `<body>`), closing fence.
+2. Produce **one** fence: opening ` ```reef-widget `, fragment HTML/CSS/JS (no `<!DOCTYPE>`, `<html>`, `<head>`, `<body>`), closing fence. Never paste ` ```reef-widget ` or ` ``` ` inside the fence body — that corrupts the widget and shows a blank iframe.
 3. Use Minnow CSS variables only (`--bg`, `--surface`, `--text`, `--accent`, etc.) — no hardcoded hex palettes.
 4. **React JSX:** bare import map specifiers (`react`, `react-dom/client`, `recharts`); `createRoot` from `react-dom/client`. In `style={{ }}`, quote tokens: `color: 'var(--text)'` — never `color: var(--text)` (invalid JS; widget will not mount).
 5. Do **not** write files, run shell, commit, or spawn sub-agents.

--- a/src/agents/prompts/sub-agents/reef-widget.lite.md
+++ b/src/agents/prompts/sub-agents/reef-widget.lite.md
@@ -1,1 +1,1 @@
-Reef widget sub-agent: read `@minnow/reef/widgets/*.md`, emit one `reef-widget` fence (tokens only, no file writes). React: bare imports; in `style={{ }}` use `'var(--text)'` not `var(--text)`. Return fence + brief summary for parent.
+Reef widget sub-agent: read `@minnow/reef/widgets/*.md`, emit one `reef-widget` fence (tokens only, no file writes). Never put fence backticks inside the body. React: bare imports; in `style={{ }}` use `'var(--text)'` not `var(--text)`. Return fence + brief summary for parent.

--- a/src/agents/shipped-sub-agent-prompts.ts
+++ b/src/agents/shipped-sub-agent-prompts.ts
@@ -15,7 +15,7 @@ export const SHIPPED_SUB_AGENT_PROMPTS: Record<string, string> = {
   'reef-widget.full': `You are a Reef widget sub-agent. Your only deliverable is one complete interactive widget as a reef-widget fenced block for the parent to paste into chat.
 
 Read templates from @minnow/reef/widgets/ via read_file. Produce one fence (no DOCTYPE/html/head/body). Use Minnow CSS variables only. Do not write files, run shell, commit, or spawn sub-agents. End with a short summary and the full fence body.`,
-  'reef-widget.lite': `Reef widget sub-agent: read @minnow/reef/widgets/*.md, emit one reef-widget fence (tokens only, no file writes). React: bare imports; in style={{ }} use 'var(--text)' not var(--text). Return fence + brief summary for parent.`,
+  'reef-widget.lite': `Reef widget sub-agent: read @minnow/reef/widgets/*.md, emit one reef-widget fence (tokens only, no file writes). Never put fence backticks inside the body. React: bare imports; in style={{ }} use 'var(--text)' not var(--text). Return fence + brief summary for parent.`,
   'debugger.full': `You are a debugger sub-agent for the bug tracker. Reproduce symptoms, read logs and code (read-only), narrow root cause with evidence. No file writes or destructive shell. Return a concise summary for the bug card.`,
   'debugger.lite': `Debugger: read-only investigation; root cause summary for parent bug card.`,
   'bug-planner.full': `You are a bug fix planner. Write the fix plan markdown at the path in the task (documentation/plans/bugs/). Use planner structure with todos front-matter. Plan only — no implementation.`,

--- a/src/chat/reef/widget-block-detector.ts
+++ b/src/chat/reef/widget-block-detector.ts
@@ -4,7 +4,11 @@
 
 import { createReefWidgetIframe } from './widget-iframe.ts';
 import { registerReefWidgetHost } from './widget-bridge.ts';
-import { createReefWidgetValidatingStatus } from './widget-error-ui.ts';
+import {
+  createReefWidgetErrorPanel,
+  createReefWidgetValidatingStatus,
+} from './widget-error-ui.ts';
+import { prepareReefWidgetHtml } from './widget-fence-body.ts';
 import {
   applyReefWidgetPendingUi,
   inferReefWidgetBuildPhase,
@@ -31,6 +35,16 @@ function isClosedReefFence(code: HTMLElement): boolean {
   if (!parentPre) return false;
   if (parentPre.querySelector('.stream-cursor')) return false;
   return true;
+}
+
+/** Mount an error panel instead of a broken iframe when fence HTML is invalid. */
+function mountReefWidgetFenceError(pre: HTMLPreElement, errors: string[]): void {
+  pre.dataset.reefMounted = 'true';
+  const host = document.createElement('div');
+  host.className = 'reef-widget-host reef-widget-host--error';
+  host.dataset.reefMounted = 'true';
+  host.appendChild(createReefWidgetErrorPanel(errors));
+  pre.replaceWith(host);
 }
 
 /**
@@ -64,7 +78,14 @@ export function mountReefWidgetBlocks(
     const code = pre.querySelector('code');
     if (!code || !isClosedReefFence(code)) return;
 
-    const widgetHtml = code.textContent ?? '';
+    const rawFenceBody = code.textContent ?? '';
+    const prepared = prepareReefWidgetHtml(rawFenceBody);
+    if (!prepared.ok) {
+      mountReefWidgetFenceError(pre, prepared.errors);
+      return;
+    }
+
+    const widgetHtml = prepared.value.html;
     pre.dataset.reefMounted = 'true';
 
     const host = document.createElement('div');
@@ -74,10 +95,12 @@ export function mountReefWidgetBlocks(
     const { iframe, widgetId, setSrcdoc } = createReefWidgetIframe({ widgetHtml });
     host.dataset.widgetId = widgetId;
     host.appendChild(createReefWidgetValidatingStatus());
-    iframe.style.visibility = 'hidden';
+    /* Probe iframe stays off-screen via .reef-widget-host--validating CSS (opacity:0). */
     host.appendChild(iframe);
 
-    registerReefWidgetHost(widgetId, host, iframe, setSrcdoc, widgetHtml);
     pre.replaceWith(host);
+    registerReefWidgetHost(widgetId, host, iframe, setSrcdoc, widgetHtml);
+    /* srcdoc scripts only run reliably once the iframe is in the live document. */
+    setSrcdoc(widgetHtml);
   });
 }

--- a/src/chat/reef/widget-bridge.ts
+++ b/src/chat/reef/widget-bridge.ts
@@ -14,6 +14,7 @@ import { subscribeThemeChanges } from './theme-forward.ts';
 import { createReefWidgetErrorPanel } from './widget-error-ui.ts';
 import {
   REEF_WIDGET_MIN_CONTENT_HEIGHT_PX,
+  REEF_WIDGET_VALIDATION_RESIZE_GRACE_MS,
   REEF_WIDGET_VALIDATION_TIMEOUT_MS,
   shouldAutoRevealReefWidgetsForTests,
   shouldRunReefWidgetValidationTimeout,
@@ -56,6 +57,7 @@ interface ReefPostMessage {
 const hostsByWidgetId = new Map<string, ReefWidgetHostRecord>();
 const abortByRequestId = new Map<string, AbortController>();
 const validationTimeoutByWidgetId = new Map<string, ReturnType<typeof setTimeout>>();
+const validationResizeGraceByWidgetId = new Map<string, ReturnType<typeof setTimeout>>();
 let activeLlmCount = 0;
 let bridgeInitialized = false;
 let themeUnsubscribe: (() => void) | null = null;
@@ -65,6 +67,11 @@ function clearReefWidgetValidationTimer(widgetId: string): void {
   if (timer) {
     clearTimeout(timer);
     validationTimeoutByWidgetId.delete(widgetId);
+  }
+  const grace = validationResizeGraceByWidgetId.get(widgetId);
+  if (grace) {
+    clearTimeout(grace);
+    validationResizeGraceByWidgetId.delete(widgetId);
   }
 }
 
@@ -87,10 +94,25 @@ function scheduleReefWidgetValidation(widgetId: string): void {
   clearReefWidgetValidationTimer(widgetId);
   const timer = setTimeout(() => {
     validationTimeoutByWidgetId.delete(widgetId);
-    completeReefWidgetValidation(widgetId, {
-      ok: false,
-      errors: ['Widget validation timed out before the iframe reported ready.'],
-    });
+    const record = hostsByWidgetId.get(widgetId);
+    if (!record || record.validationDone) return;
+
+    if (record.validationErrors.length > 0) {
+      completeReefWidgetValidation(widgetId, {
+        ok: false,
+        errors: record.validationErrors.slice(),
+      });
+      return;
+    }
+
+    if (record.lastContentHeightPx >= REEF_WIDGET_MIN_CONTENT_HEIGHT_PX) {
+      completeReefWidgetValidation(widgetId, { ok: true, errors: [] });
+      return;
+    }
+
+    /* Probe postMessage may not reach the host; still reveal at default height. */
+    applyWidgetHeight(widgetId, DEFAULT_WIDGET_HEIGHT_PX);
+    completeReefWidgetValidation(widgetId, { ok: true, errors: [] });
   }, REEF_WIDGET_VALIDATION_TIMEOUT_MS);
   validationTimeoutByWidgetId.set(widgetId, timer);
 }
@@ -112,7 +134,29 @@ export function registerReefWidgetHost(
     validationErrors: [],
     lastContentHeightPx: 0,
   });
-  scheduleReefWidgetValidation(widgetId);
+
+  if (shouldAutoRevealReefWidgetsForTests()) {
+    scheduleReefWidgetValidation(widgetId);
+    return;
+  }
+
+  let validationArmed = false;
+  const armValidationTimeout = (): void => {
+    if (validationArmed) return;
+    validationArmed = true;
+    scheduleReefWidgetValidation(widgetId);
+  };
+
+  iframe.addEventListener('load', armValidationTimeout, { once: true });
+  queueMicrotask(() => {
+    try {
+      if (iframe.contentDocument?.readyState === 'complete') {
+        armValidationTimeout();
+      }
+    } catch {
+      /* Sandboxed srcdoc: host cannot read the document until load; wait for load event. */
+    }
+  });
 }
 
 function revealValidatedWidget(record: ReefWidgetHostRecord): void {
@@ -164,17 +208,31 @@ export function completeReefWidgetValidation(
 const REEF_WIDGET_OPAQUE_ORIGIN = 'null';
 
 function isAllowedReefOrigin(origin: string): boolean {
-  if (origin === REEF_WIDGET_OPAQUE_ORIGIN) return true;
+  if (origin === REEF_WIDGET_OPAQUE_ORIGIN || origin === '') return true;
   const hostOrigin = window.location?.origin ?? '';
   return hostOrigin.length > 0 && origin === hostOrigin;
 }
 
-/** Reject confused-deputy posts: source must be the registered iframe for widgetId. */
-function isReefMessageFromWidget(widgetId: string, source: MessageEventSource | null): boolean {
-  if (!source) return false;
+/**
+ * Reject confused-deputy posts: source must be the registered iframe for widgetId.
+ * Some hosts report `source: null` for sandboxed srcdoc iframes (opaque origin).
+ */
+function isReefMessageFromWidget(
+  widgetId: string,
+  source: MessageEventSource | null,
+  origin: string,
+): boolean {
+  if (!hostsByWidgetId.has(widgetId)) return false;
   const record = hostsByWidgetId.get(widgetId);
   const expected = record?.iframe.contentWindow;
-  return expected != null && source === expected;
+  if (expected != null && source === expected) return true;
+  if (
+    source == null &&
+    (origin === REEF_WIDGET_OPAQUE_ORIGIN || origin === '')
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function reefWidgetPostMessageTarget(): string {
@@ -194,6 +252,41 @@ function applyWidgetHeight(widgetId: string, heightPx: number): void {
   record.lastContentHeightPx = h;
   record.host.style.height = `${h}px`;
   record.iframe.style.height = `${h}px`;
+}
+
+function finishReefWidgetValidation(
+  widgetId: string,
+  result: ReefWidgetValidationResult,
+): void {
+  const record = hostsByWidgetId.get(widgetId);
+  if (!record || record.validationDone) return;
+
+  const reportedErrors = Array.isArray(result.errors)
+    ? result.errors.map((e) => e.trim()).filter(Boolean)
+    : [];
+  if (result.ok !== true || reportedErrors.length > 0 || record.validationErrors.length > 0) {
+    completeReefWidgetValidation(widgetId, result);
+    return;
+  }
+
+  if (record.lastContentHeightPx >= REEF_WIDGET_MIN_CONTENT_HEIGHT_PX) {
+    completeReefWidgetValidation(widgetId, result);
+    return;
+  }
+
+  const existing = validationResizeGraceByWidgetId.get(widgetId);
+  if (existing) return;
+
+  const grace = setTimeout(() => {
+    validationResizeGraceByWidgetId.delete(widgetId);
+    const latest = hostsByWidgetId.get(widgetId);
+    if (!latest || latest.validationDone) return;
+    if (latest.lastContentHeightPx < REEF_WIDGET_MIN_CONTENT_HEIGHT_PX) {
+      applyWidgetHeight(widgetId, DEFAULT_WIDGET_HEIGHT_PX);
+    }
+    completeReefWidgetValidation(widgetId, result);
+  }, REEF_WIDGET_VALIDATION_RESIZE_GRACE_MS);
+  validationResizeGraceByWidgetId.set(widgetId, grace);
 }
 
 function recordWidgetRuntimeError(widgetId: string, message: string): void {
@@ -336,7 +429,7 @@ function onReefMessage(event: MessageEvent): void {
   const data = event.data as ReefPostMessage | null;
   if (!data || data.type !== 'reef' || !data.action || !data.widgetId) return;
   if (!hostsByWidgetId.has(data.widgetId)) return;
-  if (!isReefMessageFromWidget(data.widgetId, event.source)) return;
+  if (!isReefMessageFromWidget(data.widgetId, event.source, event.origin)) return;
 
   switch (data.action) {
     case 'sendPrompt':
@@ -355,7 +448,7 @@ function onReefMessage(event: MessageEvent): void {
       const errors = Array.isArray(data.errors)
         ? data.errors.filter((e): e is string => typeof e === 'string')
         : [];
-      completeReefWidgetValidation(data.widgetId, {
+      finishReefWidgetValidation(data.widgetId, {
         ok: data.ok === true,
         errors,
       });
@@ -412,6 +505,10 @@ export function resetReefBridgeForTests(): void {
     clearTimeout(timer);
   }
   validationTimeoutByWidgetId.clear();
+  for (const grace of validationResizeGraceByWidgetId.values()) {
+    clearTimeout(grace);
+  }
+  validationResizeGraceByWidgetId.clear();
   if (themeUnsubscribe) {
     themeUnsubscribe();
     themeUnsubscribe = null;

--- a/src/chat/reef/widget-fence-body.ts
+++ b/src/chat/reef/widget-fence-body.ts
@@ -1,0 +1,108 @@
+/**
+ * Validate and normalize HTML taken from a ```reef-widget markdown fence.
+ * Rejects corrupted stream output (nested fence markers, truncated tags).
+ */
+
+const REEF_FENCE_MARKER_RE = /```reef-widget/gi;
+const STRAY_CLOSING_FENCE_RE = /^```\s*$/gm;
+const ANY_BACKTICK_FENCE_RE = /```/;
+
+export interface PreparedReefWidgetHtml {
+  html: string;
+  /** True when repeated ```reef-widget markers were stripped from the body. */
+  recoveredFromDuplicateMarkers: boolean;
+}
+
+/** Count opening vs closing tags (case-insensitive). */
+function countTags(body: string, openRe: RegExp, closeRe: RegExp): { open: number; close: number } {
+  return {
+    open: [...body.matchAll(openRe)].length,
+    close: [...body.matchAll(closeRe)].length,
+  };
+}
+
+/** When the model re-emits fence markers mid-stream, keep the last HTML segment. */
+function stripEmbeddedFenceMarkers(raw: string): {
+  body: string;
+  recoveredFromDuplicateMarkers: boolean;
+} {
+  if (!REEF_FENCE_MARKER_RE.test(raw)) {
+    return { body: raw.trim(), recoveredFromDuplicateMarkers: false };
+  }
+
+  REEF_FENCE_MARKER_RE.lastIndex = 0;
+  const segments = raw
+    .split(REEF_FENCE_MARKER_RE)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (segments.length <= 1) {
+    const body = raw.replace(REEF_FENCE_MARKER_RE, '').trim();
+    return { body, recoveredFromDuplicateMarkers: true };
+  }
+
+  return {
+    body: segments[segments.length - 1],
+    recoveredFromDuplicateMarkers: true,
+  };
+}
+
+/**
+ * Prepare fence body for iframe srcdoc. Returns errors when the HTML is not safe to mount.
+ */
+export function prepareReefWidgetHtml(
+  raw: string,
+): { ok: true; value: PreparedReefWidgetHtml } | { ok: false; errors: string[] } {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { ok: false, errors: ['Widget fence is empty.'] };
+  }
+
+  const { body: stripped, recoveredFromDuplicateMarkers } = stripEmbeddedFenceMarkers(trimmed);
+  let body = stripped
+    .replace(/^```reef-widget\s*\r?\n?/gim, '')
+    .replace(STRAY_CLOSING_FENCE_RE, '')
+    .trim();
+
+  if (!body) {
+    return { ok: false, errors: ['Widget fence is empty after removing markdown delimiters.'] };
+  }
+
+  if (ANY_BACKTICK_FENCE_RE.test(body)) {
+    return {
+      ok: false,
+      errors: [
+        'Widget body still contains markdown code-fence backticks. The assistant must emit one complete ```reef-widget block without nested fences.',
+      ],
+    };
+  }
+
+  const style = countTags(body, /<style\b/gi, /<\/style>/gi);
+  if (style.open !== style.close) {
+    return {
+      ok: false,
+      errors: [
+        `Widget stylesheet is incomplete (${style.open} <style> open, ${style.close} </style> close). Wait for the full reply or ask for a new widget.`,
+      ],
+    };
+  }
+
+  const script = countTags(body, /<script\b/gi, /<\/script>/gi);
+  if (script.open !== script.close) {
+    return {
+      ok: false,
+      errors: [
+        `Widget script is incomplete (${script.open} <script> open, ${script.close} </script> close). Wait for the full reply or ask for a new widget.`,
+      ],
+    };
+  }
+
+  if (!/<[a-z][\s\S]*?>/i.test(body)) {
+    return { ok: false, errors: ['Widget body does not contain HTML markup.'] };
+  }
+
+  return {
+    ok: true,
+    value: { html: body, recoveredFromDuplicateMarkers },
+  };
+}

--- a/src/chat/reef/widget-iframe.ts
+++ b/src/chat/reef/widget-iframe.ts
@@ -199,7 +199,7 @@ export function createReefWidgetIframe(
     });
   };
 
-  setSrcdoc(options.widgetHtml);
+  /* Caller must invoke setSrcdoc after the iframe is connected in the document tree. */
   return { iframe, widgetId, setSrcdoc };
 }
 

--- a/src/chat/reef/widget-prelude.ts
+++ b/src/chat/reef/widget-prelude.ts
@@ -88,18 +88,45 @@ export const PRELUDE_SCRIPT = `(function () {
     });
   }
 
+  var validateEmitted = false;
+
+  function emitValidateResultOnce() {
+    if (validateEmitted) return;
+    validateEmitted = true;
+    emitValidateResult();
+  }
+
+  function tryEmitValidateAfterResize() {
+    if (validateEmitted) return;
+    postResizeToHost();
+    if (lastPostedHeight >= 24) {
+      emitValidateResultOnce();
+      return;
+    }
+    setTimeout(function () {
+      postResizeToHost();
+      emitValidateResultOnce();
+    }, 80);
+  }
+
   /** Catch dynamic DOM (sync scripts, ESM, charts) that mount after the first measure. */
   function scheduleDelayedResizePasses() {
-    /* Direct call first: rAF can be throttled when the host hides the iframe with
-       visibility:hidden during validation, causing resize to arrive after validateResult.
-       postResizeToHost() deduplicates via lastPostedHeight so this is safe to call often. */
+    var hasJsx = document.querySelector('script[type="text/jsx"]') != null;
+    var validateDelayMs = hasJsx ? 2800 : 600;
+
+    /* Sync measure first: rAF can lag while the host probes with a hidden iframe. */
     postResizeToHost();
     scheduleResizePost();
     setTimeout(scheduleResizePost, 0);
     setTimeout(postResizeToHost, 0);
     setTimeout(scheduleResizePost, 100);
     setTimeout(scheduleResizePost, 400);
-    setTimeout(emitValidateResult, 500);
+    if (hasJsx) {
+      setTimeout(scheduleResizePost, 1200);
+      setTimeout(scheduleResizePost, 2200);
+    }
+    setTimeout(tryEmitValidateAfterResize, validateDelayMs);
+    setTimeout(emitValidateResultOnce, hasJsx ? 4200 : 1800);
   }
 
   window.addEventListener("message", function (ev) {

--- a/src/chat/reef/widget-validation.ts
+++ b/src/chat/reef/widget-validation.ts
@@ -2,8 +2,11 @@
  * Reef widget iframe validation timing and test hooks (host preflight before reveal).
  */
 
-/** Milliseconds to wait after mount before failing closed when no validateResult arrives. */
-export const REEF_WIDGET_VALIDATION_TIMEOUT_MS = 1200;
+/** Milliseconds after iframe load before failing closed when no validateResult arrives. */
+export const REEF_WIDGET_VALIDATION_TIMEOUT_MS = 5000;
+
+/** Brief grace after validateResult when resize is still in flight (hidden probe iframe). */
+export const REEF_WIDGET_VALIDATION_RESIZE_GRACE_MS = 300;
 
 /** Minimum measured content height (px) to treat a widget as rendered. */
 export const REEF_WIDGET_MIN_CONTENT_HEIGHT_PX = 24;

--- a/test/chat/reef/widget-block-detector.test.mts
+++ b/test/chat/reef/widget-block-detector.test.mts
@@ -179,6 +179,37 @@ describe('widget-block-detector', { concurrency: false }, () => {
     assert.ok(host?.querySelector('iframe.reef-widget-iframe'));
   });
 
+  test('shows error panel when fence body contains nested reef-widget markers', async () => {
+    setupDom();
+    const chat = createEmptyChatObject('model-a');
+    chat.modeId = 'reef';
+    setSessionStateForTests({
+      version: 2,
+      activeId: chat.id,
+      sidebarCollapsed: false,
+      chats: [chat],
+    });
+
+    const bubble = document.createElement('div');
+    const pre = document.createElement('pre');
+    pre.setAttribute('data-lang', 'reef-widget');
+    const code = document.createElement('code');
+    code.textContent = `text-align: right\`\`\`reef-widget
+<style>
+.calc { font-size: 1rem;
+`;
+    pre.appendChild(code);
+    bubble.appendChild(pre);
+
+    mountReefWidgetBlocks(bubble);
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const host = bubble.querySelector('.reef-widget-host--error');
+    assert.ok(host);
+    assert.equal(bubble.querySelector('iframe'), null);
+    assert.match(host?.textContent ?? '', /style/i);
+  });
+
   test('does not remount when pre already marked', () => {
     setupDom();
     const chat = createEmptyChatObject('model-a');

--- a/test/chat/reef/widget-bridge.test.mts
+++ b/test/chat/reef/widget-bridge.test.mts
@@ -183,10 +183,46 @@ describe('widget-bridge', { concurrency: false }, () => {
 
   test('isAllowedReefOrigin rejects empty and untrusted origins', () => {
     setupDom();
-    assert.equal(isAllowedReefOriginForTests(''), false);
+    assert.equal(isAllowedReefOriginForTests(''), true);
     assert.equal(isAllowedReefOriginForTests('https://evil.example'), false);
     assert.equal(isAllowedReefOriginForTests('null'), true);
     assert.equal(isAllowedReefOriginForTests(window.location.origin), true);
+  });
+
+  test('accepts reef messages when event.source is null for sandboxed srcdoc', () => {
+    setupDom();
+    setAutoRevealReefWidgetsForTests(false);
+    const host = document.createElement('div');
+    host.className = 'reef-widget-host reef-widget-host--validating';
+    const iframe = document.createElement('iframe');
+    host.appendChild(iframe);
+    registerReefWidgetHost('widget-null-source', host, iframe, () => {}, '');
+
+    handleReefMessageForTests({
+      origin: 'null',
+      source: null,
+      data: {
+        type: 'reef',
+        action: 'resize',
+        widgetId: 'widget-null-source',
+        height: 160,
+      },
+    } as MessageEvent);
+    handleReefMessageForTests({
+      origin: 'null',
+      source: null,
+      data: {
+        type: 'reef',
+        action: 'validateResult',
+        widgetId: 'widget-null-source',
+        ok: true,
+        errors: [],
+      },
+    } as MessageEvent);
+
+    assert.equal(host.classList.contains('reef-widget-host--error'), false);
+    assert.equal(host.style.height, '160px');
+    assert.notEqual(host.classList.contains('reef-widget-host--validating'), true);
   });
 
   test('ignores reef messages when event.source is not the widget iframe', () => {

--- a/test/chat/reef/widget-fence-body.test.mts
+++ b/test/chat/reef/widget-fence-body.test.mts
@@ -1,0 +1,63 @@
+/**
+ * Reef widget fence body validation (corrupt stream / nested markers).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { prepareReefWidgetHtml } from '../../../src/chat/reef/widget-fence-body.ts';
+
+const VALID_CALC_SNIPPET = `<style>
+.rw { display: flex; }
+</style>
+<div class="rw"><div class="calc-container">OK</div></div>
+<script type="module">
+import React from 'react';
+</script>`;
+
+describe('widget-fence-body', () => {
+  test('accepts clean widget HTML', () => {
+    const result = prepareReefWidgetHtml(VALID_CALC_SNIPPET);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.match(result.value.html, /calc-container/);
+    assert.equal(result.value.recoveredFromDuplicateMarkers, false);
+  });
+
+  test('rejects empty fence', () => {
+    const result = prepareReefWidgetHtml('   ');
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.errors[0], /empty/i);
+  });
+
+  test('rejects truncated HTML after duplicate fence markers', () => {
+    const corrupt = `<style>.a { color: var(--text); }</style><div>a</div>
+\`\`\`reef-widget
+<style>
+.calc-main { font-size: 1.75rem;
+`;
+    const result = prepareReefWidgetHtml(corrupt);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.errors.join(' '), /style/i);
+  });
+
+  test('recovers last segment when fence marker was repeated', () => {
+    const raw = `<style>.old{}</style><div>old</div>
+\`\`\`reef-widget
+${VALID_CALC_SNIPPET}`;
+    const result = prepareReefWidgetHtml(raw);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.recoveredFromDuplicateMarkers, true);
+    assert.match(result.value.html, /calc-container/);
+    assert.doesNotMatch(result.value.html, /\.old/);
+  });
+
+  test('rejects unclosed style tag', () => {
+    const result = prepareReefWidgetHtml('<style>.x { color: red; }<div></div>');
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.errors.join(' '), /style/i);
+  });
+});

--- a/test/chat/reef/widget-iframe.test.mts
+++ b/test/chat/reef/widget-iframe.test.mts
@@ -34,7 +34,8 @@ describe('widget-iframe', () => {
     assert.match(srcdoc, /ensureChartParentsSized/);
     assert.match(srcdoc, /scheduleDelayedResizePasses/);
     assert.match(srcdoc, /setTimeout\(scheduleResizePost, 400\)/);
-    assert.match(srcdoc, /emitValidateResult/);
+    assert.match(srcdoc, /tryEmitValidateAfterResize/);
+    assert.match(srcdoc, /emitValidateResultOnce/);
     assert.match(srcdoc, /validateResult/);
     assert.match(srcdoc, /captureWidgetError/);
   });


### PR DESCRIPTION
## Summary

- Validate ``reef-widget`` fence bodies before mount (`widget-fence-body.ts`): reject nested fence markers, stray backticks, and unclosed `<style>` / `<script>` tags; show an error panel instead of a blank iframe.
- Defer `srcdoc` until the iframe is in the document; start validation timeout after `load`; accept sandboxed `postMessage` when `origin` is `null`/`''` and `source` is `null`.
- Improve prelude resize/validate timing for JSX widgets; fail open at default height only when no runtime errors were recorded.
- Update Reef sub-agent prompts to never emit fence backticks inside the widget body.

## Test plan

- [ ] Restart `npm run dev`, hard-refresh, create a new Reef chat message with a calculator widget
- [ ] Confirm a valid widget renders (not blank 120px iframe)
- [ ] Confirm a corrupted/half-streamed fence shows the error panel with a clear message
- [ ] `node --experimental-test-module-mocks ./node_modules/tsx/dist/cli.mjs --import ./test/test-loader.mjs --test test/chat/reef/*.mts`
