### PR TITLE
Sampler presets per agent (MIN-45)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -2,7 +2,7 @@
 
 User-facing setup and quick start: [`README.md`](../README.md).
 
-**Feature gap audit (2026):** [`documentation/plans/feature-audit-roadmap.md`](plans/feature-audit-roadmap.md) — shipped vs partial vs missing across agents, Reef, trace/replay, and settings. **Local eval harness (audit #21, planned):** [`documentation/plans/Build out/feature-21-local-eval-harness.md`](plans/Build%20out/feature-21-local-eval-harness.md). **In-app LLM Benchmark screen (Bench, planned):** [`documentation/plans/benchmark-system-implementation.md`](plans/benchmark-system-implementation.md) — active-model integration battery + run history (complements Feature 21). **#03 Context budgets per agent (plan):** [`documentation/plans/Build out/feature-03-context-budgets.md`](plans/Build%20out/feature-03-context-budgets.md). **#07 Sub-agent budgets + structured summaries (shipped MIN-43):** [`documentation/plans/Build out/feature-07-sub-agent-budgets.md`](plans/Build%20out/feature-07-sub-agent-budgets.md). **#09 Sampler presets per agent (plan):** [`documentation/plans/Build out/feature-09-sampler-presets.md`](plans/Build%20out/feature-09-sampler-presets.md). **#12 Prompt diffing (plan):** [`documentation/plans/Build out/feature-12-prompt-diffing.md`](plans/Build%20out/feature-12-prompt-diffing.md). **#13 Prompt profiles (plan):** [`documentation/plans/Build out/feature-13-prompt-profiles.md`](plans/Build%20out/feature-13-prompt-profiles.md). **#20 Multi-model conversation (plan):** [`documentation/plans/Build out/feature-20-multi-model-conversation.md`](plans/Build%20out/feature-20-multi-model-conversation.md). **Sub-agent orchestration** is documented below under **Sub-agent orchestration (Step 09)**; verification: [`documentation/plans/verification/step-09.md`](plans/verification/step-09.md).
+**Feature gap audit (2026):** [`documentation/plans/feature-audit-roadmap.md`](plans/feature-audit-roadmap.md) — shipped vs partial vs missing across agents, Reef, trace/replay, and settings. **Local eval harness (audit #21, planned):** [`documentation/plans/Build out/feature-21-local-eval-harness.md`](plans/Build%20out/feature-21-local-eval-harness.md). **In-app LLM Benchmark screen (Bench, planned):** [`documentation/plans/benchmark-system-implementation.md`](plans/benchmark-system-implementation.md) — active-model integration battery + run history (complements Feature 21). **#03 Context budgets per agent (plan):** [`documentation/plans/Build out/feature-03-context-budgets.md`](plans/Build%20out/feature-03-context-budgets.md). **#07 Sub-agent budgets + structured summaries (shipped MIN-43):** [`documentation/plans/Build out/feature-07-sub-agent-budgets.md`](plans/Build%20out/feature-07-sub-agent-budgets.md). **#09 Sampler presets per agent (built):** per work-agent and sub-agent-type `sampler` objects merged at send time in [`src/agents/resolve-sampler.ts`](../src/agents/resolve-sampler.ts) → [`src/tools/loop.ts`](../src/tools/loop.ts) and [`src/agents/sub-agent-runner.ts`](../src/agents/sub-agent-runner.ts); defaults in [`src/agents/defaults/work-agent-samplers.json`](../src/agents/defaults/work-agent-samplers.json) and [`src/agents/defaults/sub-agents.json`](../src/agents/defaults/sub-agents.json). Plan: [`documentation/plans/Build out/feature-09-sampler-presets.md`](plans/Build%20out/feature-09-sampler-presets.md). **#12 Prompt diffing (plan):** [`documentation/plans/Build out/feature-12-prompt-diffing.md`](plans/Build%20out/feature-12-prompt-diffing.md). **#13 Prompt profiles (plan):** [`documentation/plans/Build out/feature-13-prompt-profiles.md`](plans/Build%20out/feature-13-prompt-profiles.md). **#20 Multi-model conversation (plan):** [`documentation/plans/Build out/feature-20-multi-model-conversation.md`](plans/Build%20out/feature-20-multi-model-conversation.md). **Sub-agent orchestration** is documented below under **Sub-agent orchestration (Step 09)**; verification: [`documentation/plans/verification/step-09.md`](plans/verification/step-09.md).
 
 **To-fix roadmap:** Backlog in [`documentation/plans/to-fix.md`](plans/to-fix.md). **Implementation build plans** (with tests and todos): [`documentation/plans/Build out/`](plans/Build%20out/) — `switch-chats-while-waiting`, `reef-files-minnow-home`, `reef-optional-save-prompt`, `no-auto-open-terminal`, `no-restart-finished-chat`, `llm-mode-switch-suggestions`, `fix-chat-titles-thinking-leak`, `files-sidebar-close-arrow` (line numbers in each plan link to `to-fix.md`). Product backlog plans remain `feature-01` … `feature-30` in the same folder. **Persistence contract (Step 02+):** `~/.minnow/sessions/state.json` — single session blob, not per-chat files. **Tests (Step 02+):** `npm test` → `node --test` (JS suites), then `tsx --import ./test/test-loader.mjs --test` (TS/UI; loader stubs `.css` / xterm).
 
@@ -478,6 +478,7 @@ Task-specific agents with per-agent prompts, optional provider/model binding, an
 | Concern | Location |
 |---------|----------|
 | Types + registry | `src/agents/work-agent-types.ts`, `work-agent-registry.ts` |
+| Sampler presets | `src/agents/sampler-types.ts`, `resolve-sampler.ts`, `defaults/work-agent-samplers.json` |
 | Binding resolver | `src/agents/resolve-work-agent-binding.ts` |
 | Turn resolution | `src/agents/resolve-work-agent.ts`, `set-work-agent.ts` (S09 hook) |
 | Shipped prompts | `src/chat/prompts/work-agents/<id>/agent.{full,lite}.md`, `registry.json` |
@@ -488,7 +489,7 @@ Task-specific agents with per-agent prompts, optional provider/model binding, an
 
 **Built-in ids:** `default`, `builder`, `plan` → `planner`, `research` → `researcher`, plus `reviewer`. Mode auto-map via `defaultForModes` when `workAgentAuto` is true (default).
 
-**Send path:** `resolveActiveWorkAgent()` → `resolveComposedSystemPrompt()` sets `workAgentId` / `workAgentLabel` → `resolveWorkAgentBinding()` picks provider + model **per turn** (does not overwrite `chat.modelId`). Optional `allowedTools` filters the tool list. Status pill: `Generating reply (Builder)…`.
+**Send path:** `resolveActiveWorkAgent()` → `resolveComposedSystemPrompt()` sets `workAgentId` / `workAgentLabel` → `resolveWorkAgentBinding()` picks provider + model **per turn** (does not overwrite `chat.modelId`). **`resolveSamplerPreset({ kind: 'work-agent' })`** merges drawer `#temperature` / `#maxTokens` → shipped role defaults (`work-agent-samplers.json`) → `work-agents.json` partial `sampler` override, then `applySamplerToBody()` before `streamCompletionTurn`. Passthrough agent `default` skips role defaults. Optional `allowedTools` filters the tool list. Status pill: `Generating reply (Builder)…`.
 
 **Legacy system prompt:** `#systemPrompt` textarea remains fallback when composed prompt is empty. Full per-agent editor UI deferred to **Step 20**.
 
@@ -498,11 +499,11 @@ Task-specific agents with per-agent prompts, optional provider/model binding, an
 |--------|------|---------|
 | `GET` | `/api/work-agents` | `{ agents, overrides }` |
 | `GET` | `/api/work-agents/:id` | Single merged agent |
-| `PUT` | `/api/work-agents/:id` | Patch `work-agents.json` override |
+| `PUT` | `/api/work-agents/:id` | Patch `work-agents.json` override (`providerId`, `modelId`, `sampler`, …) |
 | `GET` | `/api/work-agents/:id/prompt?profile=full\|lite` | `{ content, source }` |
 | `PUT` | `/api/work-agents/:id/prompt` | Write `~/.minnow/prompts/work-agents/...` |
 
-**Tests:** `test/work-agents/**/*.test.mjs`. Verification: [`documentation/plans/verification/step-08.md`](plans/verification/step-08.md).
+**Tests:** `test/work-agents/**/*.test.mjs`, `test/agents/sampler-resolve.test.mts`. Verification: [`documentation/plans/verification/step-08.md`](plans/verification/step-08.md).
 
 ### Workspace folder (AI project root)
 
@@ -566,8 +567,9 @@ Parent tool loop can spawn **isolated sub-agents** (separate messages, model, to
 | Config merge | `src/agents/sub-agent-config.ts`, `src/agents/defaults/sub-agents.json` |
 | Orchestrator | `src/agents/orchestrator.ts` — spawn, cancel, queue, `restartSubAgent`, `cancelAllForParentTurn`, list/status helpers; `deriveSubAgentTerminalReason` + `terminalReason` on `get_sub_agent_status` / aggregate JSON |
 | Events | `src/agents/sub-agent-events.ts` |
-| Runner | `src/agents/sub-agent-runner.ts` — headless tool loop; per-type `maxToolTurns`; context budget enforcement; structured JSON final turn; accumulates `usage` / `stats` on `SubAgentRun` for Orchestrate metrics rollup (MIN-36) |
+| Runner | `src/agents/sub-agent-runner.ts` — headless tool loop; per-type `maxToolTurns`; context budget enforcement; **`resolveSamplerPreset({ kind: 'sub-agent' })`** (not parent drawer temperature; default `max_tokens` 2048); structured JSON final turn; accumulates `usage` / `stats` on `SubAgentRun` for Orchestrate metrics rollup (MIN-36) |
 | Structured outcome | `src/agents/sub-agent-structured-outcome.ts`, `src/agents/sub-agent-summary-schemas.ts` |
+| Sampler presets | `src/agents/sampler-types.ts`, `resolve-sampler.ts` |
 | Tool subset | `src/agents/sub-agent-tools.ts` |
 | Prompts | `src/agents/shipped-sub-agent-prompts.ts`, `src/agents/prompts/sub-agents/*.md` |
 | Parent tools | `spawn_sub_agent`, `cancel_sub_agent`, `list_sub_agents`, `get_sub_agent_status` in `src/tools/definitions.ts` |
@@ -578,7 +580,7 @@ Parent tool loop can spawn **isolated sub-agents** (separate messages, model, to
 
 **Built-in types:** `generalPurpose`, `explore`, `shell`, `explorer` (Step 19 self-heal stub, `maxConcurrent: 1`).
 
-**Config (`sub-agents.json`):** root `enabled`, `globalMaxConcurrent`, `defaultTimeoutMs`, `defaultMaxToolTurns`, optional `defaultMaxInputTokens`, `defaultContextEnforcementPolicy`, `defaultSummarySchema`; per-type `providerId`, `modelId`, `maxConcurrent`, `timeoutMs`, `maxToolTurns`, `maxInputTokens`, `contextEnforcementPolicy`, `summarySchema` (Settings → Sub-agents per-type editor), `allowedTools` (whitelist or null), `deniedTools`, optional `workAgentId`. Hitting the tool-turn cap sets run status **`failed`** with `terminalReason: max_tool_turns`; context budget exhaustion uses **`context_budget`**. `get_sub_agent_status` exposes **`success: false`** and **`outcome`** when terminal; linked board tasks **`failed`** — never **`complete`** when the run did not succeed (`src/agents/sub-agent-outcome.ts`, `syncBoardTaskOnSettle`, `board_update_task` guard) (MIN-15 / MIN-10). Orchestrate supervisor R2 empty-summary detection prefers `structuredOutcome.summary` (`src/agents/supervisor/detector.ts`).
+**Config (`sub-agents.json`):** root `enabled`, `globalMaxConcurrent`, `defaultTimeoutMs`, `defaultMaxToolTurns`, optional `defaultMaxInputTokens`, `defaultContextEnforcementPolicy`, `defaultSummarySchema`; per-type `providerId`, `modelId`, `maxConcurrent`, `timeoutMs`, `maxToolTurns`, `maxInputTokens`, `contextEnforcementPolicy`, `summarySchema`, optional **`sampler`** (`temperature`, `topP`, `topK`, `minP`, `repetitionPenalty`) (Settings → Sub-agents per-type editor), `allowedTools` (whitelist or null), `deniedTools`, optional `workAgentId`. Hitting the tool-turn cap sets run status **`failed`** with `terminalReason: max_tool_turns`; context budget exhaustion uses **`context_budget`**. `get_sub_agent_status` exposes **`success: false`** and **`outcome`** when terminal; linked board tasks **`failed`** — never **`complete`** when the run did not succeed (`src/agents/sub-agent-outcome.ts`, `syncBoardTaskOnSettle`, `board_update_task` guard) (MIN-15 / MIN-10). Orchestrate supervisor R2 empty-summary detection prefers `structuredOutcome.summary` (`src/agents/supervisor/detector.ts`).
 
 **Concurrency:** Over-cap spawns stay **`queued`** until a slot frees (FIFO global queue). Slots are tracked with `holdsConcurrencySlot` so cancelled queued runs do not corrupt the cap; `executeRun` wraps prompt setup + runner in one `try/catch` so a failed start always releases the slot and calls `drainQueue()`. Empty per-type `modelId` falls back to the parent chat's `modelId` before `POST /api/generations`.
 
@@ -586,7 +588,7 @@ Parent tool loop can spawn **isolated sub-agents** (separate messages, model, to
 
 **Persistence:** `GET/PUT /api/config/sub-agents` when `npm start`; client mirror `minnow.subAgents` in `localStorage` when Vite-only. Settled sub-agent transcripts also persist on **`chat.subAgentRuns`** in `sessions/state.json` (capped message list).
 
-**Tests:** `test/sub-agents/**/*.test.mts`. Verification: [`documentation/plans/verification/step-09.md`](plans/verification/step-09.md).
+**Tests:** `test/sub-agents/**/*.test.mts`, `test/agents/sampler-resolve.test.mts`, `test/agents/sampler-server.test.mjs`. Verification: [`documentation/plans/verification/step-09.md`](plans/verification/step-09.md).
 
 | Method | Path | Purpose |
 |--------|------|---------|

--- a/server/agents/sampler.js
+++ b/server/agents/sampler.js
@@ -1,0 +1,91 @@
+/**
+ * Shared sampler preset normalization for work-agents and sub-agents APIs.
+ */
+
+const TEMP_MIN = 0;
+const TEMP_MAX = 2;
+const TOP_P_MIN = 0;
+const TOP_P_MAX = 1;
+const MIN_P_MIN = 0;
+const MIN_P_MAX = 1;
+const REP_MIN = 1;
+const REP_MAX = 2;
+const TOP_K_MIN = 1;
+const TOP_K_MAX = 200;
+const MAX_TOKENS_MIN = 1;
+const MAX_TOKENS_MAX = 131072;
+
+function clampTemperature(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(TEMP_MAX, Math.max(TEMP_MIN, n));
+}
+
+function clampTopP(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(TOP_P_MAX, Math.max(TOP_P_MIN, n));
+}
+
+function clampTopK(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n < TOP_K_MIN) return undefined;
+  return Math.min(TOP_K_MAX, Math.floor(n));
+}
+
+function clampMinP(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.min(MIN_P_MAX, Math.max(MIN_P_MIN, n));
+}
+
+function clampRepetitionPenalty(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n < REP_MIN) return undefined;
+  return Math.min(REP_MAX, n);
+}
+
+function clampMaxTokens(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n < MAX_TOKENS_MIN) return undefined;
+  return Math.min(MAX_TOKENS_MAX, Math.floor(n));
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {Record<string, number>|null}
+ */
+export function normalizeSamplerPreset(raw) {
+  if (raw === null) return null;
+  if (!raw || typeof raw !== 'object') return null;
+
+  const src = /** @type {Record<string, unknown>} */ (raw);
+  const out = {};
+
+  if ('temperature' in src) {
+    const v = clampTemperature(src.temperature);
+    if (v !== undefined) out.temperature = v;
+  }
+  if ('topP' in src) {
+    const v = clampTopP(src.topP);
+    if (v !== undefined) out.topP = v;
+  }
+  if ('topK' in src) {
+    const v = clampTopK(src.topK);
+    if (v !== undefined) out.topK = v;
+  }
+  if ('minP' in src) {
+    const v = clampMinP(src.minP);
+    if (v !== undefined) out.minP = v;
+  }
+  if ('repetitionPenalty' in src) {
+    const v = clampRepetitionPenalty(src.repetitionPenalty);
+    if (v !== undefined) out.repetitionPenalty = v;
+  }
+  if ('maxTokens' in src) {
+    const v = clampMaxTokens(src.maxTokens);
+    if (v !== undefined) out.maxTokens = v;
+  }
+
+  return Object.keys(out).length > 0 ? out : {};
+}

--- a/server/config/validators.js
+++ b/server/config/validators.js
@@ -4,6 +4,7 @@
 
 import { ALL_TOOL_IDS } from './tool-ids.js';
 import { normalizeOrchestratePlanPath } from './orchestrate-plan-path.js';
+import { normalizeSamplerPreset } from '../agents/sampler.js';
 
 const PLACEHOLDER_CHAT_NAME = 'New chat';
 const MAX_CHATS = 50;
@@ -1101,6 +1102,17 @@ export function normalizeSubAgentsConfig(body) {
         delete row.summarySchema;
       } else {
         row.summarySchema = schema.slice(0, 64);
+      }
+    }
+
+    if (row.sampler !== undefined) {
+      const normalized = normalizeSamplerPreset(row.sampler);
+      if (normalized === null) {
+        delete row.sampler;
+      } else if (Object.keys(normalized).length === 0) {
+        delete row.sampler;
+      } else {
+        row.sampler = normalized;
       }
     }
   }

--- a/server/work-agents/routes.js
+++ b/server/work-agents/routes.js
@@ -15,6 +15,7 @@ import {
   readWorkAgentPrompt,
   writeWorkAgentPromptOverride,
 } from './registry.js';
+import { normalizeSamplerPreset } from '../agents/sampler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, '../..');
@@ -102,6 +103,12 @@ export async function handleWorkAgentsRequest(req, res, pathname, search) {
       if ('minRecentTurns' in body) patch.minRecentTurns = body.minRecentTurns;
       if ('summaryReserveTokens' in body) {
         patch.summaryReserveTokens = body.summaryReserveTokens;
+      }
+      if ('sampler' in body) {
+        patch.sampler =
+          body.sampler === null
+            ? null
+            : normalizeSamplerPreset(body.sampler);
       }
       await patchWorkAgentOverride(agentId, patch);
       const agent = await getWorkAgentById(PROJECT_ROOT, agentId);

--- a/src/agents/defaults/sub-agents.json
+++ b/src/agents/defaults/sub-agents.json
@@ -25,7 +25,13 @@
       "systemPromptPath": null,
       "maxInputTokens": null,
       "contextEnforcementPolicy": "slide",
-      "summarySchema": "minnow.sub-agent.v1"
+      "summarySchema": "minnow.sub-agent.v1",
+      "sampler": {
+        "temperature": 0.4,
+        "topP": 0.9,
+        "topK": 40,
+        "repetitionPenalty": 1.05
+      }
     },
     "explore": {
       "label": "Explore",
@@ -58,7 +64,13 @@
       "systemPromptPath": null,
       "maxInputTokens": 16000,
       "contextEnforcementPolicy": "slide",
-      "summarySchema": "minnow.sub-agent.explore"
+      "summarySchema": "minnow.sub-agent.explore",
+      "sampler": {
+        "temperature": 0.45,
+        "topP": 0.92,
+        "topK": 40,
+        "repetitionPenalty": 1
+      }
     },
     "researcher": {
       "label": "Research worker",
@@ -98,7 +110,13 @@
         "git_add",
         "git_push"
       ],
-      "systemPromptPath": null
+      "systemPromptPath": null,
+      "sampler": {
+        "temperature": 0.5,
+        "topP": 0.92,
+        "topK": 50,
+        "repetitionPenalty": 1
+      }
     },
     "shell": {
       "label": "Shell",
@@ -122,7 +140,13 @@
       "systemPromptPath": null,
       "maxInputTokens": 8000,
       "contextEnforcementPolicy": "truncate",
-      "summarySchema": "minnow.sub-agent.v1"
+      "summarySchema": "minnow.sub-agent.v1",
+      "sampler": {
+        "temperature": 0.15,
+        "topP": 0.85,
+        "topK": 20,
+        "repetitionPenalty": 1.1
+      }
     },
     "explorer": {
       "label": "Explorer (self-heal)",
@@ -139,7 +163,13 @@
         "cancel_sub_agent"
       ],
       "systemPromptPath": null,
-      "summarySchema": "minnow.sub-agent.v1"
+      "summarySchema": "minnow.sub-agent.v1",
+      "sampler": {
+        "temperature": 0.35,
+        "topP": 0.9,
+        "topK": 35,
+        "repetitionPenalty": 1
+      }
     },
     "debugger": {
       "label": "Debugger",
@@ -178,7 +208,13 @@
         "git_push"
       ],
       "systemPromptPath": null,
-      "summarySchema": "minnow.sub-agent.v1"
+      "summarySchema": "minnow.sub-agent.v1",
+      "sampler": {
+        "temperature": 0.25,
+        "topP": 0.88,
+        "topK": 30,
+        "repetitionPenalty": 1.05
+      }
     },
     "bug-planner": {
       "label": "Bug planner",
@@ -195,7 +231,13 @@
         "cancel_sub_agent"
       ],
       "systemPromptPath": null,
-      "summarySchema": "minnow.sub-agent.v1"
+      "summarySchema": "minnow.sub-agent.v1",
+      "sampler": {
+        "temperature": 0.55,
+        "topP": 0.92,
+        "topK": 50,
+        "repetitionPenalty": 1
+      }
     },
     "reef-widget": {
       "label": "Reef widget",
@@ -233,7 +275,13 @@
         "git_push"
       ],
       "systemPromptPath": null,
-      "summarySchema": "minnow.sub-agent.lite"
+      "summarySchema": "minnow.sub-agent.lite",
+      "sampler": {
+        "temperature": 0.35,
+        "topP": 0.9,
+        "topK": 35,
+        "repetitionPenalty": 1
+      }
     }
   }
 }

--- a/src/agents/defaults/work-agent-samplers.json
+++ b/src/agents/defaults/work-agent-samplers.json
@@ -1,0 +1,34 @@
+{
+  "builder": {
+    "temperature": 0.25,
+    "topP": 0.95,
+    "topK": 40,
+    "repetitionPenalty": 1.05
+  },
+  "planner": {
+    "temperature": 0.55,
+    "topP": 0.92,
+    "topK": 50,
+    "minP": 0.05,
+    "repetitionPenalty": 1
+  },
+  "reviewer": {
+    "temperature": 0.2,
+    "topP": 0.9,
+    "topK": 30,
+    "repetitionPenalty": 1.08
+  },
+  "researcher": {
+    "temperature": 0.65,
+    "topP": 0.95,
+    "topK": 60,
+    "minP": 0.03,
+    "repetitionPenalty": 1
+  },
+  "ui-designer": {
+    "temperature": 0.4,
+    "topP": 0.9,
+    "topK": 40,
+    "repetitionPenalty": 1.02
+  }
+}

--- a/src/agents/resolve-sampler.ts
+++ b/src/agents/resolve-sampler.ts
@@ -1,0 +1,95 @@
+/**
+ * Resolve merged sampler presets for work agents and sub-agent types at send time.
+ */
+
+import WORK_AGENT_SAMPLER_DEFAULTS from './defaults/work-agent-samplers.json';
+import SUB_AGENT_DEFAULTS from './defaults/sub-agents.json';
+import { isPassthroughWorkAgentId } from './resolve-work-agent';
+import { getUserWorkAgentOverride } from './work-agent-registry';
+import {
+  clampSamplerPreset,
+  mergeSamplerLayers,
+  type SamplerPreset,
+} from './sampler-types';
+import type { SubAgentTypeConfig } from './types';
+
+export type SamplerResolveKind = 'work-agent' | 'sub-agent';
+
+export interface ResolveSamplerInput {
+  /** Work agent id or sub-agent type id; null for passthrough main chat. */
+  agentKey: string | null;
+  kind: SamplerResolveKind;
+  global: { temperature: number; maxTokens: number };
+  /** Sub-agent merged type row (includes shipped + user sampler). */
+  subAgentType?: SubAgentTypeConfig | null;
+}
+
+export interface ResolvedSampler {
+  preset: SamplerPreset;
+  maxTokens: number;
+}
+
+const DEFAULT_SUB_AGENT_MAX_TOKENS = 2048;
+
+function builtinWorkAgentSampler(agentId: string): SamplerPreset {
+  const map = WORK_AGENT_SAMPLER_DEFAULTS as Record<string, SamplerPreset>;
+  return map[agentId] ? { ...map[agentId] } : {};
+}
+
+function builtinSubAgentSampler(typeId: string): SamplerPreset {
+  const types = SUB_AGENT_DEFAULTS.types as Record<string, SubAgentTypeConfig>;
+  const row = types[typeId];
+  return row?.sampler ? { ...row.sampler } : {};
+}
+
+function globalLayer(input: ResolveSamplerInput): SamplerPreset {
+  const temp = Number(input.global.temperature);
+  const layer: SamplerPreset = {};
+  if (Number.isFinite(temp)) layer.temperature = temp;
+  return layer;
+}
+
+function userWorkAgentSampler(agentId: string | null): SamplerPreset {
+  if (!agentId) return {};
+  const override = getUserWorkAgentOverride(agentId)?.sampler;
+  return override ? { ...override } : {};
+}
+
+/**
+ * Merge global drawer → role defaults → user overrides (main chat);
+ * sub-agents use shipped + merged type config only (no drawer temperature).
+ */
+export function resolveSamplerPreset(input: ResolveSamplerInput): ResolvedSampler {
+  let merged: SamplerPreset;
+
+  if (input.kind === 'sub-agent') {
+    const key = input.agentKey;
+    const typeSampler =
+      input.subAgentType?.sampler ??
+      (key ? builtinSubAgentSampler(key) : {});
+    merged = clampSamplerPreset(typeSampler);
+  } else {
+    const key = input.agentKey;
+    const global = globalLayer(input);
+    let roleDefault: SamplerPreset = {};
+    if (key && !isPassthroughWorkAgentId(key)) {
+      roleDefault = builtinWorkAgentSampler(key);
+    }
+    const userOverride = userWorkAgentSampler(key ?? 'default');
+    merged = clampSamplerPreset(
+      mergeSamplerLayers(global, roleDefault, userOverride),
+    );
+  }
+
+  let maxTokens = input.global.maxTokens;
+  if (input.kind === 'sub-agent') {
+    maxTokens = merged.maxTokens ?? DEFAULT_SUB_AGENT_MAX_TOKENS;
+  }
+  if (!Number.isFinite(maxTokens) || maxTokens < 1) {
+    maxTokens =
+      input.kind === 'sub-agent' ? DEFAULT_SUB_AGENT_MAX_TOKENS : 32768;
+  }
+
+  const { maxTokens: _drop, ...preset } = merged;
+  return { preset, maxTokens: Math.floor(maxTokens) };
+}

--- a/src/agents/sampler-types.ts
+++ b/src/agents/sampler-types.ts
@@ -1,0 +1,147 @@
+/**
+ * Per-agent sampler presets (temperature, nucleus, penalties) for completion bodies.
+ */
+
+/** Partial preset; omitted keys inherit from lower merge layers. */
+export interface SamplerPreset {
+  temperature?: number;
+  /** Nucleus sampling; 1 = effectively off. */
+  topP?: number;
+  /** Top-k cap; omitted when unset (not sent upstream). */
+  topK?: number;
+  /** Min-p threshold; omitted when unset. */
+  minP?: number;
+  /** Repeat penalty; 1 = no penalty. */
+  repetitionPenalty?: number;
+  /** Sub-agent output cap when set on type defaults or user override. */
+  maxTokens?: number;
+}
+
+/** OpenAI-compatible sampler fields merged into a completion body. */
+export interface SamplerCompletionFields {
+  temperature: number;
+  max_tokens: number;
+  top_p?: number;
+  top_k?: number;
+  min_p?: number;
+  repetition_penalty?: number;
+}
+
+const TEMP_MIN = 0;
+const TEMP_MAX = 2;
+const TOP_P_MIN = 0;
+const TOP_P_MAX = 1;
+const MIN_P_MIN = 0;
+const MIN_P_MAX = 1;
+const REP_MIN = 1;
+const REP_MAX = 2;
+const TOP_K_MIN = 1;
+const TOP_K_MAX = 200;
+const MAX_TOKENS_MIN = 1;
+const MAX_TOKENS_MAX = 131072;
+
+/** Field-level merge: later layers override earlier keys when defined. */
+export function mergeSamplerLayers(
+  ...layers: Array<SamplerPreset | null | undefined>
+): SamplerPreset {
+  const out: SamplerPreset = {};
+  for (const layer of layers) {
+    if (!layer) continue;
+    if (layer.temperature !== undefined) out.temperature = layer.temperature;
+    if (layer.topP !== undefined) out.topP = layer.topP;
+    if (layer.topK !== undefined) out.topK = layer.topK;
+    if (layer.minP !== undefined) out.minP = layer.minP;
+    if (layer.repetitionPenalty !== undefined) {
+      out.repetitionPenalty = layer.repetitionPenalty;
+    }
+    if (layer.maxTokens !== undefined) out.maxTokens = layer.maxTokens;
+  }
+  return out;
+}
+
+function clampTemperature(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(TEMP_MAX, Math.max(TEMP_MIN, n));
+}
+
+function clampTopP(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(TOP_P_MAX, Math.max(TOP_P_MIN, n));
+}
+
+function clampTopK(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n < TOP_K_MIN) return undefined;
+  return Math.min(TOP_K_MAX, Math.floor(n));
+}
+
+function clampMinP(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.min(MIN_P_MAX, Math.max(MIN_P_MIN, n));
+}
+
+function clampRepetitionPenalty(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n < REP_MIN) return undefined;
+  return Math.min(REP_MAX, n);
+}
+
+function clampMaxTokens(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n < MAX_TOKENS_MIN) return undefined;
+  return Math.min(MAX_TOKENS_MAX, Math.floor(n));
+}
+
+/** Normalize and clamp a partial preset (strips invalid fields). */
+export function clampSamplerPreset(raw: SamplerPreset | null | undefined): SamplerPreset {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: SamplerPreset = {};
+  const temperature = clampTemperature(raw.temperature);
+  if (temperature !== undefined) out.temperature = temperature;
+  const topP = clampTopP(raw.topP);
+  if (topP !== undefined) out.topP = topP;
+  const topK = clampTopK(raw.topK);
+  if (topK !== undefined) out.topK = topK;
+  const minP = clampMinP(raw.minP);
+  if (minP !== undefined) out.minP = minP;
+  const repetitionPenalty = clampRepetitionPenalty(raw.repetitionPenalty);
+  if (repetitionPenalty !== undefined) out.repetitionPenalty = repetitionPenalty;
+  const maxTokens = clampMaxTokens(raw.maxTokens);
+  if (maxTokens !== undefined) out.maxTokens = maxTokens;
+  return out;
+}
+
+/** Map internal preset to outbound completion JSON keys (omit unset fields). */
+export function samplerToCompletionFields(
+  preset: SamplerPreset,
+  maxTokens: number,
+): SamplerCompletionFields {
+  const temperature =
+    preset.temperature !== undefined && Number.isFinite(preset.temperature)
+      ? preset.temperature
+      : 0.7;
+  const fields: SamplerCompletionFields = {
+    temperature,
+    max_tokens: maxTokens,
+  };
+  if (preset.topP !== undefined) fields.top_p = preset.topP;
+  if (preset.topK !== undefined) fields.top_k = preset.topK;
+  if (preset.minP !== undefined) fields.min_p = preset.minP;
+  if (preset.repetitionPenalty !== undefined) {
+    fields.repetition_penalty = preset.repetitionPenalty;
+  }
+  return fields;
+}
+
+/** Apply sampler fields onto an existing completion body object. */
+export function applySamplerToBody<T extends Record<string, unknown>>(
+  body: T,
+  preset: SamplerPreset,
+  maxTokens: number,
+): T & SamplerCompletionFields {
+  const mapped = samplerToCompletionFields(preset, maxTokens);
+  return { ...body, ...mapped };
+}

--- a/src/agents/sub-agent-config.ts
+++ b/src/agents/sub-agent-config.ts
@@ -6,6 +6,7 @@ import { detectConfigServer, isServerStorageMode } from '../config/storage-mode'
 import { DEFAULT_CONTEXT_ENFORCEMENT_POLICY } from '../chat/context-budget';
 import { DEFAULT_SUB_AGENT_SUMMARY_SCHEMA } from './sub-agent-structured-outcome';
 import DEFAULTS from './defaults/sub-agents.json';
+import { clampSamplerPreset, mergeSamplerLayers } from './sampler-types';
 import type { SubAgentTypeConfig, SubAgentsFile } from './types';
 
 const SUB_AGENTS_STORAGE_KEY = 'minnow.subAgents';
@@ -21,6 +22,7 @@ function cloneTypeConfig(raw: SubAgentTypeConfig): SubAgentTypeConfig {
     ...raw,
     allowedTools: raw.allowedTools ? [...raw.allowedTools] : null,
     deniedTools: [...raw.deniedTools],
+    sampler: raw.sampler ? { ...raw.sampler } : undefined,
   };
 }
 
@@ -69,6 +71,12 @@ export function mergeSubAgentConfig(
         deniedTools: ['spawn_sub_agent', 'cancel_sub_agent'],
         systemPromptPath: null,
       };
+      const mergedSampler =
+        patch.sampler !== undefined
+          ? clampSamplerPreset(
+              mergeSamplerLayers(existing.sampler, patch.sampler),
+            )
+          : existing.sampler;
       merged.types[id] = {
         ...existing,
         ...patch,
@@ -87,6 +95,7 @@ export function mergeSubAgentConfig(
         deniedTools: patch.deniedTools
           ? [...patch.deniedTools]
           : [...existing.deniedTools],
+        sampler: mergedSampler,
       };
     }
   }

--- a/src/agents/sub-agent-runner.ts
+++ b/src/agents/sub-agent-runner.ts
@@ -37,6 +37,9 @@ import {
   MAX_PROSE_QUESTION_RETRIES,
   PROSE_QUESTION_RETRY_INSTRUCTION,
 } from '../tools/turn-continuation';
+import { getSubAgentTypeConfig } from './sub-agent-config';
+import { resolveSamplerPreset } from './resolve-sampler';
+import { applySamplerToBody } from './sampler-types';
 import type { SubAgentRunner, SubAgentRunnerOutput } from './types';
 
 /** Legacy export: prefer per-type `maxToolTurns` from sub-agents config. */
@@ -63,6 +66,10 @@ interface SubAgentCompletionBody {
   messages: ApiMessage[];
   temperature: number;
   max_tokens: number;
+  top_p?: number;
+  top_k?: number;
+  min_p?: number;
+  repetition_penalty?: number;
   stream?: boolean;
   tools?: OpenAIFunctionDefinition[];
   tool_choice?: 'auto';
@@ -154,8 +161,13 @@ export const defaultSubAgentRunner: SubAgentRunner = {
     let toolTurns = 0;
     let proseQuestionRetries = 0;
     const hasAskQuestionTool = input.tools.some((t) => t.function.name === 'ask_question');
-    const temperature = 0.4;
-    const maxTokens = 2048;
+    const typeConfig = await getSubAgentTypeConfig(input.type);
+    const resolvedSampler = resolveSamplerPreset({
+      kind: 'sub-agent',
+      agentKey: input.type,
+      global: { temperature: 0.4, maxTokens: 2048 },
+      subAgentType: typeConfig,
+    });
     const maxToolTurns = Math.max(1, Math.floor(input.maxToolTurns) || MAX_SUB_AGENT_TOOL_TURNS);
     const contextBudget = input.contextBudget ?? {
       maxInputTokens: null,
@@ -228,13 +240,15 @@ export const defaultSubAgentRunner: SubAgentRunner = {
         });
       }
 
-      const body: SubAgentCompletionBody = {
-        model: input.modelId || undefined,
-        messages: finalMessages,
-        temperature,
-        max_tokens: maxTokens,
-        stream: true,
-      };
+      const body = applySamplerToBody(
+        {
+          model: input.modelId || undefined,
+          messages: finalMessages,
+          stream: true,
+        },
+        resolvedSampler.preset,
+        resolvedSampler.maxTokens,
+      ) as SubAgentCompletionBody;
 
       const turnResult = await streamSubAgentTurn(
         input.providerId,
@@ -283,13 +297,15 @@ export const defaultSubAgentRunner: SubAgentRunner = {
         };
       }
 
-      const body: SubAgentCompletionBody = {
-        model: input.modelId || undefined,
-        messages,
-        temperature,
-        max_tokens: maxTokens,
-        stream: true,
-      };
+      const body = applySamplerToBody(
+        {
+          model: input.modelId || undefined,
+          messages,
+          stream: true,
+        },
+        resolvedSampler.preset,
+        resolvedSampler.maxTokens,
+      ) as SubAgentCompletionBody;
 
       if (input.tools.length > 0) {
         body.tools = input.tools;

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -9,6 +9,7 @@ import type {
   SubAgentBudgetEvent,
   SubAgentStructuredOutcome,
 } from './sub-agent-structured-outcome';
+import type { SamplerPreset } from './sampler-types';
 
 /** Lifecycle status for a sub-agent run. */
 export type SubAgentStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
@@ -41,6 +42,8 @@ export interface SubAgentTypeConfig {
   summaryReserveTokens?: number;
   /** Preset id for structured final outcome validation (e.g. minnow.sub-agent.v1). */
   summarySchema?: string;
+  /** Per-type sampler preset (shipped default + user partial override). */
+  sampler?: SamplerPreset;
 }
 
 /** Root sub-agents.json shape (user + merged). */

--- a/src/agents/work-agent-prompt-api.ts
+++ b/src/agents/work-agent-prompt-api.ts
@@ -2,6 +2,8 @@
  * Client helpers for Work Agent prompt editor API.
  */
 
+import { mergeUserWorkAgentOverride } from './work-agent-registry';
+
 export type WorkAgentPromptProfile = 'full' | 'lite';
 
 export interface WorkAgentPromptResponse {
@@ -72,6 +74,7 @@ export async function patchWorkAgentOverride(
     contextEnforcementPolicy?: import('../chat/context-budget').ContextEnforcementPolicy;
     minRecentTurns?: number;
     summaryReserveTokens?: number;
+    sampler?: import('./sampler-types').SamplerPreset | null;
   },
 ): Promise<import('./work-agent-types').WorkAgentDefinition | null> {
   try {
@@ -82,6 +85,7 @@ export async function patchWorkAgentOverride(
     });
     if (!res.ok) return null;
     const data = (await res.json()) as { agent: import('./work-agent-types').WorkAgentDefinition };
+    mergeUserWorkAgentOverride(agentId, patch);
     return data.agent ?? null;
   } catch {
     return null;

--- a/src/agents/work-agent-registry.ts
+++ b/src/agents/work-agent-registry.ts
@@ -169,6 +169,14 @@ export function setUserWorkAgentOverrides(
   userOverrides = { ...overrides };
 }
 
+/** Merge one agent override row (after Settings save). */
+export function mergeUserWorkAgentOverride(
+  agentId: string,
+  patch: WorkAgentUserOverride,
+): void {
+  userOverrides[agentId] = { ...(userOverrides[agentId] ?? {}), ...patch };
+}
+
 /** Load built-in agents from Vite glob or test fixture map. */
 export function initBuiltinWorkAgentRegistry(raw: Record<string, string> = {}): void {
   builtinAgents = buildAgentsFromRaw(raw);

--- a/src/agents/work-agent-types.ts
+++ b/src/agents/work-agent-types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ContextEnforcementPolicy } from '../chat/context-budget';
+import type { SamplerPreset } from './sampler-types';
 
 /** Shipped or user-defined Work Agent definition. */
 export interface WorkAgentDefinition {
@@ -30,6 +31,8 @@ export interface WorkAgentDefinition {
   minRecentTurns?: number;
   /** summarize: token budget for injected summary block (default 512). */
   summaryReserveTokens?: number;
+  /** Shipped role sampler defaults (from work-agent-samplers.json). */
+  sampler?: SamplerPreset;
 }
 
 /** User overrides stored under ~/.minnow/work-agents.json */
@@ -43,6 +46,8 @@ export interface WorkAgentUserOverride {
   contextEnforcementPolicy?: ContextEnforcementPolicy;
   minRecentTurns?: number;
   summaryReserveTokens?: number;
+  /** Partial sampler override (field-level merge at send time). */
+  sampler?: SamplerPreset | null;
 }
 
 export interface WorkAgentRegistrySnapshot {

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -80,6 +80,10 @@ export interface ChatCompletionBody {
   messages: ApiMessage[];
   temperature: number;
   max_tokens: number;
+  top_p?: number;
+  top_k?: number;
+  min_p?: number;
+  repetition_penalty?: number;
   tools?: OpenAIFunctionDefinition[];
   tool_choice?: 'auto';
 }

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -169,6 +169,8 @@ import {
 import { assertUiDesignerToolAllowed } from '../agents/ui-designer/tools';
 import { WorkAgentConfigError } from '../agents/work-agent-types';
 import { getUserWorkAgentOverride } from '../agents/work-agent-registry';
+import { resolveSamplerPreset } from '../agents/resolve-sampler';
+import { applySamplerToBody } from '../agents/sampler-types';
 import {
   cancelAllForParentTurn,
 } from '../agents/orchestrator';
@@ -226,6 +228,10 @@ interface ChatCompletionBody {
   messages: ApiMessage[];
   temperature: number;
   max_tokens: number;
+  top_p?: number;
+  top_k?: number;
+  min_p?: number;
+  repetition_penalty?: number;
   stream?: boolean;
   stream_options?: { include_usage: boolean };
   tools?: ReturnType<typeof getEnabledToolDefinitionsForMode>;
@@ -660,6 +666,11 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
   }
 
   const activeWorkAgent = resolveActiveWorkAgent(chat);
+  const resolvedSampler = resolveSamplerPreset({
+    kind: 'work-agent',
+    agentKey: activeWorkAgent?.id ?? null,
+    global: { temperature: temp, maxTokens: maxTok },
+  });
   let sendModelId = modelId || chat.modelId;
   let sendProviderId = chat.providerId;
 
@@ -872,8 +883,8 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
         maxToolTurns: maxToolTurnsCap,
         providerId: sendProviderId,
         modelId: sendModelId,
-        temperature: temp,
-        maxTokens: maxTok,
+        temperature: resolvedSampler.preset.temperature ?? temp,
+        maxTokens: resolvedSampler.maxTokens,
         skillId,
         userContent,
       });
@@ -940,14 +951,16 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
       ) {
         setStatus('ok', budgetApplied.statusMessage);
       }
-      const body: ChatCompletionBody = {
-        model: sendModelId || undefined,
-        messages,
-        temperature: temp,
-        max_tokens: maxTok,
-        stream: true,
-        stream_options: { include_usage: true },
-      };
+      const body = applySamplerToBody(
+        {
+          model: sendModelId || undefined,
+          messages,
+          stream: true,
+          stream_options: { include_usage: true },
+        },
+        resolvedSampler.preset,
+        resolvedSampler.maxTokens,
+      ) as ChatCompletionBody;
       if (enabledTools.length > 0) {
         body.tools = enabledTools;
         body.tool_choice = 'auto';
@@ -1150,12 +1163,14 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
       let streamMeta = turnResult.streamMeta;
 
       if (!fullText.trim()) {
-        const fallbackBody: ChatCompletionBody = {
-          model: sendModelId || undefined,
-          messages,
-          temperature: temp,
-          max_tokens: maxTok,
-        };
+        const fallbackBody = applySamplerToBody(
+          {
+            model: sendModelId || undefined,
+            messages,
+          },
+          resolvedSampler.preset,
+          resolvedSampler.maxTokens,
+        ) as ChatCompletionBody;
         if (enabledTools.length > 0) {
           fallbackBody.tools = enabledTools;
           fallbackBody.tool_choice = 'auto';

--- a/src/ui/settings-entity-editor.ts
+++ b/src/ui/settings-entity-editor.ts
@@ -18,6 +18,8 @@ import {
 } from '../chat/prompts/prompt-file-api';
 import type { ContextEnforcementPolicy } from '../chat/context-budget';
 import { listSummarySchemaPresetIds } from '../agents/sub-agent-summary-schemas';
+import type { SamplerPreset } from '../agents/sampler-types';
+import { getUserWorkAgentOverride } from '../agents/work-agent-registry';
 import { isProvidersApiAvailable, listProviders } from '../providers/store';
 import { fillModelSelect } from './settings-model-binding';
 import { setStatus } from './status';
@@ -39,6 +41,72 @@ function buildSummarySchemaSelect(initial: string): HTMLSelectElement {
   }
   sel.value = initial;
   return sel;
+}
+
+interface SamplerFieldInputs {
+  root: HTMLElement;
+  readPatch: () => SamplerPreset | null;
+}
+
+/** Numeric inputs for per-agent sampler overrides (empty = inherit role default). */
+function buildSamplerFieldInputs(initial: SamplerPreset | null | undefined): SamplerFieldInputs {
+  const root = el('div', 'settings-model-row settings-sampler-row');
+  const fields: Array<{
+    key: keyof SamplerPreset;
+    label: string;
+    step: string;
+    min: string;
+    max: string;
+  }> = [
+    { key: 'temperature', label: 'Temperature', step: '0.05', min: '0', max: '2' },
+    { key: 'topP', label: 'Top P', step: '0.05', min: '0', max: '1' },
+    { key: 'topK', label: 'Top K', step: '1', min: '1', max: '200' },
+    { key: 'minP', label: 'Min P', step: '0.01', min: '0', max: '1' },
+    {
+      key: 'repetitionPenalty',
+      label: 'Repeat penalty',
+      step: '0.01',
+      min: '1',
+      max: '2',
+    },
+  ];
+
+  const inputs = new Map<keyof SamplerPreset, HTMLInputElement>();
+
+  for (const field of fields) {
+    root.appendChild(el('label', 'settings-field-label', field.label));
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'settings-select settings-kv-input';
+    input.step = field.step;
+    input.min = field.min;
+    input.max = field.max;
+    input.placeholder = 'Inherit';
+    const value = initial?.[field.key];
+    if (value !== undefined && Number.isFinite(value)) {
+      input.value = String(value);
+    }
+    inputs.set(field.key, input);
+    root.appendChild(input);
+  }
+
+  const readPatch = (): SamplerPreset | null => {
+    const patch: SamplerPreset = {};
+    for (const [key, input] of inputs) {
+      const raw = input.value.trim();
+      if (!raw) continue;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) continue;
+      if (key === 'temperature') patch.temperature = n;
+      else if (key === 'topP') patch.topP = n;
+      else if (key === 'topK') patch.topK = n;
+      else if (key === 'minP') patch.minP = n;
+      else if (key === 'repetitionPenalty') patch.repetitionPenalty = n;
+    }
+    return Object.keys(patch).length > 0 ? patch : null;
+  };
+
+  return { root, readPatch };
 }
 
 function buildContextPolicySelect(initial: ContextEnforcementPolicy): HTMLSelectElement {
@@ -209,6 +277,7 @@ interface WorkAgentEditorOptions {
   initialDisabled: boolean;
   initialMaxInputTokens: number | null;
   initialContextPolicy: ContextEnforcementPolicy;
+  initialSampler?: SamplerPreset | null;
   onModelSaved?: () => void;
 }
 
@@ -247,6 +316,9 @@ export function mountWorkAgentEditor(
     options.initialMaxInputTokens != null ? String(options.initialMaxInputTokens) : '';
 
   const contextPolicySel = buildContextPolicySelect(options.initialContextPolicy);
+  const samplerFields = buildSamplerFieldInputs(
+    options.initialSampler ?? getUserWorkAgentOverride(options.agentId)?.sampler,
+  );
 
   const reloadPrompt = async () => {
     const data = await fetchWorkAgentPrompt(options.agentId, currentProfile);
@@ -312,6 +384,13 @@ export function mountWorkAgentEditor(
 
   container.appendChild(modelBlock);
   container.appendChild(budgetBlock);
+  const samplerHint = el(
+    'p',
+    'settings-field-hint',
+    'Sampler: leave fields empty to inherit the role default; global drawer temperature applies when unset.',
+  );
+  container.appendChild(samplerHint);
+  container.appendChild(samplerFields.root);
   container.appendChild(disabledRow);
 
   const meta = el('p', 'settings-field-hint');
@@ -353,6 +432,7 @@ export function mountWorkAgentEditor(
         disabled: !disabledCb.checked,
         maxInputTokens,
         contextEnforcementPolicy: contextPolicySel.value as ContextEnforcementPolicy,
+        sampler: samplerFields.readPatch(),
       });
       if (!agent) {
         setStatus('err', 'Could not save binding');
@@ -402,6 +482,7 @@ export function mountSubAgentTypeEditor(
     maxInputTokens: number | null;
     contextEnforcementPolicy: ContextEnforcementPolicy;
     summarySchema: string;
+    sampler?: SamplerPreset | null;
   },
   onSaveConfig: (
     patch: Partial<{
@@ -413,6 +494,7 @@ export function mountSubAgentTypeEditor(
       maxInputTokens: number | null;
       contextEnforcementPolicy: ContextEnforcementPolicy;
       summarySchema: string;
+      sampler: SamplerPreset | null;
     }>,
   ) => Promise<boolean>,
 ): void {
@@ -452,6 +534,7 @@ export function mountSubAgentTypeEditor(
 
   const contextPolicySel = buildContextPolicySelect(initial.contextEnforcementPolicy);
   const summarySchemaSel = buildSummarySchemaSelect(initial.summarySchema);
+  const samplerFields = buildSamplerFieldInputs(initial.sampler);
 
   const modelBlock = el('div','settings-model-row');
   modelBlock.appendChild(el('label', 'settings-field-label', 'Provider'));
@@ -484,6 +567,14 @@ export function mountSubAgentTypeEditor(
 
   extra.appendChild(toolTurnsRow);
   extra.appendChild(budgetRow);
+  extra.appendChild(
+    el(
+      'p',
+      'settings-field-hint',
+      'Sampler applies to this sub-agent type only (not the main chat drawer).',
+    ),
+  );
+  extra.appendChild(samplerFields.root);
 
   const saveCfgBtn = el('button', 'settings-action-btn', 'Save type settings');
   saveCfgBtn.type = 'button';
@@ -501,6 +592,7 @@ export function mountSubAgentTypeEditor(
             : Math.max(1, Math.floor(Number(maxInputTokensInput.value) || 0)),
         contextEnforcementPolicy: contextPolicySel.value as ContextEnforcementPolicy,
         summarySchema: summarySchemaSel.value,
+        sampler: samplerFields.readPatch(),
       });
       setStatus(ok ? 'ok' : 'err', ok ? `${label} settings saved` : 'Save failed');
     })();

--- a/src/ui/settings-sections.ts
+++ b/src/ui/settings-sections.ts
@@ -3,6 +3,7 @@
  */
 
 import { fetchWorkAgentsList } from '../agents/work-agent-prompt-api';
+import { getUserWorkAgentOverride } from '../agents/work-agent-registry';
 import { loadSubAgentConfig, saveSubAgentConfigToServer } from '../agents/sub-agent-config';
 import type { SubAgentTypeConfig } from '../agents/types';
 import { PART_ORDER } from '../chat/prompts/prompt-composer';
@@ -705,6 +706,7 @@ async function renderWorkAgentsSection(): Promise<void> {
         initialDisabled: agent.disabled === true,
         initialMaxInputTokens: agent.maxInputTokens ?? null,
         initialContextPolicy: agent.contextEnforcementPolicy ?? 'slide',
+        initialSampler: getUserWorkAgentOverride(id)?.sampler ?? null,
         onModelSaved: () => {
           void renderWorkAgentsSection();
         },
@@ -833,6 +835,7 @@ async function renderSubAgentsSection(): Promise<void> {
           maxInputTokens: type.maxInputTokens ?? null,
           contextEnforcementPolicy: type.contextEnforcementPolicy ?? 'slide',
           summarySchema: type.summarySchema ?? 'minnow.sub-agent.v1',
+          sampler: type.sampler ?? null,
         },
         (patch) => saveTypePatch(id, patch),
       );

--- a/test/agents/sampler-resolve.test.mts
+++ b/test/agents/sampler-resolve.test.mts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, test } from 'node:test';
+import { resolveSamplerPreset } from '../../src/agents/resolve-sampler.ts';
+import {
+  mergeUserWorkAgentOverride,
+  resetWorkAgentRegistry,
+  setUserWorkAgentOverrides,
+} from '../../src/agents/work-agent-registry.ts';
+import {
+  mergeSubAgentConfig,
+  resetSubAgentConfigCache,
+} from '../../src/agents/sub-agent-config.ts';
+import {
+  applySamplerToBody,
+  clampSamplerPreset,
+  mergeSamplerLayers,
+  samplerToCompletionFields,
+} from '../../src/agents/sampler-types.ts';
+import DEFAULTS from '../../src/agents/defaults/sub-agents.json';
+
+describe('sampler preset merge', () => {
+  beforeEach(() => {
+    resetWorkAgentRegistry();
+    setUserWorkAgentOverrides({});
+    resetSubAgentConfigCache();
+  });
+
+  test('work agent merges global, role default, and user partial override', () => {
+    mergeUserWorkAgentOverride('builder', { sampler: { temperature: 0.1 } });
+    const resolved = resolveSamplerPreset({
+      kind: 'work-agent',
+      agentKey: 'builder',
+      global: { temperature: 0.7, maxTokens: 8192 },
+    });
+    assert.equal(resolved.preset.temperature, 0.1);
+    assert.equal(resolved.preset.topP, 0.95);
+    assert.equal(resolved.maxTokens, 8192);
+  });
+
+  test('passthrough work agent uses global drawer only', () => {
+    const resolved = resolveSamplerPreset({
+      kind: 'work-agent',
+      agentKey: 'default',
+      global: { temperature: 0.7, maxTokens: 4096 },
+    });
+    assert.equal(resolved.preset.temperature, 0.7);
+    assert.equal(resolved.preset.topP, undefined);
+  });
+
+  test('sub-agent uses type sampler not drawer temperature', () => {
+    const merged = mergeSubAgentConfig(DEFAULTS as never, null);
+    const shell = merged.types.shell;
+    const resolved = resolveSamplerPreset({
+      kind: 'sub-agent',
+      agentKey: 'shell',
+      global: { temperature: 0.99, maxTokens: 9999 },
+      subAgentType: shell,
+    });
+    assert.equal(resolved.preset.temperature, 0.15);
+    assert.equal(resolved.maxTokens, 2048);
+  });
+
+  test('clampSamplerPreset strips invalid values', () => {
+    const clamped = clampSamplerPreset({
+      temperature: 9,
+      topP: -1,
+      topK: 0,
+      minP: 0,
+      repetitionPenalty: 0.5,
+    });
+    assert.equal(clamped.temperature, 2);
+    assert.equal(clamped.topP, 0);
+    assert.equal(clamped.topK, undefined);
+    assert.equal(clamped.repetitionPenalty, undefined);
+  });
+
+  test('samplerToCompletionFields omits unset extended params', () => {
+    const fields = samplerToCompletionFields({ temperature: 0.3 }, 2048);
+    assert.equal(fields.temperature, 0.3);
+    assert.equal(fields.max_tokens, 2048);
+    assert.equal(fields.top_p, undefined);
+  });
+
+  test('applySamplerToBody spreads mapped keys', () => {
+    const body = applySamplerToBody(
+      { model: 'test-model', messages: [] },
+      { temperature: 0.25, topP: 0.9, topK: 40 },
+      1024,
+    );
+    assert.equal(body.temperature, 0.25);
+    assert.equal(body.top_p, 0.9);
+    assert.equal(body.top_k, 40);
+    assert.equal(body.max_tokens, 1024);
+  });
+
+  test('mergeSamplerLayers is field-level', () => {
+    const merged = mergeSamplerLayers(
+      { temperature: 0.5, topP: 0.8 },
+      { temperature: 0.2 },
+    );
+    assert.equal(merged.temperature, 0.2);
+    assert.equal(merged.topP, 0.8);
+  });
+});

--- a/test/agents/sampler-server.test.mjs
+++ b/test/agents/sampler-server.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { normalizeSamplerPreset } from '../../server/agents/sampler.js';
+import { normalizeSubAgentsConfig } from '../../server/config/validators.js';
+
+describe('server sampler normalization', () => {
+  test('normalizeSamplerPreset clamps temperature', () => {
+    const out = normalizeSamplerPreset({ temperature: 5, topP: 0.5 });
+    assert.equal(out.temperature, 2);
+    assert.equal(out.topP, 0.5);
+  });
+
+  test('normalizeSubAgentsConfig clamps types.*.sampler', () => {
+    const { config } = normalizeSubAgentsConfig({
+      types: {
+        explore: {
+          sampler: { temperature: 3, topK: 80 },
+        },
+      },
+    });
+    assert.equal(config.types.explore.sampler.temperature, 2);
+    assert.equal(config.types.explore.sampler.topK, 80);
+  });
+});

--- a/test/sub-agents/sub-agent-config.test.mts
+++ b/test/sub-agents/sub-agent-config.test.mts
@@ -60,6 +60,16 @@ describe('sub-agent config', () => {
     assert.ok(r.deniedTools.includes('spawn_sub_agent'));
   });
 
+  test('user override merges sampler fields on a type', () => {
+    const merged = mergeSubAgentConfig(DEFAULTS as never, {
+      types: {
+        explore: { sampler: { temperature: 0.6 } },
+      },
+    });
+    assert.equal(merged.types.explore.sampler?.temperature, 0.6);
+    assert.equal(merged.types.explore.sampler?.topP, 0.92);
+  });
+
   test('user override can set maxInputTokens and context policy', () => {
     const merged = mergeSubAgentConfig(DEFAULTS as never, {
       types: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Feature #9 — Sampler presets per agent** (Linear MIN-45): per work-agent and sub-agent-type sampling profiles merged into OpenAI-compatible completion bodies at send time.

## Changes

- **`SamplerPreset`** type with clamp/merge helpers and `applySamplerToBody()` mapping to `temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`
- **`resolveSamplerPreset()`** — main chat: drawer → `work-agent-samplers.json` → `~/.minnow/work-agents.json`; sub-agents: shipped `sub-agents.json` defaults + user overrides (no drawer temperature)
- Wired into **`runChatTurn`** / **`sub-agent-runner`**
- Server **`normalizeSamplerPreset`** for `PUT /api/work-agents/:id` and `PUT /api/config/sub-agents`
- Settings → Work agents / Sub-agents: sampler numeric fields (empty = inherit)
- Shipped defaults for builder, planner, reviewer, researcher, ui-designer, and all sub-agent types
- Tests: `test/agents/sampler-resolve.test.mts`, `test/agents/sampler-server.test.mjs`, sub-agent config merge test
- Updated `documentation/context.md`

## Verification

- `npx tsc --noEmit`
- `node --import tsx --test test/agents/sampler-resolve.test.mts test/agents/sampler-server.test.mjs test/sub-agents/sub-agent-config.test.mts`

Closes MIN-45
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-45](https://linear.app/minnowai/issue/MIN-45/sampler-presets-per-agent)

<div><a href="https://cursor.com/agents/bc-be80041d-9558-4bc9-aaa4-9e9d1e0a3d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be80041d-9558-4bc9-aaa4-9e9d1e0a3d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

