### PR TITLE
✨ Native tool plugin API (MIN-53)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -322,9 +322,9 @@ MCP tools are namespaced `mcp__<serverId>__<toolName>` and merged into `getEnabl
 
 **Tests:** `npm run test:mcp` (in-process `fixture` server returns `pong`).
 
-### Native tool plugins (Feature #17 — planned)
+### Native tool plugins (Feature #17 — built)
 
-Drop-in **local** tools without MCP: `~/.minnow/tools/<pluginId>/{tool.json,handler.mjs}`, loaded by `server/tools/loader.js`, exposed as `plugin__<pluginId>__<functionName>` (mirrors skills scan + MCP namespacing). Build plan: [`documentation/plans/Build out/feature-17-tool-plugin.md`](plans/Build%20out/feature-17-tool-plugin.md). Roadmap gap: [`feature-audit-roadmap.md`](plans/feature-audit-roadmap.md) item **#17**.
+Drop-in **local** tools without MCP: `~/.minnow/tools/<pluginId>/{tool.json,handler.mjs}`, scanned by [`server/tools/scan.js`](../server/tools/scan.js), executed via [`server/tools/loader.js`](../server/tools/loader.js), exposed as `plugin__<pluginId>__<functionName>` (hyphens in id → underscores in the namespace segment). APIs: `GET /api/plugins/tools`, `POST /api/plugins/reload`, `POST /api/plugins/scaffold` ([`server/tools/middleware.js`](../server/tools/middleware.js)). Client cache: `refreshPluginToolCache()` in [`src/tools/client.ts`](../src/tools/client.ts); merged into `getEnabledToolDefinitionsForMode()` with MCP tools. Pack enable flags: `tools.json` → `plugins`; permissions use namespaced ids (default `ask`). Settings: **Tools → Plugins** ([`src/ui/settings-plugins.ts`](../src/ui/settings-plugins.ts)). Authoring: [`documentation/plugins/tool-authoring.md`](plugins/tool-authoring.md). Tests: `npm run test:plugins`.
 
 ### Orchestrate supervisor (replaces MIN-9 watchdog + Step 19 self-healing)
 

--- a/documentation/plans/feature-audit-roadmap.md
+++ b/documentation/plans/feature-audit-roadmap.md
@@ -104,10 +104,9 @@ A 22-item product wishlist was reviewed against the current Minnow build. This d
 - **Built (MIN-52):** Drop-in agent packs under `~/.minnow/agent-packs/<name>/` with `manifest.json`; `GET/PATCH /api/agent-packs`; merge into work-agent registry; Settings → Agent packs. Plan: [`documentation/plans/Build out/feature-16-agent-pack-plugin.md`](Build%20out/feature-16-agent-pack-plugin.md).
 - **Scope:** Define `agent-pack.schema.json`; new loader at `src/agents/pack-loader.ts`; share dir convention.
 
-### 17. Plugin API for tools — Partial
-- **Today:** MCP supported (Context7 built-in, custom add) ([server/mcp/](../../server/mcp/)). Native tool catalog is repo-internal ([src/tools/definitions.ts](../../src/tools/definitions.ts)).
-- **Gap:** Native local tool plugin path that doesn't require an MCP server — local JS module under `~/.minnow/tools/<name>/{tool.json,handler.mjs}` loaded by `server/tools/loader.js`.
-- **Scope:** Mirror the skills loader pattern; sandbox via vm if needed.
+### 17. Plugin API for tools — Built
+- **Today:** Drop-in packs at `~/.minnow/tools/<id>/{tool.json,handler.mjs}`; [`server/tools/loader.js`](../../server/tools/loader.js) + `/api/plugins/*`; namespaced as `plugin__<id>__<function>`; client merge in [`src/tools/client.ts`](../../src/tools/client.ts); Settings → Plugins ([`src/ui/settings-plugins.ts`](../../src/ui/settings-plugins.ts)).
+- **Authoring:** [`documentation/plugins/tool-authoring.md`](../plugins/tool-authoring.md). Tests: `npm run test:plugins`.
 - **Build plan:** [`Build out/feature-17-tool-plugin.md`](Build%20out/feature-17-tool-plugin.md)
 
 ### 18. Headless mode — Missing

--- a/documentation/plugins/tool-authoring.md
+++ b/documentation/plugins/tool-authoring.md
@@ -1,0 +1,125 @@
+# Native tool plugin authoring
+
+Minnow can load **local tool plugins** from `~/.minnow/tools/<pluginId>/` without running a separate MCP server. Each pack contains a JSON manifest and a single JavaScript handler executed on the Node tool server (`npm start`).
+
+## Layout
+
+```text
+~/.minnow/tools/<pluginId>/
+  tool.json       # metadata + OpenAI parameters schema
+  handler.mjs     # export default async function handler(args, ctx)
+```
+
+The folder name must match `tool.json` → `id`. Plugin ids use lowercase letters, numbers, and hyphens (`^[a-z0-9][a-z0-9-]*$`).
+
+## Exposed tool name
+
+The model sees:
+
+```text
+plugin__<pluginId>__<functionName>
+```
+
+Hyphens in the plugin id become underscores in the namespace segment only. Example: id `hello-world` + function `greet` → `plugin__hello_world__greet`.
+
+## tool.json
+
+See [`documentation/schemas/tool-plugin.schema.json`](../schemas/tool-plugin.schema.json).
+
+Required fields: `id`, `functionName`, `label`, `description`, `category`, `parameters` (JSON Schema object).
+
+Optional `capabilities` (v1 metadata for future gating):
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `filesystem` | `false` | Declares filesystem access needs |
+| `network` | `false` | Declares network access needs |
+| `nodeBuiltin` | `false` | Reserved for trusted Node builtins |
+
+## handler.mjs
+
+```javascript
+/**
+ * @param {Record<string, unknown>} args — arguments from the model
+ * @param {import('../../server/tools/plugin-context.js').PluginContext} ctx
+ * @returns {Promise<string>} — result text (use "Error: …" for failures)
+ */
+export default async function handler(args, ctx) {
+  return `Hello, ${args.name ?? 'world'}`;
+}
+```
+
+`ctx` provides:
+
+- `workspaceRoot` — active workspace path
+- `minnowHome` — `~/.minnow` (or `MINNOW_HOME`)
+- `log(message)` — server log line
+- `env` — read-only `NODE_ENV`, `MINNOW_HOME`
+
+Return a **string** from the handler. Uncaught errors are converted to `Error: …` strings by the server.
+
+## Enablement and permissions
+
+`~/.minnow/tools.json`:
+
+```json
+{
+  "plugins": {
+    "my-plugin": { "enabled": true }
+  },
+  "permissions": {
+    "default": {
+      "plugin__my_plugin__greet": "ask"
+    }
+  }
+}
+```
+
+- `plugins.<id>.enabled: false` removes the tool from `GET /api/plugins/tools` and from chat tool lists.
+- `permissions.default.<namespacedName>` uses `full`, `ask`, or `off` (default for new plugin tools is `ask`).
+
+Configure in **Settings → Tools → Plugins**, or edit `tools.json` directly.
+
+## APIs
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/plugins/ping` | Health check |
+| GET | `/api/plugins` | List plugin metadata |
+| GET | `/api/plugins/tools` | OpenAI function definitions (enabled packs) |
+| POST | `/api/plugins/reload` | Rescan packs and clear handler cache |
+| POST | `/api/plugins/scaffold` | Copy `_template` to `~/.minnow/tools/<id>/` |
+
+Execution uses the same path as built-in server tools: `POST /api/tools` with `{ "name": "plugin__…", "args": {} }`.
+
+## Scaffold
+
+With `npm start` running:
+
+```bash
+curl -X POST http://localhost:5173/api/plugins/scaffold \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"demo"}'
+```
+
+Or use **Scaffold new plugin…** in Settings → Tools → Plugins.
+
+## Sandbox and trust
+
+By default, handlers run in a **Node `vm` wrapper** with a minimal sandbox (`args`, `ctx`, limited `console.log`). For local development only, set `MINNOW_PLUGIN_UNSAFE=1` to load handlers via full dynamic `import()` (same OS user as the dev server — only use on trusted code).
+
+## Comparison with MCP
+
+| | MCP | Native plugin |
+|---|-----|----------------|
+| Process | Separate stdio server | In-process handler |
+| Naming | `mcp__server__tool` | `plugin__id__function` |
+| Best for | Existing MCP tools | Quick local extensions |
+
+## Tests
+
+```bash
+npm run test:plugins
+```
+
+Fixtures live under `test/fixtures/plugin-tools/echo/` (`plugin__echo__ping` → `pong`).

--- a/documentation/schemas/tool-plugin.schema.json
+++ b/documentation/schemas/tool-plugin.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://minnow.local/schemas/tool-plugin.json",
+  "title": "Minnow native tool plugin manifest",
+  "type": "object",
+  "required": ["id", "functionName", "label", "description", "category", "parameters"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "description": "Must match parent folder name under ~/.minnow/tools/"
+    },
+    "functionName": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "description": "Exposed as plugin__<id>__<functionName> (hyphens in id become underscores)"
+    },
+    "label": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "category": {
+      "type": "string",
+      "enum": ["web", "utility", "files", "git", "code", "agents", "browser", "lsp"]
+    },
+    "parameters": {
+      "type": "object",
+      "required": ["type", "properties"],
+      "properties": {
+        "type": { "const": "object" },
+        "properties": { "type": "object" },
+        "required": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "properties": {
+        "filesystem": { "type": "boolean" },
+        "network": { "type": "boolean" },
+        "nodeBuiltin": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:memory": "node --test test/memory/*.test.mjs",
     "test:lsp": "node --test test/lsp/*.test.mjs",
     "test:mcp": "node --test test/mcp/*.test.mjs",
+    "test:plugins": "node --test test/tools/plugin-scan.test.mjs test/tools/plugin-loader.test.mjs test/plugins/api.test.mjs",
     "test:ui-designer": "tsx --test test/ui-designer/**/*.test.mts && node scripts/step15-smoke.mjs",
     "test:browser": "node --test test/cdp/*.test.js test/browser-cdp.test.mjs",
     "test:benchmark": "node --experimental-test-module-mocks ./node_modules/tsx/dist/cli.mjs --import ./test/test-loader.mjs --test test/benchmark/*.test.mts && node --test test/ui/benchmark-page-html.test.mjs"

--- a/server.js
+++ b/server.js
@@ -44,6 +44,8 @@ import { initMemoryApi } from './server/memory/routes.js';
 import { createLspMiddleware, initLspConfig } from './server/lsp/middleware.js';
 import { createMcpMiddleware, initMcpApi } from './server/mcp/middleware.js';
 import { callMcpTool, isMcpToolName } from './server/mcp/registry.js';
+import { callPluginTool, isPluginToolName } from './server/tools/loader.js';
+import { createPluginsMiddleware, initPluginsApi } from './server/tools/middleware.js';
 import { getAppRoot, getWorkspaceRoot, initWorkspaceRoot } from './server/workspace/root.js';
 import { isResolvedPathUnderRoot } from './server/workspace/safe-path.js';
 import { createWorkspaceMiddleware } from './server/workspace/middleware.js';
@@ -696,6 +698,10 @@ async function executeServerTool(name, args) {
   const allowOutsideWorkspace = fsAccess === 'full';
   return pathAccessStore.run({ allowOutsideWorkspace }, async () => {
     try {
+      if (isPluginToolName(name)) {
+        const result = await callPluginTool(name, args ?? {});
+        return { result: String(result) };
+      }
       if (isMcpToolName(name)) {
         const result = await callMcpTool(name, args ?? {});
         return { result: String(result) };
@@ -848,6 +854,7 @@ async function main() {
           server.middlewares.use(createReefMiddleware());
           server.middlewares.use(createLspMiddleware(() => getWorkspaceRoot()));
           server.middlewares.use(createMcpMiddleware());
+          server.middlewares.use(createPluginsMiddleware());
           server.middlewares.use(createPromptConfigsMiddleware());
           server.middlewares.use(createProfilesMiddleware());
           server.middlewares.use(createProviderMiddleware());
@@ -876,6 +883,7 @@ async function main() {
   await initMemoryApi();
   await initLspConfig();
   await initMcpApi();
+  await initPluginsApi();
   const homePath = getMinnowHome();
   console.log(`Minnow data: ${homePath}`);
 

--- a/server/config/home.js
+++ b/server/config/home.js
@@ -67,6 +67,7 @@ const SCAFFOLD_DIRS = [
   'profiles',
   'prompts',
   'skills',
+  'tools',
   'agent-packs',
   'backups',
   'logs/sub-agents',
@@ -211,6 +212,7 @@ function defaultToolsJson() {
     enabled,
     permissions: { default: permissionsDefault, perAgent: {}, patterns: [] },
     keys: { braveApiKey: '' },
+    plugins: {},
   };
 }
 

--- a/server/config/validators.js
+++ b/server/config/validators.js
@@ -529,6 +529,7 @@ export function normalizeToolConfig(raw) {
     permissions: { default: permissionsDefault, perAgent: {}, patterns: [] },
     keys: { braveApiKey: '' },
     toolCache: { enabled: true },
+    plugins: {},
   };
 
   if (!raw || typeof raw !== 'object') return config;
@@ -588,6 +589,17 @@ export function normalizeToolConfig(raw) {
   }
   if (!config.toolCache) {
     config.toolCache = { enabled: true };
+  }
+
+  if (stored.plugins && typeof stored.plugins === 'object') {
+    const pluginsMap = /** @type {Record<string, unknown>} */ (stored.plugins);
+    for (const [pluginId, meta] of Object.entries(pluginsMap)) {
+      if (!pluginId.trim() || typeof meta !== 'object' || meta === null) continue;
+      const row = /** @type {Record<string, unknown>} */ (meta);
+      config.plugins[pluginId.trim()] = {
+        enabled: row.enabled !== false,
+      };
+    }
   }
 
   return config;

--- a/server/tools/_template/README.md
+++ b/server/tools/_template/README.md
@@ -1,0 +1,10 @@
+# Tool plugin template
+
+Place custom tool packs under `~/.minnow/tools/<id>/` with:
+
+- `tool.json` — metadata and JSON Schema parameters
+- `handler.mjs` — `export default async function handler(args, ctx)`
+
+Scaffold from Minnow: `POST /api/plugins/scaffold` with `{ "id": "your-plugin-id" }` while `npm start` is running.
+
+Authoring guide: `documentation/plugins/tool-authoring.md`

--- a/server/tools/_template/handler.mjs
+++ b/server/tools/_template/handler.mjs
@@ -1,0 +1,10 @@
+/**
+ * @param {Record<string, unknown>} args
+ * @param {import('../plugin-context.js').PluginContext} ctx
+ * @returns {Promise<string>}
+ */
+export default async function handler(args, ctx) {
+  const name = typeof args.name === 'string' ? args.name : 'world';
+  ctx.log(`greet called for ${name}`);
+  return `Hello, ${name}`;
+}

--- a/server/tools/_template/tool.json
+++ b/server/tools/_template/tool.json
@@ -1,0 +1,22 @@
+{
+  "id": "my-plugin",
+  "functionName": "greet",
+  "label": "My Plugin",
+  "description": "Returns a greeting string.",
+  "category": "utility",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "Name to greet"
+      }
+    },
+    "required": ["name"]
+  },
+  "capabilities": {
+    "filesystem": false,
+    "network": false,
+    "nodeBuiltin": false
+  }
+}

--- a/server/tools/bridge.js
+++ b/server/tools/bridge.js
@@ -1,0 +1,41 @@
+/**
+ * Native tool plugin namespacing (parallel to MCP bridge).
+ */
+
+/** plugin__<pluginId>__<functionName> — hyphens in id become underscores in the namespace segment. */
+export function toPluginNamespacedName(pluginId, functionName) {
+  const safeId = String(pluginId).replace(/-/g, '_');
+  const safeFn = String(functionName).replace(/-/g, '_');
+  return `plugin__${safeId}__${safeFn}`;
+}
+
+/**
+ * @param {string} name
+ * @returns {{ pluginId: string, functionName: string } | null}
+ */
+export function parsePluginNamespacedName(name) {
+  if (!name.startsWith('plugin__')) return null;
+  const parts = name.slice(8).split('__');
+  if (parts.length < 2) return null;
+  const pluginId = parts[0].replace(/_/g, '-');
+  const functionName = parts.slice(1).join('__').replace(/_/g, '-');
+  return { pluginId, functionName };
+}
+
+export function isPluginToolName(name) {
+  return typeof name === 'string' && name.startsWith('plugin__');
+}
+
+/**
+ * @param {import('./scan.js').PluginManifest} manifest
+ */
+export function manifestToOpenAIDefinition(manifest) {
+  return {
+    type: 'function',
+    function: {
+      name: toPluginNamespacedName(manifest.id, manifest.functionName),
+      description: manifest.description,
+      parameters: manifest.parameters ?? { type: 'object', properties: {} },
+    },
+  };
+}

--- a/server/tools/loader.js
+++ b/server/tools/loader.js
@@ -1,0 +1,142 @@
+/**
+ * Load plugin handlers and execute plugin__* tools server-side.
+ */
+
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  isPluginToolName,
+  manifestToOpenAIDefinition,
+  parsePluginNamespacedName,
+} from './bridge.js';
+import { createPluginContext } from './plugin-context.js';
+import { listMergedPlugins } from './scan.js';
+
+/** @type {Map<string, import('./scan.js').PluginListItem>} */
+let pluginByNamespaced = new Map();
+
+/** @type {Map<string, { mtimeMs: number, run: (args: Record<string, unknown>, ctx: import('./plugin-context.js').PluginContext) => Promise<string> }>} */
+const handlerCache = new Map();
+
+let loadGeneration = 0;
+
+/**
+ * @param {import('./scan.js').PluginListItem} item
+ */
+async function compileHandler(item) {
+  const stat = await fs.stat(item.handlerPath);
+  const cached = handlerCache.get(item.namespacedName);
+  if (cached && cached.mtimeMs === stat.mtimeMs) {
+    return cached.run;
+  }
+
+  const run = await buildHandlerRunner(item);
+  handlerCache.set(item.namespacedName, { mtimeMs: stat.mtimeMs, run });
+  return run;
+}
+
+/**
+ * @param {import('./scan.js').PluginListItem} item
+ */
+async function buildHandlerRunner(item) {
+  if (process.env.MINNOW_PLUGIN_UNSAFE === '1') {
+    const url = `${pathToFileURL(item.handlerPath).href}?g=${loadGeneration}`;
+    const mod = await import(url);
+    if (typeof mod.default !== 'function') {
+      throw new Error(`${item.id}/handler.mjs must export default async function`);
+    }
+    const handler = mod.default;
+    return async (args, ctx) => {
+      const result = await handler(args, ctx);
+      return String(result ?? '');
+    };
+  }
+
+  const source = await fs.readFile(item.handlerPath, 'utf8');
+  const body = source.replace(/^\s*export\s+default\s+/m, '').trim();
+  const scriptSource = `(async (args, ctx) => {
+    ${body}
+    if (typeof handler !== 'function') {
+      throw new Error('Plugin handler must export default async function handler(args, ctx)');
+    }
+    const result = await handler(args, ctx);
+    return String(result ?? '');
+  })`;
+
+  const script = new vm.Script(scriptSource, { filename: item.handlerPath });
+
+  return async (args, ctx) => {
+    const sandbox = {
+      args,
+      ctx,
+      console: {
+        log: (...parts) => ctx.log(parts.map(String).join(' ')),
+      },
+    };
+    const context = vm.createContext(sandbox);
+    const fn = script.runInContext(context);
+    return await fn(args, ctx);
+  };
+}
+
+/**
+ * Refresh in-memory plugin catalog and clear handler cache.
+ */
+export async function reloadPlugins() {
+  loadGeneration += 1;
+  handlerCache.clear();
+  const plugins = await listMergedPlugins();
+  const next = new Map();
+  for (const item of plugins) {
+    next.set(item.namespacedName, item);
+  }
+  pluginByNamespaced = next;
+  return plugins;
+}
+
+/**
+ * @returns {Promise<object[]>}
+ */
+export async function getPluginToolDefinitions() {
+  if (pluginByNamespaced.size === 0) {
+    await reloadPlugins();
+  }
+  return [...pluginByNamespaced.values()].map(manifestToOpenAIDefinition);
+}
+
+/**
+ * @param {string} name
+ * @param {Record<string, unknown>} args
+ * @returns {Promise<string>}
+ */
+export async function callPluginTool(name, args) {
+  if (!isPluginToolName(name)) {
+    return `Error: invalid plugin tool name ${name}`;
+  }
+
+  if (pluginByNamespaced.size === 0) {
+    await reloadPlugins();
+  }
+
+  const item = pluginByNamespaced.get(name);
+  if (!item) {
+    const parsed = parsePluginNamespacedName(name);
+    if (!parsed) {
+      return `Error: invalid plugin tool name ${name}`;
+    }
+    return `Error: plugin tool "${name}" is not loaded or is disabled`;
+  }
+
+  try {
+    const ctx = createPluginContext();
+    const run = await compileHandler(item);
+    return await run(args ?? {}, ctx);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `Error: ${message}`;
+  }
+}
+
+export { isPluginToolName } from './bridge.js';

--- a/server/tools/middleware.js
+++ b/server/tools/middleware.js
@@ -1,0 +1,221 @@
+/**
+ * Native tool plugin API: /api/plugins/*
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getMinnowHome } from '../config/home.js';
+import { readConfigJson, writeConfigJson } from '../config/store.js';
+import {
+  getPluginToolDefinitions,
+  reloadPlugins,
+} from './loader.js';
+import { listMergedPlugins, PLUGIN_ID_RE } from './scan.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const TEMPLATE_ROOT = path.join(__dirname, '_template');
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function sendJson(res, status, payload) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(payload));
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}'));
+      } catch {
+        reject(new Error('Invalid JSON'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+/**
+ * @param {string} srcDir
+ * @param {string} destDir
+ */
+async function copyDirRecursive(srcDir, destDir) {
+  await fs.mkdir(destDir, { recursive: true });
+  const entries = await fs.readdir(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = path.join(srcDir, entry.name);
+    const dest = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirRecursive(src, dest);
+    } else {
+      await fs.copyFile(src, dest);
+    }
+  }
+}
+
+/**
+ * @param {string} id
+ */
+async function ensurePluginIndexEntry(id, enabled = true) {
+  const toolsConfig = (await readConfigJson('tools.json')) ?? {};
+  const base =
+    toolsConfig && typeof toolsConfig === 'object'
+      ? { .../** @type {Record<string, unknown>} */ (toolsConfig) }
+      : {};
+  const plugins =
+    base.plugins && typeof base.plugins === 'object'
+      ? { .../** @type {Record<string, { enabled?: boolean }>} */ (base.plugins) }
+      : {};
+  plugins[id] = { enabled };
+  base.plugins = plugins;
+  await writeConfigJson('tools.json', base);
+}
+
+/**
+ * @param {import('http').IncomingMessage} req
+ * @param {import('http').ServerResponse} res
+ * @param {string} pathname
+ * @returns {Promise<boolean>}
+ */
+export async function handlePluginsRequest(req, res, pathname) {
+  if (!pathname.startsWith('/api/plugins')) {
+    return false;
+  }
+
+  setCorsHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return true;
+  }
+
+  try {
+    if (pathname === '/api/plugins/ping' && req.method === 'GET') {
+      sendJson(res, 200, {
+        ok: true,
+        homeDir: getMinnowHome(),
+        pluginCount: (await listMergedPlugins()).length,
+      });
+      return true;
+    }
+
+    if (pathname === '/api/plugins' && req.method === 'GET') {
+      const plugins = await listMergedPlugins();
+      sendJson(
+        res,
+        200,
+        {
+          plugins: plugins.map((p) => ({
+            id: p.id,
+            label: p.label,
+            description: p.description,
+            category: p.category,
+            functionName: p.functionName,
+            namespacedName: p.namespacedName,
+          })),
+        },
+      );
+      return true;
+    }
+
+    if (pathname === '/api/plugins/tools' && req.method === 'GET') {
+      await reloadPlugins();
+      const tools = await getPluginToolDefinitions();
+      sendJson(res, 200, { tools });
+      return true;
+    }
+
+    if (pathname === '/api/plugins/reload' && req.method === 'POST') {
+      await reloadPlugins();
+      sendJson(res, 200, { ok: true });
+      return true;
+    }
+
+    if (pathname === '/api/plugins/scaffold' && req.method === 'POST') {
+      const body = await readJsonBody(req);
+      const id = typeof body.id === 'string' ? body.id.trim() : '';
+      if (!id) {
+        sendJson(res, 400, { error: 'Plugin id is required' });
+        return true;
+      }
+      if (!PLUGIN_ID_RE.test(id) || id.startsWith('_')) {
+        sendJson(res, 400, {
+          error: 'Invalid plugin id (use lowercase letters, numbers, hyphens)',
+        });
+        return true;
+      }
+
+      const destDir = path.join(getMinnowHome(), 'tools', id);
+      const manifestPath = path.join(destDir, 'tool.json');
+      try {
+        await fs.access(manifestPath);
+        sendJson(res, 400, { error: `Plugin "${id}" already exists` });
+        return true;
+      } catch (err) {
+        if (/** @type {NodeJS.ErrnoException} */ (err).code !== 'ENOENT') {
+          throw err;
+        }
+      }
+
+      await copyDirRecursive(TEMPLATE_ROOT, destDir);
+      const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+      manifest.id = id;
+      await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+      await ensurePluginIndexEntry(id, true);
+      await reloadPlugins();
+
+      sendJson(res, 201, {
+        ok: true,
+        path: destDir,
+        plugin: (await listMergedPlugins()).find((p) => p.id === id) ?? null,
+      });
+      return true;
+    }
+
+    sendJson(res, 404, { error: 'Not found' });
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    sendJson(res, 400, { error: message });
+    return true;
+  }
+}
+
+/**
+ * @returns {(req: import('connect').IncomingMessage, res: import('http').ServerResponse, next: () => void) => void}
+ */
+export function createPluginsMiddleware() {
+  return (req, res, next) => {
+    const url = req.url?.split('?')[0] ?? '';
+    if (!url.startsWith('/api/plugins')) {
+      next();
+      return;
+    }
+    void handlePluginsRequest(req, res, url).then((handled) => {
+      if (!handled) next();
+    });
+  };
+}
+
+/**
+ * Load plugins on server boot (non-fatal).
+ */
+export async function initPluginsApi() {
+  try {
+    await reloadPlugins();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn('[plugins] init skipped:', message);
+  }
+}

--- a/server/tools/plugin-context.js
+++ b/server/tools/plugin-context.js
@@ -1,0 +1,35 @@
+/**
+ * Frozen context passed to plugin handler.mjs (workspace + minnow home).
+ */
+
+import { getMinnowHome } from '../config/home.js';
+import { getWorkspaceRoot } from '../workspace/root.js';
+
+/**
+ * @typedef {object} PluginContext
+ * @property {string} workspaceRoot
+ * @property {string} minnowHome
+ * @property {(message: string) => void} log
+ * @property {Readonly<Record<string, string | undefined>>} env
+ */
+
+/**
+ * @param {{ log?: (message: string) => void }} [options]
+ * @returns {PluginContext}
+ */
+export function createPluginContext(options = {}) {
+  const log =
+    typeof options.log === 'function'
+      ? options.log
+      : (message) => console.log(`[plugin] ${message}`);
+
+  return Object.freeze({
+    workspaceRoot: getWorkspaceRoot(),
+    minnowHome: getMinnowHome(),
+    log,
+    env: Object.freeze({
+      NODE_ENV: process.env.NODE_ENV,
+      MINNOW_HOME: process.env.MINNOW_HOME,
+    }),
+  });
+}

--- a/server/tools/scan.js
+++ b/server/tools/scan.js
@@ -1,0 +1,169 @@
+/**
+ * Scan ~/.minnow/tools/<id>/ for tool.json + handler.mjs plugin packs.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getMinnowHome } from '../config/home.js';
+import { readConfigJson } from '../config/store.js';
+import { toPluginNamespacedName } from './bridge.js';
+import { ALL_TOOL_IDS } from '../config/tool-ids.js';
+import {
+  MAX_MANIFEST_BYTES,
+  PLUGIN_ID_RE,
+  validateToolManifest,
+} from './validate.js';
+
+export { PLUGIN_ID_RE } from './validate.js';
+
+/**
+ * @typedef {object} PluginCapabilities
+ * @property {boolean} filesystem
+ * @property {boolean} network
+ * @property {boolean} nodeBuiltin
+ */
+
+/**
+ * @typedef {object} PluginManifest
+ * @property {string} id
+ * @property {string} functionName
+ * @property {string} label
+ * @property {string} description
+ * @property {string} category
+ * @property {object} parameters
+ * @property {PluginCapabilities} capabilities
+ */
+
+/**
+ * @typedef {PluginManifest & { source: 'user', path: string, handlerPath: string, namespacedName: string }} PluginListItem
+ */
+
+/**
+ * @returns {string}
+ */
+export function getUserPluginsRoot() {
+  return path.join(getMinnowHome(), 'tools');
+}
+
+/**
+ * @param {string} dirName
+ */
+export function shouldExposePluginDir(dirName) {
+  return !dirName.startsWith('_');
+}
+
+/**
+ * @param {string} rootDir
+ * @returns {Promise<PluginListItem[]>}
+ */
+export async function scanPluginDir(rootDir) {
+  /** @type {PluginListItem[]} */
+  const items = [];
+
+  let entries;
+  try {
+    entries = await fs.readdir(rootDir, { withFileTypes: true });
+  } catch (err) {
+    if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') {
+      return items;
+    }
+    console.warn(`[plugins] Cannot read ${rootDir}:`, err);
+    return items;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!shouldExposePluginDir(entry.name)) continue;
+
+    const pluginDir = path.join(rootDir, entry.name);
+    const manifestPath = path.join(pluginDir, 'tool.json');
+    const handlerPath = path.join(pluginDir, 'handler.mjs');
+
+    let manifestRaw;
+    try {
+      const stat = await fs.stat(manifestPath);
+      if (stat.size > MAX_MANIFEST_BYTES) {
+        console.warn(
+          `[plugins] Skip ${entry.name}: tool.json exceeds ${MAX_MANIFEST_BYTES} bytes`,
+        );
+        continue;
+      }
+      manifestRaw = await fs.readFile(manifestPath, 'utf8');
+    } catch {
+      console.warn(`[plugins] Skip ${entry.name}: missing or unreadable tool.json`);
+      continue;
+    }
+
+    try {
+      await fs.access(handlerPath);
+    } catch {
+      console.warn(`[plugins] Skip ${entry.name}: missing handler.mjs`);
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(manifestRaw);
+      const manifest = validateToolManifest(parsed, entry.name);
+      if (ALL_TOOL_IDS.includes(manifest.id)) {
+        console.warn(`[plugins] Skip ${entry.name}: id collides with built-in tool id`);
+        continue;
+      }
+
+      const namespaced = toPluginNamespacedName(manifest.id, manifest.functionName);
+
+      items.push({
+        ...manifest,
+        source: 'user',
+        path: manifestPath,
+        handlerPath,
+        namespacedName: namespaced,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[plugins] Skip ${entry.name}: ${message}`);
+    }
+  }
+
+  return items;
+}
+
+/**
+ * @returns {Promise<Record<string, { enabled?: boolean }>>}
+ */
+async function loadPluginsIndex() {
+  const toolsConfig = (await readConfigJson('tools.json')) ?? {};
+  const plugins =
+    toolsConfig && typeof toolsConfig === 'object' && toolsConfig.plugins
+      ? /** @type {Record<string, { enabled?: boolean }>} */ (toolsConfig.plugins)
+      : {};
+  return plugins ?? {};
+}
+
+/**
+ * @param {PluginListItem[]} items
+ * @param {Record<string, { enabled?: boolean }>} index
+ */
+export function filterPluginsByIndex(items, index) {
+  return items.filter((item) => {
+    const meta = index[item.id];
+    if (!meta) return true;
+    return meta.enabled !== false;
+  });
+}
+
+/**
+ * @returns {Promise<PluginListItem[]>}
+ */
+export async function listMergedPlugins() {
+  const root = getUserPluginsRoot();
+  try {
+    await fs.mkdir(root, { recursive: true });
+  } catch {
+    /* ignore */
+  }
+  const scanned = await scanPluginDir(root);
+  const index = await loadPluginsIndex();
+  return filterPluginsByIndex(scanned, index).sort((a, b) =>
+    a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
+  );
+}

--- a/server/tools/validate.js
+++ b/server/tools/validate.js
@@ -1,0 +1,133 @@
+/**
+ * Validation for ~/.minnow/tools/<id>/tool.json manifests.
+ */
+
+import { ALL_TOOL_IDS } from '../config/tool-ids.js';
+
+/** Same id rules as skills. */
+export const PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+export const MAX_MANIFEST_BYTES = 32 * 1024;
+export const MAX_PARAMETER_PROPERTIES = 50;
+
+const VALID_CATEGORIES = new Set([
+  'web',
+  'utility',
+  'files',
+  'git',
+  'code',
+  'agents',
+  'browser',
+  'lsp',
+]);
+
+const RESERVED_FUNCTION_NAMES = new Set([
+  ...ALL_TOOL_IDS,
+  'web_search_ddg',
+]);
+
+/**
+ * @param {string} id
+ */
+export function validatePluginId(id) {
+  if (!PLUGIN_ID_RE.test(id)) {
+    throw new Error('Invalid plugin id (use lowercase letters, numbers, hyphens)');
+  }
+  if (id.startsWith('_')) {
+    throw new Error('Plugin id cannot start with underscore');
+  }
+}
+
+/**
+ * @param {string} functionName
+ */
+export function validateFunctionName(functionName) {
+  if (!/^[a-z][a-z0-9_]*$/.test(functionName)) {
+    throw new Error(
+      'functionName must be lowercase snake_case starting with a letter',
+    );
+  }
+  if (RESERVED_FUNCTION_NAMES.has(functionName)) {
+    throw new Error(`functionName "${functionName}" is reserved`);
+  }
+  if (functionName.startsWith('mcp__') || functionName.startsWith('plugin__')) {
+    throw new Error('functionName cannot use reserved prefixes');
+  }
+}
+
+/**
+ * @param {unknown} raw
+ * @param {string} folderName
+ * @returns {import('./scan.js').PluginManifest}
+ */
+export function validateToolManifest(raw, folderName) {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('tool.json must be a JSON object');
+  }
+  const row = /** @type {Record<string, unknown>} */ (raw);
+
+  const id = typeof row.id === 'string' ? row.id.trim() : '';
+  const functionName =
+    typeof row.functionName === 'string' ? row.functionName.trim() : '';
+  const label = typeof row.label === 'string' ? row.label.trim() : '';
+  const description =
+    typeof row.description === 'string' ? row.description.trim() : '';
+  const category = typeof row.category === 'string' ? row.category.trim() : 'utility';
+
+  if (!id) throw new Error('tool.json: id is required');
+  if (id !== folderName) {
+    throw new Error(`tool.json id "${id}" must match folder "${folderName}"`);
+  }
+  validatePluginId(id);
+  if (!functionName) throw new Error('tool.json: functionName is required');
+  validateFunctionName(functionName);
+  if (!label) throw new Error('tool.json: label is required');
+  if (!description) throw new Error('tool.json: description is required');
+  if (!VALID_CATEGORIES.has(category)) {
+    throw new Error(`tool.json: invalid category "${category}"`);
+  }
+
+  const parameters = row.parameters;
+  if (!parameters || typeof parameters !== 'object') {
+    throw new Error('tool.json: parameters object is required');
+  }
+  const paramsObj = /** @type {Record<string, unknown>} */ (parameters);
+  if (paramsObj.type !== 'object') {
+    throw new Error('tool.json: parameters.type must be "object"');
+  }
+  const props = paramsObj.properties;
+  if (props && typeof props === 'object') {
+    const count = Object.keys(/** @type {object} */ (props)).length;
+    if (count > MAX_PARAMETER_PROPERTIES) {
+      throw new Error(
+        `tool.json: too many parameter properties (max ${MAX_PARAMETER_PROPERTIES})`,
+      );
+    }
+  }
+
+  let capabilities = {
+    filesystem: false,
+    network: false,
+    nodeBuiltin: false,
+  };
+  if (row.capabilities && typeof row.capabilities === 'object') {
+    const cap = /** @type {Record<string, unknown>} */ (row.capabilities);
+    capabilities = {
+      filesystem: cap.filesystem === true,
+      network: cap.network === true,
+      nodeBuiltin: cap.nodeBuiltin === true,
+    };
+  }
+
+  return {
+    id,
+    functionName,
+    label,
+    description,
+    category,
+    parameters: /** @type {import('./scan.js').PluginManifest['parameters']} */ (
+      parameters
+    ),
+    capabilities,
+  };
+}

--- a/src/chat/modes/tool-policy.ts
+++ b/src/chat/modes/tool-policy.ts
@@ -33,6 +33,17 @@ export function filterToolsByMode(
 ): ToolDefinition[] {
   return defs.filter((tool) => {
     const name = tool.definition.function.name;
-    return effectiveAction(modeId, name) === 'allow';
+    return isToolAllowedForMode(modeId, name);
   });
+}
+
+/**
+ * Whether a tool function name may be sent to the model for this mode.
+ * MCP and plugin tools use the same policy map as built-ins.
+ */
+export function isToolAllowedForMode(
+  modeId: ModeId,
+  toolName: string,
+): boolean {
+  return effectiveAction(modeId, toolName) === 'allow';
 }

--- a/src/styles/settings-page.css
+++ b/src/styles/settings-page.css
@@ -961,6 +961,17 @@
   font-weight: 600;
 }
 
+.tool-custom-badge {
+  margin-left: 6px;
+  padding: 2px 6px;
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--mn-fg-muted);
+  vertical-align: middle;
+}
+
 .settings-mcp-badge--builtin {
   background: var(--mn-surface-0);
 }

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -16,7 +16,10 @@ import {
   setLocalServerAvailable,
 } from './config';
 import { blockPlanModeWrite } from '../chat/modes/plan-write-guard';
-import { filterToolsByMode } from '../chat/modes/tool-policy';
+import {
+  filterToolsByMode,
+  isToolAllowedForMode,
+} from '../chat/modes/tool-policy';
 import { normalizeModeId, type ModeId } from '../chat/modes/types';
 import type { ToolExecutionResult } from '../types';
 import {
@@ -64,6 +67,9 @@ function maybeRecordOrchestrateParentTool(name: string, context: ExecuteToolCont
 /** Cached MCP tool definitions from GET /api/mcp/tools. */
 let cachedMcpToolDefinitions: OpenAIFunctionDefinition[] = [];
 
+/** Cached native plugin tool definitions from GET /api/plugins/tools. */
+let cachedPluginToolDefinitions: OpenAIFunctionDefinition[] = [];
+
 /**
  * Probes the dev server tools API with a short timeout and updates availability in config.
  */
@@ -84,9 +90,10 @@ export async function detectLocalServer(): Promise<boolean> {
     const available = body?.ok === true;
     setLocalServerAvailable(available);
     if (available) {
-      await refreshMcpToolCache();
+      await Promise.all([refreshMcpToolCache(), refreshPluginToolCache()]);
     } else {
       cachedMcpToolDefinitions = [];
+      cachedPluginToolDefinitions = [];
     }
     return available;
   } catch {
@@ -138,6 +145,21 @@ export async function refreshMcpToolCache(): Promise<void> {
     cachedMcpToolDefinitions = Array.isArray(body.tools) ? body.tools : [];
   } catch {
     cachedMcpToolDefinitions = [];
+  }
+}
+
+/** Refresh native plugin tool definitions when the local server is available. */
+export async function refreshPluginToolCache(): Promise<void> {
+  try {
+    const response = await fetch('/api/plugins/tools');
+    if (!response.ok) {
+      cachedPluginToolDefinitions = [];
+      return;
+    }
+    const body = (await response.json()) as { tools?: OpenAIFunctionDefinition[] };
+    cachedPluginToolDefinitions = Array.isArray(body.tools) ? body.tools : [];
+  } catch {
+    cachedPluginToolDefinitions = [];
   }
 }
 
@@ -247,11 +269,11 @@ async function executeToolInner(
     return { content: await executeRequestBrowserOriginAccess(args, context) };
   }
 
-  if (name.startsWith('mcp__')) {
+  if (name.startsWith('mcp__') || name.startsWith('plugin__')) {
     if (!isLocalServerAvailable()) {
       return {
         content:
-          'Error: MCP tools require the local server. Run `npm start` (not Vite-only dev).',
+          'Error: MCP and plugin tools require the local server. Run `npm start` (not Vite-only dev).',
       };
     }
     const blocked = await maybeBlockToolForUserApproval(name, args, context, name);
@@ -398,10 +420,16 @@ export function getEnabledToolCatalogEntries(): ToolDefinition[] {
  * Returns OpenAI function definitions for tools the user enabled and that can run here.
  * Server-required tools are omitted when the local server was not detected.
  */
+function getEnabledDynamicToolDefinitions(): OpenAIFunctionDefinition[] {
+  return [...cachedMcpToolDefinitions, ...cachedPluginToolDefinitions].filter(
+    (def) => isToolEnabled(def.function.name),
+  );
+}
+
 export function getEnabledToolDefinitions(): OpenAIFunctionDefinition[] {
   return [
     ...getEnabledToolCatalogEntries().map((tool) => tool.definition),
-    ...cachedMcpToolDefinitions,
+    ...getEnabledDynamicToolDefinitions(),
   ];
 }
 
@@ -414,10 +442,17 @@ export function getEnabledToolDefinitionsForMode(
   const normalized = normalizeModeId(
     typeof modeId === 'string' ? modeId : modeId ?? undefined,
   );
-  return filterToolsByMode(getEnabledToolCatalogEntries(), normalized).map(
+  const builtins = filterToolsByMode(getEnabledToolCatalogEntries(), normalized).map(
     (tool) => tool.definition,
   );
+  const dynamic = getEnabledDynamicToolDefinitions().filter((def) =>
+    isToolAllowedForMode(normalized, def.function.name),
+  );
+  return [...builtins, ...dynamic];
 }
+
+/** Alias for send path — built-in, MCP, and plugin tools after mode + permission filters. */
+export const getEnabledToolDefinitionsForSend = getEnabledToolDefinitionsForMode;
 
 /** Map code tools to process argv for the terminal runner. */
 function mapCodeToolToCommand(

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -225,7 +225,7 @@ export function getToolPermissionForId(
 ): ToolPermissionMode {
   const raw = config.permissions.default[id];
   if (isToolPermissionMode(raw)) return raw;
-  if (id.startsWith('mcp__')) return 'ask';
+  if (id.startsWith('mcp__') || id.startsWith('plugin__')) return 'ask';
   if (id === 'web_search_ddg') {
     return getToolPermissionForId(config, 'web_search');
   }

--- a/src/tools/plugin-settings-types.ts
+++ b/src/tools/plugin-settings-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Native tool plugin metadata for Settings UI.
+ */
+
+export interface PluginListItem {
+  id: string;
+  label: string;
+  description: string;
+  category: string;
+  functionName: string;
+  namespacedName: string;
+}
+
+export interface PluginToolMeta extends PluginListItem {
+  /** User pack under ~/.minnow/tools/<id>/ */
+  source: 'user';
+}

--- a/src/ui/settings-plugins.ts
+++ b/src/ui/settings-plugins.ts
@@ -1,0 +1,158 @@
+/**
+ * Settings → Tools: native plugin packs (Feature #17).
+ */
+
+import {
+  isToolPermissionMode,
+  loadToolConfig,
+  setToolPermission,
+} from '../tools/config';
+import type { PluginListItem } from '../tools/plugin-settings-types';
+import { bindToolsListChange } from './tools-list';
+
+/** Fetch plugin metadata for settings rows. */
+export async function fetchPluginList(): Promise<PluginListItem[]> {
+  try {
+    const response = await fetch('/api/plugins');
+    if (!response.ok) return [];
+    const body = (await response.json()) as { plugins?: PluginListItem[] };
+    return Array.isArray(body.plugins) ? body.plugins : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Append plugin tool rows to a tools list container (Custom badge + permission select).
+ */
+export async function appendPluginToolsToList(
+  listId: string,
+): Promise<void> {
+  const container = document.getElementById(listId);
+  if (!container) return;
+
+  const plugins = await fetchPluginList();
+  const existing = container.querySelector('[data-tool-category="plugins"]');
+  if (existing) existing.remove();
+
+  if (plugins.length === 0) return;
+
+  const group = document.createElement('section');
+  group.className = 'tool-group';
+  group.setAttribute('data-tool-category', 'plugins');
+
+  const head = document.createElement('div');
+  head.className = 'tool-group-head';
+  const header = document.createElement('h3');
+  header.className = 'tool-group-header';
+  header.textContent = 'Plugins';
+  head.appendChild(header);
+  group.appendChild(head);
+
+  const hint = document.createElement('p');
+  hint.className = 'tool-group-hint';
+  hint.innerHTML =
+    'Drop-in tools under <code>~/.minnow/tools/&lt;id&gt;/</code>. See <a href="documentation/plugins/tool-authoring.md" target="_blank" rel="noopener">tool authoring</a>.';
+  group.appendChild(hint);
+
+  const scaffoldRow = document.createElement('div');
+  scaffoldRow.className = 'settings-plugin-scaffold-row';
+  const scaffoldBtn = document.createElement('button');
+  scaffoldBtn.type = 'button';
+  scaffoldBtn.className = 'settings-inline-btn';
+  scaffoldBtn.textContent = 'Scaffold new plugin…';
+  scaffoldBtn.addEventListener('click', () => {
+    void scaffoldPluginFromPrompt(listId);
+  });
+  scaffoldRow.appendChild(scaffoldBtn);
+  group.appendChild(scaffoldRow);
+
+  const config = loadToolConfig();
+
+  for (const plugin of plugins) {
+    const row = document.createElement('div');
+    row.className = 'tool-row tool-row--plugin';
+    row.setAttribute('data-tool-id', plugin.namespacedName);
+    row.setAttribute('data-server-required', '');
+
+    const controlWrap = document.createElement('div');
+    controlWrap.className = 'tool-permission-wrap';
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'tool-label';
+    const badge = document.createElement('span');
+    badge.className = 'tool-custom-badge';
+    badge.textContent = 'Custom';
+    nameSpan.append(plugin.label, document.createTextNode(' '), badge);
+
+    const select = document.createElement('select');
+    select.className = 'tool-permission-select';
+    select.setAttribute('aria-label', `${plugin.label} permission`);
+    for (const optDef of [
+      { value: 'off', label: 'Disabled' },
+      { value: 'ask', label: 'Requires permission' },
+      { value: 'full', label: 'Full permission' },
+    ] as const) {
+      const opt = document.createElement('option');
+      opt.value = optDef.value;
+      opt.textContent = optDef.label;
+      select.appendChild(opt);
+    }
+    const mode = config.permissions.default[plugin.namespacedName];
+    select.value =
+      typeof mode === 'string' && isToolPermissionMode(mode) ? mode : 'ask';
+
+    controlWrap.append(nameSpan, select);
+    row.appendChild(controlWrap);
+
+    const desc = document.createElement('p');
+    desc.className = 'tool-desc';
+    desc.textContent = `${plugin.description} (${plugin.namespacedName})`;
+    row.appendChild(desc);
+
+    group.appendChild(row);
+  }
+
+  container.appendChild(group);
+  bindToolsListChange(container);
+}
+
+async function scaffoldPluginFromPrompt(listId: string): Promise<void> {
+  const id = window.prompt(
+    'Plugin id (lowercase letters, numbers, hyphens):',
+    'my-plugin',
+  );
+  if (!id?.trim()) return;
+
+  try {
+    const response = await fetch('/api/plugins/scaffold', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: id.trim() }),
+    });
+    const body = (await response.json()) as { error?: string; path?: string };
+    if (!response.ok) {
+      window.alert(body.error ?? `Scaffold failed (HTTP ${response.status})`);
+      return;
+    }
+    await fetch('/api/plugins/reload', { method: 'POST' });
+    const { refreshPluginToolCache } = await import('../tools/client');
+    await refreshPluginToolCache();
+    await appendPluginToolsToList(listId);
+    const { loadToolConfigIntoDrawer } = await import('../tools/config');
+    loadToolConfigIntoDrawer();
+    window.alert(`Plugin created at ${body.path ?? id.trim()}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    window.alert(`Scaffold failed: ${message}`);
+  }
+}
+
+/** Persist permission for a plugin namespaced tool id. */
+export function setPluginToolPermission(
+  namespacedName: string,
+  mode: 'full' | 'ask' | 'off',
+  root: ParentNode = document,
+): void {
+  setToolPermission(namespacedName, mode, root);
+}

--- a/src/ui/settings-sections.ts
+++ b/src/ui/settings-sections.ts
@@ -1184,6 +1184,8 @@ async function renderToolsSection(): Promise<void> {
   mountToolApprovalRulesSection(mount);
 
   fillToolsSection('settingsToolsList');
+  const { appendPluginToolsToList } = await import('./settings-plugins');
+  await appendPluginToolsToList('settingsToolsList');
 
   allFullBtn.addEventListener('click', () => {
     const ok = window.confirm(

--- a/test/fixtures/plugin-tools/echo/handler.mjs
+++ b/test/fixtures/plugin-tools/echo/handler.mjs
@@ -1,0 +1,8 @@
+/**
+ * Deterministic fixture handler for plugin loader tests.
+ * @param {Record<string, unknown>} _args
+ * @param {import('../../../../server/tools/plugin-context.js').PluginContext} _ctx
+ */
+export default async function handler(_args, _ctx) {
+  return 'pong';
+}

--- a/test/fixtures/plugin-tools/echo/tool.json
+++ b/test/fixtures/plugin-tools/echo/tool.json
@@ -1,0 +1,16 @@
+{
+  "id": "echo",
+  "functionName": "ping",
+  "label": "Echo",
+  "description": "Returns pong.",
+  "category": "utility",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  },
+  "capabilities": {
+    "filesystem": false,
+    "network": false
+  }
+}

--- a/test/plugins/api.test.mjs
+++ b/test/plugins/api.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { resetMinnowHomeCache } from '../../server/config/home.js';
+import { writeConfigJson } from '../../server/config/store.js';
+import { handlePluginsRequest } from '../../server/tools/middleware.js';
+import { reloadPlugins } from '../../server/tools/loader.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = path.join(__dirname, '../fixtures/plugin-tools');
+const EXPECTED_TOOL = 'plugin__echo__ping';
+
+function httpRequest(baseUrl, method, pathname, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(pathname, baseUrl);
+    const payload = body != null ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      url,
+      {
+        method,
+        headers: payload ? { 'Content-Type': 'application/json' } : undefined,
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8');
+          let json = null;
+          try {
+            json = text ? JSON.parse(text) : null;
+          } catch {
+            json = text;
+          }
+          resolve({ status: res.statusCode, json, text });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+describe('plugins API', () => {
+  let homeDir;
+  /** @type {import('node:http').Server} */
+  let server;
+  let baseUrl;
+
+  before(async () => {
+    homeDir = path.join(os.tmpdir(), `minnow-plugin-api-${process.pid}`);
+    process.env.MINNOW_HOME = homeDir;
+    resetMinnowHomeCache();
+
+    await fs.rm(homeDir, { recursive: true, force: true });
+    await fs.mkdir(path.join(homeDir, 'tools'), { recursive: true });
+    await fs.cp(
+      path.join(FIXTURE_ROOT, 'echo'),
+      path.join(homeDir, 'tools', 'echo'),
+      { recursive: true },
+    );
+
+    await writeConfigJson('tools.json', {
+      enabled: {},
+      permissions: { default: {}, perAgent: {}, patterns: [] },
+      keys: { braveApiKey: '' },
+      plugins: { echo: { enabled: true } },
+    });
+
+    await reloadPlugins();
+
+    server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      void handlePluginsRequest(req, res, url.pathname).then((handled) => {
+        if (!handled) {
+          res.statusCode = 404;
+          res.end('not found');
+        }
+      });
+    });
+
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    delete process.env.MINNOW_HOME;
+    resetMinnowHomeCache();
+    await fs.rm(homeDir, { recursive: true, force: true });
+  });
+
+  test('GET /api/plugins/ping', async () => {
+    const { status, json } = await httpRequest(baseUrl, 'GET', '/api/plugins/ping');
+    assert.equal(status, 200);
+    assert.equal(json.ok, true);
+  });
+
+  test('GET /api/plugins/tools lists echo', async () => {
+    const { status, json } = await httpRequest(baseUrl, 'GET', '/api/plugins/tools');
+    assert.equal(status, 200);
+    const names = (json.tools ?? []).map((t) => t.function?.name);
+    assert.ok(names.includes(EXPECTED_TOOL));
+  });
+
+  test('POST /api/plugins/scaffold rejects duplicate', async () => {
+    const first = await httpRequest(baseUrl, 'POST', '/api/plugins/scaffold', {
+      id: 'demo-api',
+    });
+    assert.equal(first.status, 201);
+
+    const second = await httpRequest(baseUrl, 'POST', '/api/plugins/scaffold', {
+      id: 'demo-api',
+    });
+    assert.equal(second.status, 400);
+    assert.match(String(second.json?.error ?? ''), /already exists/i);
+  });
+
+  test('unknown route returns 404', async () => {
+    const { status } = await httpRequest(baseUrl, 'GET', '/api/plugins/unknown-route');
+    assert.equal(status, 404);
+  });
+});

--- a/test/tools/plugin-loader.test.mjs
+++ b/test/tools/plugin-loader.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { resetMinnowHomeCache } from '../../server/config/home.js';
+import { writeConfigJson } from '../../server/config/store.js';
+import {
+  callPluginTool,
+  reloadPlugins,
+} from '../../server/tools/loader.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = path.join(__dirname, '../fixtures/plugin-tools');
+const EXPECTED_TOOL = 'plugin__echo__ping';
+const EXPECTED_RESULT = 'pong';
+
+describe('plugin loader', () => {
+  let homeDir;
+
+  before(async () => {
+    homeDir = path.join(os.tmpdir(), `minnow-plugin-loader-${process.pid}`);
+    process.env.MINNOW_HOME = homeDir;
+    resetMinnowHomeCache();
+
+    await fs.rm(homeDir, { recursive: true, force: true });
+    await fs.mkdir(path.join(homeDir, 'tools'), { recursive: true });
+    await fs.cp(
+      path.join(FIXTURE_ROOT, 'echo'),
+      path.join(homeDir, 'tools', 'echo'),
+      { recursive: true },
+    );
+
+    await writeConfigJson('tools.json', {
+      enabled: {},
+      permissions: { default: {}, perAgent: {}, patterns: [] },
+      keys: { braveApiKey: '' },
+      plugins: { echo: { enabled: true } },
+    });
+
+    await reloadPlugins();
+  });
+
+  after(async () => {
+    delete process.env.MINNOW_HOME;
+    resetMinnowHomeCache();
+    await reloadPlugins();
+    await fs.rm(homeDir, { recursive: true, force: true });
+  });
+
+  test('callPluginTool returns pong', async () => {
+    const result = await callPluginTool(EXPECTED_TOOL, {});
+    assert.equal(result, EXPECTED_RESULT);
+  });
+
+  test('reload clears and reloads handlers', async () => {
+    const first = await callPluginTool(EXPECTED_TOOL, {});
+    assert.equal(first, EXPECTED_RESULT);
+    await reloadPlugins();
+    const second = await callPluginTool(EXPECTED_TOOL, {});
+    assert.equal(second, EXPECTED_RESULT);
+  });
+
+  test('disabled plugin is not loaded', async () => {
+    await writeConfigJson('tools.json', {
+      enabled: {},
+      permissions: { default: {}, perAgent: {}, patterns: [] },
+      keys: { braveApiKey: '' },
+      plugins: { echo: { enabled: false } },
+    });
+    await reloadPlugins();
+    const result = await callPluginTool(EXPECTED_TOOL, {});
+    assert.match(result, /not loaded|disabled/i);
+
+    await writeConfigJson('tools.json', {
+      enabled: {},
+      permissions: { default: {}, perAgent: {}, patterns: [] },
+      keys: { braveApiKey: '' },
+      plugins: { echo: { enabled: true } },
+    });
+    await reloadPlugins();
+  });
+
+  test('unknown plugin returns error string', async () => {
+    const result = await callPluginTool('plugin__missing__ping', {});
+    assert.match(result, /^Error:/);
+  });
+});

--- a/test/tools/plugin-scan.test.mjs
+++ b/test/tools/plugin-scan.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { scanPluginDir } from '../../server/tools/scan.js';
+import { validateToolManifest } from '../../server/tools/validate.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = path.join(__dirname, '../fixtures/plugin-tools');
+
+describe('plugin scan', () => {
+  test('valid echo fixture scans successfully', async () => {
+    const items = await scanPluginDir(FIXTURE_ROOT);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].id, 'echo');
+    assert.equal(items[0].namespacedName, 'plugin__echo__ping');
+  });
+
+  test('rejects id mismatch with folder', () => {
+    assert.throws(
+      () => validateToolManifest({ id: 'wrong', functionName: 'ping', label: 'X', description: 'Y', category: 'utility', parameters: { type: 'object', properties: {} } }, 'echo'),
+      /must match folder/,
+    );
+  });
+
+  test('rejects reserved built-in id', async () => {
+    const tmp = path.join(os.tmpdir(), `minnow-plugin-scan-${process.pid}`);
+    await fs.rm(tmp, { recursive: true, force: true });
+    await fs.mkdir(path.join(tmp, 'read_file'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmp, 'read_file', 'tool.json'),
+      JSON.stringify({
+        id: 'read_file',
+        functionName: 'ping',
+        label: 'Bad',
+        description: 'Bad',
+        category: 'files',
+        parameters: { type: 'object', properties: {} },
+      }),
+      'utf8',
+    );
+    await fs.writeFile(path.join(tmp, 'read_file', 'handler.mjs'), 'export default async function handler() { return "x"; }\n', 'utf8');
+
+    const items = await scanPluginDir(tmp);
+    assert.equal(items.length, 0);
+
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  test('skips directories starting with underscore', async () => {
+    const tmp = path.join(os.tmpdir(), `minnow-plugin-scan-us-${process.pid}`);
+    await fs.rm(tmp, { recursive: true, force: true });
+    await fs.mkdir(path.join(tmp, '_template'), { recursive: true });
+    await fs.writeFile(path.join(tmp, '_template', 'tool.json'), '{}', 'utf8');
+
+    const items = await scanPluginDir(tmp);
+    assert.equal(items.length, 0);
+
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Feature #17: drop-in local tool plugins under `~/.minnow/tools/<id>/` without requiring an MCP server.

## Changes

- **Server:** `server/tools/{scan,validate,loader,bridge,middleware,plugin-context}.js`, `_template/` pack, wired into `executeServerTool` and `initPluginsApi`
- **API:** `GET /api/plugins/ping`, `GET /api/plugins`, `GET /api/plugins/tools`, `POST /api/plugins/reload`, `POST /api/plugins/scaffold`
- **Client:** `refreshPluginToolCache()`, `plugin__*` execution via `/api/tools`, merged into `getEnabledToolDefinitionsForMode()` (fixes MCP omission on send path)
- **Settings:** Plugins section with Custom badge, permissions, scaffold button
- **Persistence:** `tools.json` → `plugins` index; default `ask` permission for `plugin__*`
- **Docs:** `documentation/plugins/tool-authoring.md`, schema, updated `context.md` and roadmap
- **Tests:** `npm run test:plugins` (12 tests)

## Verification

```bash
npx tsc --noEmit
npm run test:plugins
```

## Notes

- Handlers run in a Node `vm` sandbox by default; set `MINNOW_PLUGIN_UNSAFE=1` for full dynamic `import()` during trusted local development.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-53](https://linear.app/minnowai/issue/MIN-53/plugin-api-for-tools)

<div><a href="https://cursor.com/agents/bc-f8a303d5-d25a-4a39-b617-77d46f42842f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8a303d5-d25a-4a39-b617-77d46f42842f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

