### PR TITLE
Fix memory recall injection and save_memory guidance

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -270,7 +270,7 @@ Dual entry: **`/ui-designer`** slash skill or **UI Designer** Work Agent (`ui-de
 
 ### Memory system (Step 16)
 
-Persistent notes under `~/.minnow/memory/` (`index.json` + `entries/<uuid>.md`). Injected via composer `memory` part and `{{memory}}` when enabled.
+Persistent notes under `~/.minnow/memory/` (`index.json` + `entries/<uuid>.md`). Injected via composer `memory` part (`src/chat/prompts/memory/*.md` wraps `{{memory}}` around the retrieved block) when enabled. **Retrieve fallback:** keyword queries with no token matches still inject recent/pinned entries (`server/memory/retrieve.js`). **Sub-agents:** `buildSubAgentSystemPrompt` in [`src/agents/sub-agent-prompt.ts`](../src/agents/sub-agent-prompt.ts) injects the same memory block (task text as query) and `save_memory` guidance when the tool is allowed. **Save guidance:** full/lite base prompts + memory templates tell the model to call `save_memory` for explicit “remember this” requests and stable preferences/facts (not secrets or one-off state).
 
 | API | Purpose |
 |-----|---------|

--- a/server/memory/retrieve.js
+++ b/server/memory/retrieve.js
@@ -88,6 +88,16 @@ export function retrieveMemoryBlock(allEntries, opts = {}) {
   }));
 
   ranked = ranked.filter((r) => (tokens.length > 0 ? r.score > 0 : r.score >= 0));
+
+  // Keyword queries with no matches still inject recent/pinned notes (v1 has no embeddings).
+  if (ranked.length === 0 && allEntries.length > 0) {
+    ranked = allEntries.map(({ meta, body }) => ({
+      meta,
+      body,
+      score: meta.pinned ? 2 : 1,
+    }));
+  }
+
   ranked.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;
     return String(b.meta.updatedAt).localeCompare(String(a.meta.updatedAt));

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -282,6 +282,7 @@ async function executeRun(internals: RunInternals, modeId: string): Promise<void
       run.task,
       typeConfig,
       [...allowedNames],
+      parentChat ?? null,
     );
 
     const filteredExecute = async (

--- a/src/agents/sub-agent-prompt.ts
+++ b/src/agents/sub-agent-prompt.ts
@@ -2,9 +2,17 @@
  * Build system prompts for sub-agent runs.
  */
 
+import { interpolatePromptBody } from '../chat/prompts/interpolate';
+import { loadPromptById } from '../chat/prompts/prompt-loader';
 import { fetchPromptFile } from '../chat/prompts/prompt-file-api';
 import { getPromptMetaSettingsSync } from '../config/prompt-meta';
 import { detectConfigServer, isServerStorageMode } from '../config/storage-mode';
+import { fetchMemoryEnabled, retrieveMemoryBlock } from '../memory/client';
+import {
+  fetchMemoryInjectionEnabled,
+  isMemoryEnabledForChat,
+} from '../memory/config';
+import type { Chat } from '../types';
 import { SHIPPED_SUB_AGENT_PROMPTS } from './shipped-sub-agent-prompts';
 import { getWorkAgentPromptOverride } from './work-agent-registry';
 import { fetchWorkAgentPrompt } from './work-agent-prompt-api';
@@ -70,11 +78,84 @@ export function appendSubAgentAskQuestionRules(
   return `${systemPrompt}${SUB_AGENT_ASK_QUESTION_RULES}`;
 }
 
+const SUB_AGENT_SAVE_MEMORY_RULES = `
+
+### Memory (sub-agent)
+Notes below are from prior sessions — treat as context and verify against the codebase.
+Use \`save_memory\` for stable preferences or explicit "remember this" requests (not secrets or one-off state). Confirm only after the tool succeeds.`;
+
+/** Inject retrieved memories and optional save_memory guidance for sub-agents. */
+export async function appendSubAgentMemorySection(
+  systemPrompt: string,
+  task: string,
+  enabledToolNames: string[],
+  parentChat?: Chat | null,
+): Promise<string> {
+  const injectionOn = await fetchMemoryInjectionEnabled();
+  if (!injectionOn) {
+    return appendSubAgentSaveMemoryRules(systemPrompt, enabledToolNames);
+  }
+  const globalEnabled = await fetchMemoryEnabled();
+  const inject = parentChat
+    ? isMemoryEnabledForChat(parentChat, globalEnabled)
+    : globalEnabled;
+  if (!inject) {
+    return appendSubAgentSaveMemoryRules(systemPrompt, enabledToolNames);
+  }
+
+  const meta = getPromptMetaSettingsSync();
+  const profile = meta.activePromptProfile === 'lite' ? 'lite' : 'full';
+  const block = await retrieveMemoryBlock({ query: task, profile });
+
+  let result = systemPrompt;
+  if (block.trim()) {
+    const loaded = loadPromptById('info', 'memory', profile);
+    const template = loaded?.body?.trim() ?? 'Prior notes:\n\n{{memory}}';
+    const section = interpolatePromptBody(template, {
+      mode: '',
+      mode_label: '',
+      profile,
+      expert: '',
+      enabled_tools: '',
+      cwd: '',
+      memory: block,
+      user_message: task,
+      chat_history_summary: '',
+      work_agent: '',
+      work_agent_label: '',
+      skill: '',
+      date: new Date().toISOString().slice(0, 10),
+      os: typeof navigator !== 'undefined' ? navigator.platform : 'node',
+      plan_granularity: '',
+      orchestrate_plan: '',
+    });
+    if (section.trim()) {
+      result = `${result}\n\n---\n\n${section.trim()}`;
+    }
+  }
+
+  return appendSubAgentSaveMemoryRules(result, enabledToolNames);
+}
+
+function appendSubAgentSaveMemoryRules(
+  systemPrompt: string,
+  enabledToolNames: string[],
+): string {
+  if (!enabledToolNames.includes('save_memory')) {
+    return systemPrompt;
+  }
+  if (systemPrompt.includes('save_memory')) {
+    return systemPrompt;
+  }
+  return `${systemPrompt}${SUB_AGENT_SAVE_MEMORY_RULES}`;
+}
+
 export async function buildSubAgentSystemPrompt(
   typeId: string,
   task: string,
   typeConfig: SubAgentTypeConfig,
   enabledToolNames: string[] = [],
+  parentChat?: Chat | null,
 ): Promise<string> {
   const base = await resolveSubAgentBasePrompt(typeId, typeConfig);
   const envelope = `${base}
@@ -86,5 +167,11 @@ Return a concise summary for the parent when done.
 
 Task:
 ${task}`;
-  return appendSubAgentAskQuestionRules(envelope, enabledToolNames);
+  const withMemory = await appendSubAgentMemorySection(
+    envelope,
+    task,
+    enabledToolNames,
+    parentChat,
+  );
+  return appendSubAgentAskQuestionRules(withMemory, enabledToolNames);
 }

--- a/src/chat/prompts/base/default.full.md
+++ b/src/chat/prompts/base/default.full.md
@@ -48,7 +48,14 @@ You may be running on a local model with a constrained context window. Be effici
 
 ## Memory
 
-Persistent notes from prior sessions (if any) appear later in this system prompt under a "memory" section. Treat them as background context, not as absolute truth — always verify against the current state of the codebase before acting on them. To store a new note, use the **`save_memory`** tool (requires `npm start`); do not tell the user you remembered something unless that tool call succeeded.
+Persistent notes from prior sessions (if any) appear later in this system prompt under a "memory" section. Treat them as background context, not as absolute truth — always verify against the current state of the codebase before acting on them.
+
+Use the **`save_memory`** tool (requires `npm start`) when:
+- the user asks you to remember something;
+- you learn a **stable** preference, convention, or project fact that should apply in future chats (e.g. test runner, branch naming, deployment constraints);
+- a decision or constraint would be costly to rediscover.
+
+Do **not** save transient task state, one-off commands, or secrets. Do not tell the user you remembered something unless `save_memory` succeeded.
 
 ---
 

--- a/src/chat/prompts/base/default.lite.md
+++ b/src/chat/prompts/base/default.lite.md
@@ -16,3 +16,4 @@ You are **Minnow**, a local-first AI assistant. Cwd: `{{cwd}}`. Date: {{date}}. 
 - File refs as `path:line`. Code in fenced blocks.
 - No secrets in output. No destructive commands without explicit permission.
 - Be concise. No preamble, no closing summary.
+- Prior notes may appear later under "memory" (verify against the repo). Use **`save_memory`** for stable preferences or explicit "remember this" requests (requires `npm start`); confirm only after the tool succeeds.

--- a/src/chat/prompts/memory/full.md
+++ b/src/chat/prompts/memory/full.md
@@ -17,4 +17,4 @@ The following notes were saved from prior sessions with this user or in this wor
 - If a note references a file, function, or flag, verify it still exists before acting on it.
 - If a note contradicts the user's current message, follow the user.
 
-**Saving new notes:** When the user asks you to remember something, or when a stable preference or project fact should persist across chats, call the **`save_memory`** tool with a short `title` and a clear `body` (optional `tags`). Do not claim you saved a memory unless that tool succeeded.
+**Saving new notes:** Call **`save_memory`** (short `title`, clear `body`, optional `tags`) when the user asks you to remember something, or when you learn a **stable** preference, convention, or project fact worth carrying into future chats. Skip one-off task state, secrets, and ephemeral details. Do not claim you saved a memory unless that tool succeeded.

--- a/src/chat/prompts/memory/lite.md
+++ b/src/chat/prompts/memory/lite.md
@@ -9,4 +9,4 @@ Prior notes (may be stale — verify before acting):
 
 {{memory}}
 
-Use **`save_memory`** when the user wants something remembered (title + body). Confirm only after the tool succeeds.
+Use **`save_memory`** for explicit "remember this" requests or **stable** preferences/facts (title + body). Skip secrets and one-off state. Confirm only after the tool succeeds.

--- a/src/chat/prompts/prompt-composer.ts
+++ b/src/chat/prompts/prompt-composer.ts
@@ -158,6 +158,11 @@ function resolvePartBody(
     return ctx.skillBody.trim();
   }
   if (partId === 'memory' && ctx.memoryBlock?.trim()) {
+    const loadProfile = profile === 'lite' ? 'lite' : 'full';
+    const loaded = loadPromptById('info', 'memory', loadProfile);
+    if (loaded?.body?.trim()) {
+      return loaded.body.trim();
+    }
     return ctx.memoryBlock.trim();
   }
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1160,7 +1160,7 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
     serverRequired: true,
     definition: toolSchema(
       'save_memory',
-      'Save a durable memory entry under ~/.minnow/memory for retrieval in later sessions. Use when the user asks you to remember something or when a stable preference or project fact should persist.',
+      'Save a durable memory entry under ~/.minnow/memory for retrieval in later sessions. Use when the user asks you to remember something, or when you learn a stable preference, convention, or project fact worth carrying into future chats. Do not save secrets, one-off task state, or ephemeral details.',
       {
         title: {
           type: 'string',

--- a/test/memory/retrieve.test.mjs
+++ b/test/memory/retrieve.test.mjs
@@ -34,6 +34,21 @@ describe('memory retrieve', () => {
     assert.equal(block, expected);
   });
 
+  test('retrieveMemoryBlock falls back when query has no token matches', () => {
+    const all = [
+      { meta: META_A, body: 'Use npm start for integration tests.' },
+      { meta: META_B, body: 'Use poetry for Python projects.' },
+    ];
+    const { block, ids } = retrieveMemoryBlock(all, {
+      query: 'hello world unrelated',
+      limit: 4,
+      maxChars: 4000,
+    });
+    assert.match(block, /npm workflow/);
+    assert.match(block, /Python only/);
+    assert.equal(ids.length, 2);
+  });
+
   test('retrieveMemoryBlock ranks npm over python', () => {
     const all = [
       { meta: META_A, body: 'Use npm start for integration tests.' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Saved memories were not reliably reaching agents, and save instructions were easy to miss.

## Changes

- **Retrieve fallback** (`server/memory/retrieve.js`): When a user message has query tokens but none match stored memories, inject recent/pinned entries instead of an empty block (keyword retrieval has no embeddings yet).
- **Prompt composer** (`prompt-composer.ts`): When memories are retrieved, wrap them with `memory/full.md` or `memory/lite.md` so models see both the notes and how to use/save them (previously only the raw `## Retrieved memory` list was injected).
- **Save guidance**: Clearer instructions in full/lite base prompts, memory templates, and the `save_memory` tool schema (stable preferences/facts yes; secrets and one-off state no).
- **Sub-agents** (`sub-agent-prompt.ts`): Inject the same memory block (task text as query) and optional `save_memory` rules when the tool is allowed on the sub-agent.

## Testing

- `npm run test:memory` (10/10 pass)
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80cc3e3e-8f2c-4f17-994f-84901b8ba594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80cc3e3e-8f2c-4f17-994f-84901b8ba594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

