### PR TITLE
✨ POLISH-004: Benchmark per-test descriptions (MIN-94)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -207,6 +207,7 @@ Full-page **Benchmark** at `#/benchmark` (top-bar chart icon before workspace). 
 | Piece | Location |
 |-------|----------|
 | Runner + suites | `src/benchmark/` (`runner.ts`, `llm-driver.ts`, `suites/*`) |
+| Per-test descriptions (POLISH-004 / MIN-94) | `src/benchmark/test-catalog.ts` — `resolveTestDescription()` + `listExpectedTestsForSuites()`; static copy for capability/speed/coding, templates for `tool-*`, `skill-*`, `mode-*`. Cards render `.benchmark-test-card-desc` (distinct from runtime `details`); suite headers show `SUITE_INTROS`. Coverage: `test/benchmark/catalog-coverage.test.mts`. Plan: [`documentation/plans/Bug Fixes/POLISH-004-benchmark-test-descriptions.md`](plans/Bug%20Fixes/POLISH-004-benchmark-test-descriptions.md). |
 | UI | `src/ui/benchmark-page.ts`, `src/styles/benchmark-page.css` — live progress bar, responsive per-test card grid (pass checkmark animation), suite sections updated from `onProgress` |
 | Persistence | `GET/POST /api/benchmarks`, `GET /api/benchmarks/:id` → `~/.minnow/benchmarks/`; `localStorage` fallback (`minnow.benchmarks.history`, cap 5) when `npm run dev` only |
 | Transcript drill-down (POLISH-005) | Click a finished test card → `benchmark-transcript-drawer.ts` (read-only messages/tools; reuses `transcript-view.ts`). `TestResult.transcript` / `transcriptMeta` captured via `buildTestResult` in suites; `prepareBenchmarkRunForPersistence` trims oversized JSON before POST. Old runs without `transcript` show empty-state + `details`. |

--- a/documentation/plans/Bug Fixes/POLISH-004-benchmark-test-descriptions.md
+++ b/documentation/plans/Bug Fixes/POLISH-004-benchmark-test-descriptions.md
@@ -2,30 +2,30 @@
 name: POLISH-004 — Benchmark per-test descriptions
 overview: Add static helper copy to each benchmark test card so users understand purpose, method, and pass criteria—not only short labels and runtime details.
 source: documentation/bug-hunt-session-2026-05-24.md § POLISH-004
-status: planned
-scope: plan-only (no implementation in this item)
+status: shipped
+scope: implemented (MIN-94)
 todos:
   - id: catalog-schema
     content: Define BenchmarkTestDescription type and test-catalog module keyed by testId (incl. dynamic patterns)
-    status: pending
+    status: completed
   - id: catalog-content
     content: Author descriptions for all static tests; templates for tool-*, skill-*, mode-* probes
-    status: pending
+    status: completed
   - id: catalog-validation
     content: Add test/benchmark/catalog-coverage.test.mts asserting every emitted testId resolves in catalog
-    status: pending
+    status: completed
   - id: ui-render
     content: Render description on cards in benchmark-page.ts (live + history); separate from runtime details
-    status: pending
+    status: completed
   - id: ui-styles-a11y
     content: Style .benchmark-test-card-desc; optional details/summary expand; aria-labelledby on cards
-    status: pending
+    status: completed
   - id: suite-intros
     content: Optional one-line suite blurbs in suite block headers (capability, speed, tools, …)
-    status: pending
+    status: completed
   - id: docs-context
     content: Link plan from context.md benchmark section; note POLISH-004 in bug-hunt when shipped
-    status: pending
+    status: completed
 isProject: false
 ---
 
@@ -241,12 +241,12 @@ Reuse existing tool/skill `description` fields where accurate; add benchmark-spe
 
 ## Acceptance criteria
 
-- [ ] Every `testId` produced by [`runCapabilitySuite`](../../../src/benchmark/suites/capability.ts), [`runSpeedSuite`](../../../src/benchmark/suites/speed.ts), [`runToolsSuite`](../../../src/benchmark/suites/tools.ts), [`runSkillsSuite`](../../../src/benchmark/suites/skills.ts), [`runModesSuite`](../../../src/benchmark/suites/modes.ts), and [`runCodingSuite`](../../../src/benchmark/suites/coding.ts) resolves to non-empty `purpose` + `passCriteria` via catalog.
-- [ ] Benchmark cards in live run and history view show description distinct from runtime `details`.
-- [ ] Skipped tests (e.g. `cap-usage`, `cap-multimodal`, tool `needs npm start`) explain skip semantics in `passCriteria` or method text.
-- [ ] `npm run test:benchmark` passes including new catalog coverage test.
-- [ ] No change to benchmark scores, persistence schema, or API routes.
-- [ ] `documentation/context.md` benchmark bullet mentions per-test descriptions once shipped.
+- [x] Every `testId` produced by [`runCapabilitySuite`](../../../src/benchmark/suites/capability.ts), [`runSpeedSuite`](../../../src/benchmark/suites/speed.ts), [`runToolsSuite`](../../../src/benchmark/suites/tools.ts), [`runSkillsSuite`](../../../src/benchmark/suites/skills.ts), [`runModesSuite`](../../../src/benchmark/suites/modes.ts), and [`runCodingSuite`](../../../src/benchmark/suites/coding.ts) resolves to non-empty `purpose` + `passCriteria` via catalog.
+- [x] Benchmark cards in live run and history view show description distinct from runtime `details`.
+- [x] Skipped tests (e.g. `cap-usage`, `cap-multimodal`, tool `needs npm start`) explain skip semantics in `passCriteria` or method text.
+- [x] `npm run test:benchmark` passes including new catalog coverage test.
+- [x] No change to benchmark scores, persistence schema, or API routes.
+- [x] `documentation/context.md` benchmark bullet mentions per-test descriptions once shipped.
 
 ---
 

--- a/src/benchmark/test-catalog.ts
+++ b/src/benchmark/test-catalog.ts
@@ -1,0 +1,414 @@
+/**
+ * Static benchmark test descriptions keyed by testId (exact or pattern).
+ *
+ * Resolution order: exact static entry → suite-specific dynamic resolver
+ * (tool-*, skill-*, mode-*, speed-short-*) → null.
+ */
+
+import builtinManifest from '../skills/builtin-manifest.json';
+import { listModes } from '../chat/modes/registry.ts';
+import type { ModeId } from '../chat/modes/types.ts';
+import { BUILT_IN_TOOLS } from '../tools/definitions.ts';
+import type { SuiteId } from './types.ts';
+
+export interface BenchmarkTestDescription {
+  testId: string;
+  suite: SuiteId;
+  label?: string;
+  purpose: string;
+  method: string;
+  passCriteria: string;
+}
+
+export interface ExpectedBenchmarkTest {
+  testId: string;
+  suite: SuiteId;
+  label: string;
+}
+
+/** One-line helper under each suite header on the benchmark page. */
+export const SUITE_INTROS: Record<SuiteId, string> = {
+  capability:
+    'Provider wiring, streaming, usage metadata, tool schema acceptance, model catalog, and optional vision probes.',
+  speed:
+    'Median time-to-first-token and tokens-per-second from fixed prompts; pass means a non-empty completion, not answer quality.',
+  tools:
+    'One serial tool round-trip per built-in tool: model must emit the tool with fixture args; server runs it when required.',
+  skills:
+    'Built-in slash skills load into the system prompt; reply must match a topic regex for each skill.',
+  modes:
+    'Composer mode tool policy: forbidden tools must not run on negative probes; expected tools must emit on positive probes.',
+  coding:
+    'Deterministic coding puzzles plus two LLM-judged explanation/refactor tasks scored by a second model pass.',
+};
+
+const CAPABILITY_DESCRIPTIONS: Record<string, Omit<BenchmarkTestDescription, 'testId' | 'suite'>> = {
+  'cap-provider': {
+    purpose: 'Checks that the active provider record resolves and exposes a base URL.',
+    method: 'Loads provider config from the store without calling the model.',
+    passCriteria: 'Provider id and base URL are present.',
+  },
+  'cap-model': {
+    purpose: 'Confirms a model id is bound for this benchmark run.',
+    method: 'Reads the model id from the run context (same as the header picker).',
+    passCriteria: 'Model id string is non-empty.',
+  },
+  'cap-stream': {
+    purpose: 'Verifies streamed chat completions return visible assistant text.',
+    method: 'One-shot stream with a minimal hello user prompt and low max tokens.',
+    passCriteria: 'Completion text is non-empty after the stream finishes.',
+  },
+  'cap-usage': {
+    purpose: 'Detects token usage fields in the completion stream when the provider reports them.',
+    method: 'Short count-to-three prompt; inspects usage on the final chunk.',
+    passCriteria:
+      'Pass when completion or total token counts appear. Skip (not a failure) when the provider omits usage metadata.',
+  },
+  'cap-tools-schema': {
+    purpose: 'Ensures the provider accepts an OpenAI-style tools array on the request.',
+    method: 'Single completion with a calculate tool schema; answer may be text-only.',
+    passCriteria: 'Request completes without a schema or tools rejection error.',
+  },
+  'cap-models-list': {
+    purpose: 'Validates the provider models catalog endpoint returns entries.',
+    method: 'Fetches models for the active provider once (reused for multimodal gating).',
+    passCriteria: 'Non-empty models array.',
+  },
+  'cap-multimodal': {
+    purpose: 'Exercises image+text input when the active model is marked vision-capable.',
+    method: 'Sends a tiny inline image probe when the catalog marks the model as vision.',
+    passCriteria:
+      'Pass when the model returns scored probe text. Skip when the model is text-only (not a vision model).',
+  },
+};
+
+const SPEED_LONG_DESCRIPTION: Omit<BenchmarkTestDescription, 'testId' | 'suite'> = {
+  purpose: 'Measures sustained tokens-per-second on a longer generation.',
+  method: 'Fixed ~400-word transformer explainer prompt with a higher max token budget.',
+  passCriteria:
+    'Non-empty completion text. Throughput in details is informational; char count alone does not fail the test.',
+};
+
+const CODING_DESCRIPTIONS: Record<string, Omit<BenchmarkTestDescription, 'testId' | 'suite'>> = {
+  'code-fizzbuzz': {
+    purpose: 'Checks multi-step reasoning on a classic FizzBuzz line output.',
+    method: 'Single user prompt asking for 1–15 as a comma-separated line.',
+    passCriteria: 'Output includes 1 and 15 and mentions Fizz.',
+  },
+  'code-reverse': {
+    purpose: 'Validates exact string manipulation without extra prose.',
+    method: 'Reverse the literal string "minnow".',
+    passCriteria: 'Reply matches "wonnim" exactly (after trim).',
+  },
+  'code-fib': {
+    purpose: 'Tests numeric recall for a standard Fibonacci index.',
+    method: 'Ask for the 10th Fibonacci number (0-indexed definition).',
+    passCriteria: 'Answer contains 55.',
+  },
+  'code-json': {
+    purpose: 'Checks JSON-shaped output and key reordering.',
+    method: 'Swap keys in a small JSON object; model must return JSON only.',
+    passCriteria: 'Parsable JSON (or object-shaped text) containing both "a" and "b".',
+  },
+  'code-regex': {
+    purpose: 'Extracts a structured substring with regex-friendly output.',
+    method: 'Find the first email in a short sentence.',
+    passCriteria: 'Reply includes team@minnow.dev.',
+  },
+  'code-sql': {
+    purpose: 'Produces a minimal SQL filter query.',
+    method: 'Ask for names from users where active is true.',
+    passCriteria: 'Contains SELECT and users (case-insensitive).',
+  },
+  'code-bug': {
+    purpose: 'Spots and fixes an obvious arithmetic bug in a function.',
+    method: 'Function returns a-b instead of a+b; reply should be the fixed function.',
+    passCriteria: 'Fixed body uses addition (a+b).',
+  },
+  'code-type': {
+    purpose: 'Explains a TypeScript generic type parameter in plain language.',
+    method: 'One-sentence explanation of T in identity<T>.',
+    passCriteria: 'Mentions generics, type parameters, or placeholders.',
+  },
+  'code-judge-explain': {
+    purpose: 'Judged explanation quality for a short recursion summary.',
+    method: 'Model answers, then a second grading pass scores JSON {pass, reason}.',
+    passCriteria: 'Judge pass flag is true for a sensible two-sentence explanation.',
+  },
+  'code-judge-refactor': {
+    purpose: 'Judged suggestion quality for a small array pipeline refactor.',
+    method: 'Model suggests an improvement; inline judge grades the answer.',
+    passCriteria: 'Judge pass flag is true for a relevant refactor hint.',
+  },
+};
+
+/** Mirrors negative probes in suites/modes.ts (keep in sync). */
+const MODE_NEGATIVE: Partial<Record<ModeId, { forbiddenTool: string }>> = {
+  plan: { forbiddenTool: 'delete_path' },
+  research: { forbiddenTool: 'git_commit' },
+};
+
+/** Mirrors positive probes in suites/modes.ts (keep in sync). */
+const MODE_POSITIVE: Partial<Record<ModeId, { expectedTool: string }>> = {
+  general: { expectedTool: 'read_file' },
+  build: { expectedTool: 'list_directory' },
+  plan: { expectedTool: 'read_file' },
+  research: { expectedTool: 'web_search' },
+  orchestrate: { expectedTool: 'list_directory' },
+  reef: { expectedTool: 'get_datetime' },
+};
+
+function withIds(
+  suite: SuiteId,
+  map: Record<string, Omit<BenchmarkTestDescription, 'testId' | 'suite'>>,
+): Record<string, BenchmarkTestDescription> {
+  const out: Record<string, BenchmarkTestDescription> = {};
+  for (const [testId, body] of Object.entries(map)) {
+    out[testId] = { testId, suite, ...body };
+  }
+  return out;
+}
+
+const STATIC_BY_ID: Record<string, BenchmarkTestDescription> = {
+  ...withIds('capability', CAPABILITY_DESCRIPTIONS),
+  ...withIds('coding', CODING_DESCRIPTIONS),
+  'speed-long-1': { testId: 'speed-long-1', suite: 'speed', ...SPEED_LONG_DESCRIPTION },
+};
+
+function speedShortDescription(index: number): BenchmarkTestDescription {
+  return {
+    testId: `speed-short-${index}`,
+    suite: 'speed',
+    purpose: `Samples time-to-first-token and throughput on short fixed prompt ${index} of 3.`,
+    method: 'Streaming one-shot with the same short local-LLM paragraph prompt.',
+    passCriteria:
+      'Non-empty completion. TTFT/tok/s in meta are informational; zero chars in details can still pass when timing succeeded.',
+  };
+}
+
+function resolveToolDescription(testId: string, label: string): BenchmarkTestDescription | null {
+  const toolId = testId.slice('tool-'.length);
+  const tool = BUILT_IN_TOOLS.find((t) => t.id === toolId);
+  if (!tool) return null;
+
+  const serverNote = tool.serverRequired
+    ? ' Skips when Minnow tool server is offline (run npm start).'
+    : '';
+  const emitNote = tool.serverRequired
+    ? ' Server executes the tool when a call is emitted.'
+    : ' Browser-native or emit-only tools may skip server execution.';
+
+  return {
+    testId,
+    suite: 'tools',
+    label,
+    purpose: tool.description || `Checks the model can call the ${tool.label} tool.`,
+    method: `Fixture user prompt steers a single tool round-trip for \`${toolId}\`.${emitNote}`,
+    passCriteria: `Model emits \`${toolId}\` with expected arguments; execution succeeds when required.${serverNote}`,
+  };
+}
+
+function resolveSkillDescription(testId: string, label: string): BenchmarkTestDescription | null {
+  const skillId = testId.slice('skill-'.length);
+  const skill = (builtinManifest.skills ?? []).find((s) => s.id === skillId);
+  if (!skill) return null;
+
+  return {
+    testId,
+    suite: 'skills',
+    label,
+    purpose: skill.description || `Validates the ${skill.label} built-in skill shapes the reply.`,
+    method: 'Loads skill body into the system prompt, then sends a trigger user message.',
+    passCriteria: 'Assistant reply matches the suite regex for this skill topic.',
+  };
+}
+
+function resolveModeDescription(testId: string, label: string): BenchmarkTestDescription | null {
+  const negMatch = /^mode-(.+)-negative$/.exec(testId);
+  if (negMatch) {
+    const modeId = negMatch[1] as ModeId;
+    const spec = MODE_NEGATIVE[modeId];
+    if (!spec) return null;
+    const mode = listModes().find((m) => m.id === modeId);
+    return {
+      testId,
+      suite: 'modes',
+      label,
+      purpose: `${mode?.label ?? modeId} mode must block destructive or disallowed tool use.`,
+      method: `User prompt requests \`${spec.forbiddenTool}\`; mode system prompt and tool policy apply.`,
+      passCriteria: `The forbidden tool \`${spec.forbiddenTool}\` must not appear in tool calls.`,
+    };
+  }
+
+  const posMatch = /^mode-(.+)-positive$/.exec(testId);
+  if (posMatch) {
+    const modeId = posMatch[1] as ModeId;
+    const spec = MODE_POSITIVE[modeId];
+    if (!spec) return null;
+    const mode = listModes().find((m) => m.id === modeId);
+    const webSkip =
+      spec.expectedTool === 'web_search'
+        ? ' Skips when the tool server is unavailable (web_search needs npm start).'
+        : '';
+    return {
+      testId,
+      suite: 'modes',
+      label,
+      purpose: `${mode?.label ?? modeId} mode should allow and emit an expected everyday tool.`,
+      method: `User prompt asks for \`${spec.expectedTool}\` with mode system prompt enabled.`,
+      passCriteria: `A tool call named \`${spec.expectedTool}\` is present.${webSkip}`,
+    };
+  }
+
+  return null;
+}
+
+/** Plain-language card copy: purpose, method, pass line (kept under ~320 chars when possible). */
+export function formatTestCardDescription(desc: BenchmarkTestDescription): string {
+  return `${desc.purpose} ${desc.method} Pass: ${desc.passCriteria}`;
+}
+
+/**
+ * Resolve helper copy for a benchmark test card.
+ */
+export function resolveTestDescription(
+  testId: string,
+  suite: SuiteId,
+  label: string,
+): BenchmarkTestDescription | null {
+  const exact = STATIC_BY_ID[testId];
+  if (exact) return { ...exact, label: exact.label ?? label };
+
+  const shortMatch = /^speed-short-([1-3])$/.exec(testId);
+  if (shortMatch) {
+    const d = speedShortDescription(Number(shortMatch[1]));
+    return { ...d, label };
+  }
+
+  if (testId.startsWith('tool-')) {
+    return resolveToolDescription(testId, label);
+  }
+  if (testId.startsWith('skill-')) {
+    return resolveSkillDescription(testId, label);
+  }
+  if (testId.startsWith('mode-')) {
+    return resolveModeDescription(testId, label);
+  }
+
+  if (suite === 'speed' && testId === 'speed-long-1') {
+    return { ...SPEED_LONG_DESCRIPTION, testId, suite: 'speed', label };
+  }
+
+  return null;
+}
+
+function expectedCapabilityTests(): ExpectedBenchmarkTest[] {
+  return [
+    { testId: 'cap-provider', suite: 'capability', label: 'Provider reachable' },
+    { testId: 'cap-model', suite: 'capability', label: 'Active model selected' },
+    { testId: 'cap-stream', suite: 'capability', label: 'Streaming completion' },
+    { testId: 'cap-usage', suite: 'capability', label: 'Usage metadata' },
+    { testId: 'cap-tools-schema', suite: 'capability', label: 'Tool schema accepted' },
+    { testId: 'cap-models-list', suite: 'capability', label: 'Models list' },
+    { testId: 'cap-multimodal', suite: 'capability', label: 'Multimodal request' },
+  ];
+}
+
+function expectedSpeedTests(): ExpectedBenchmarkTest[] {
+  return [
+    { testId: 'speed-short-1', suite: 'speed', label: 'Short run 1' },
+    { testId: 'speed-short-2', suite: 'speed', label: 'Short run 2' },
+    { testId: 'speed-short-3', suite: 'speed', label: 'Short run 3' },
+    { testId: 'speed-long-1', suite: 'speed', label: 'Sustained throughput' },
+  ];
+}
+
+const CODING_LABELS: Record<string, string> = {
+  'code-fizzbuzz': 'FizzBuzz line',
+  'code-reverse': 'Reverse string',
+  'code-fib': 'Fibonacci(10)',
+  'code-json': 'JSON transform',
+  'code-regex': 'Regex extract',
+  'code-sql': 'SQL hint',
+  'code-bug': 'Spot bug',
+  'code-type': 'Type signature',
+  'code-judge-explain': 'Explain (judged)',
+  'code-judge-refactor': 'Refactor (judged)',
+};
+
+function expectedCodingTests(): ExpectedBenchmarkTest[] {
+  return Object.keys(CODING_DESCRIPTIONS).map((testId) => ({
+    testId,
+    suite: 'coding' as const,
+    label: CODING_LABELS[testId] ?? testId,
+  }));
+}
+
+function expectedToolsTests(): ExpectedBenchmarkTest[] {
+  return BUILT_IN_TOOLS.map((tool) => ({
+    testId: `tool-${tool.id}`,
+    suite: 'tools' as const,
+    label: tool.label,
+  }));
+}
+
+function expectedSkillsTests(): ExpectedBenchmarkTest[] {
+  return (builtinManifest.skills ?? []).map((skill) => ({
+    testId: `skill-${skill.id}`,
+    suite: 'skills' as const,
+    label: skill.label,
+  }));
+}
+
+function expectedModesTests(): ExpectedBenchmarkTest[] {
+  const tests: ExpectedBenchmarkTest[] = [];
+  for (const mode of listModes()) {
+    const modeId = mode.id as ModeId;
+    if (MODE_NEGATIVE[modeId]) {
+      tests.push({
+        testId: `mode-${modeId}-negative`,
+        suite: 'modes',
+        label: `${mode.label} denies ${MODE_NEGATIVE[modeId]!.forbiddenTool}`,
+      });
+    }
+    if (MODE_POSITIVE[modeId]) {
+      tests.push({
+        testId: `mode-${modeId}-positive`,
+        suite: 'modes',
+        label: `${mode.label} emits ${MODE_POSITIVE[modeId]!.expectedTool}`,
+      });
+    }
+  }
+  return tests;
+}
+
+const SUITE_TEST_LISTERS: Record<SuiteId, () => ExpectedBenchmarkTest[]> = {
+  capability: expectedCapabilityTests,
+  speed: expectedSpeedTests,
+  tools: expectedToolsTests,
+  skills: expectedSkillsTests,
+  modes: expectedModesTests,
+  coding: expectedCodingTests,
+};
+
+/** All test ids the runner emits for the given suites (for coverage tests and future pre-run UI). */
+export function listExpectedTestsForSuites(suiteIds: SuiteId[]): ExpectedBenchmarkTest[] {
+  const out: ExpectedBenchmarkTest[] = [];
+  for (const suiteId of suiteIds) {
+    const lister = SUITE_TEST_LISTERS[suiteId];
+    if (lister) out.push(...lister());
+  }
+  return out;
+}
+
+/** Full battery test ids (all six suites). */
+export function listAllExpectedBenchmarkTests(): ExpectedBenchmarkTest[] {
+  return listExpectedTestsForSuites([
+    'capability',
+    'speed',
+    'tools',
+    'skills',
+    'modes',
+    'coding',
+  ]);
+}

--- a/src/styles/benchmark-page.css
+++ b/src/styles/benchmark-page.css
@@ -286,12 +286,17 @@
 
 .benchmark-suite-block-header {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 10px;
   padding-bottom: 8px;
   border-bottom: 1px solid var(--mn-border);
+}
+
+.benchmark-suite-block-heading {
+  flex: 1;
+  min-width: 0;
 }
 
 .benchmark-suite-block-header h2 {
@@ -301,7 +306,16 @@
   letter-spacing: 0.02em;
 }
 
+.benchmark-suite-block-intro {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--mn-fg-muted);
+  max-width: 52rem;
+}
+
 .benchmark-suite-block-score {
+  flex-shrink: 0;
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
@@ -435,6 +449,17 @@
   line-height: 1.35;
 }
 
+.benchmark-test-card-desc {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--mn-fg-muted);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
 .benchmark-test-card-meta {
   margin: 4px 0 0;
   font-family: var(--font-mono, ui-monospace, monospace);
@@ -445,9 +470,11 @@
 
 .benchmark-test-card-details {
   margin: 6px 0 0;
-  font-size: 12px;
+  font-size: 11px;
+  font-family: var(--font-mono, ui-monospace, monospace);
   color: var(--mn-fg-muted);
   line-height: 1.4;
+  opacity: 0.92;
 }
 
 .benchmark-empty {

--- a/src/ui/benchmark-page.ts
+++ b/src/ui/benchmark-page.ts
@@ -6,6 +6,11 @@ import '../styles/benchmark-page.css';
 import '../styles/sub-agent-drawer.css';
 
 import { runBenchmark, resolveBenchmarkSuites } from '../benchmark/runner.ts';
+import {
+  formatTestCardDescription,
+  resolveTestDescription,
+  SUITE_INTROS,
+} from '../benchmark/test-catalog.ts';
 import { listRuns, loadRun, type BenchmarkRunSummary } from '../benchmark/persistence.ts';
 import type {
   BenchmarkPreset,
@@ -116,6 +121,11 @@ function cardIconKind(result: TestResult, regression: boolean): 'pass' | 'fail' 
   return 'pass';
 }
 
+function testCardDomId(testId: string, suffix: string): string {
+  const slug = testId.replace(/[^a-zA-Z0-9-]/g, '-');
+  return `benchmark-${suffix}-${slug}`;
+}
+
 function renderTestCard(result: TestResult, regression: boolean, animate = false): string {
   const state = cardState(result, regression);
   const icon = cardIconKind(result, regression);
@@ -123,12 +133,22 @@ function renderTestCard(result: TestResult, regression: boolean, animate = false
   const details = result.details?.trim();
   const meta = `${formatDurationMs(result.durationMs)} · ${statusText(result, regression)}${judged}`;
 
-  const ariaLabel = `View transcript: ${result.label}, ${statusText(result, regression)}`;
+  const titleId = testCardDomId(result.testId, 'title');
+  const descId = testCardDomId(result.testId, 'desc');
+  const catalogDesc = resolveTestDescription(result.testId, result.suite, result.label);
+  const descriptionHtml = catalogDesc
+    ? `<p class="benchmark-test-card-desc" id="${escapeHtml(descId)}">${escapeHtml(formatTestCardDescription(catalogDesc))}</p>`
+    : '';
 
-  return `<article class="benchmark-test-card ${state}${animate ? ' is-entering' : ''}" data-test-id="${escapeHtml(result.testId)}" role="button" tabindex="0" aria-label="${escapeHtml(ariaLabel)}">
+  const ariaLabel = `View transcript: ${result.label}, ${statusText(result, regression)}`;
+  const describedBy = catalogDesc ? ` aria-describedby="${escapeHtml(descId)}"` : '';
+  const labelledBy = ` aria-labelledby="${escapeHtml(titleId)}"`;
+
+  return `<article class="benchmark-test-card ${state}${animate ? ' is-entering' : ''}" data-test-id="${escapeHtml(result.testId)}" role="button" tabindex="0" aria-label="${escapeHtml(ariaLabel)}"${labelledBy}${describedBy}>
     <div class="benchmark-test-card-status" aria-hidden="true">${iconSvg(icon)}</div>
     <div class="benchmark-test-card-body">
-      <h3 class="benchmark-test-card-title">${escapeHtml(result.label)}</h3>
+      <h3 class="benchmark-test-card-title" id="${escapeHtml(titleId)}">${escapeHtml(result.label)}</h3>
+      ${descriptionHtml}
       <p class="benchmark-test-card-meta">${escapeHtml(meta)}</p>
       ${details ? `<p class="benchmark-test-card-details">${escapeHtml(details.slice(0, 120))}</p>` : ''}
     </div>
@@ -232,7 +252,10 @@ function ensureSuiteSection(suiteId: SuiteId, running = false): HTMLElement | nu
     section.dataset.suite = suiteId;
     section.innerHTML = `
       <header class="benchmark-suite-block-header">
-        <h2>${escapeHtml(SUITE_LABELS[suiteId])}</h2>
+        <div class="benchmark-suite-block-heading">
+          <h2>${escapeHtml(SUITE_LABELS[suiteId])}</h2>
+          <p class="benchmark-suite-block-intro">${escapeHtml(SUITE_INTROS[suiteId])}</p>
+        </div>
         <span class="benchmark-suite-block-score" data-suite-score>—</span>
       </header>
       <div class="benchmark-test-grid" data-suite-tests></div>
@@ -441,7 +464,10 @@ function renderSuites(run: BenchmarkRun, compare: BenchmarkRun | null): void {
       const total = suite.passed + suite.failed + suite.skipped;
       return `<section class="benchmark-suite-block" data-suite="${suite.id}">
         <header class="benchmark-suite-block-header">
-          <h2>${escapeHtml(suite.label)}</h2>
+          <div class="benchmark-suite-block-heading">
+            <h2>${escapeHtml(suite.label)}</h2>
+            <p class="benchmark-suite-block-intro">${escapeHtml(SUITE_INTROS[suite.id])}</p>
+          </div>
           <span class="benchmark-suite-block-score">${suite.passed}/${total} · ${formatScore(suite.score)}</span>
         </header>
         <div class="benchmark-test-grid">${cards}</div>

--- a/test/benchmark/catalog-coverage.test.mts
+++ b/test/benchmark/catalog-coverage.test.mts
@@ -1,0 +1,46 @@
+/**
+ * Every benchmark testId emitted by the runner must resolve in test-catalog.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { resolveBenchmarkSuites } from '../../src/benchmark/runner.ts';
+import {
+  listAllExpectedBenchmarkTests,
+  listExpectedTestsForSuites,
+  resolveTestDescription,
+} from '../../src/benchmark/test-catalog.ts';
+import type { SuiteId } from '../../src/benchmark/types.ts';
+
+function assertCatalogCovers(testId: string, suite: SuiteId, label: string): void {
+  const desc = resolveTestDescription(testId, suite, label);
+  assert.ok(desc, `missing catalog entry for ${suite}/${testId}`);
+  assert.ok(desc.purpose.trim(), `${testId}: purpose`);
+  assert.ok(desc.passCriteria.trim(), `${testId}: passCriteria`);
+  assert.ok(desc.method.trim(), `${testId}: method`);
+}
+
+describe('benchmark test catalog coverage', () => {
+  test('full battery resolves every emitted testId', () => {
+    const tests = listAllExpectedBenchmarkTests();
+    assert.ok(tests.length >= 80, `expected large battery, got ${tests.length}`);
+    for (const t of tests) {
+      assertCatalogCovers(t.testId, t.suite, t.label);
+    }
+  });
+
+  test('quick preset suites resolve', () => {
+    const suiteIds = resolveBenchmarkSuites('quick');
+    const tests = listExpectedTestsForSuites(suiteIds);
+    for (const t of tests) {
+      assertCatalogCovers(t.testId, t.suite, t.label);
+    }
+  });
+
+  test('full preset matches all-suite list', () => {
+    const fullSuites = resolveBenchmarkSuites('full');
+    const fromPreset = listExpectedTestsForSuites(fullSuites);
+    const all = listAllExpectedBenchmarkTests();
+    assert.equal(fromPreset.length, all.length);
+  });
+});

--- a/test/benchmark/test-catalog.test.mts
+++ b/test/benchmark/test-catalog.test.mts
@@ -1,0 +1,67 @@
+/**
+ * Spot checks for benchmark test description resolver.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  formatTestCardDescription,
+  resolveTestDescription,
+  SUITE_INTROS,
+} from '../../src/benchmark/test-catalog.ts';
+
+describe('resolveTestDescription', () => {
+  test('cap-stream static entry', () => {
+    const desc = resolveTestDescription('cap-stream', 'capability', 'Streaming completion');
+    assert.ok(desc);
+    assert.match(desc.purpose, /stream/i);
+    assert.match(desc.passCriteria, /non-empty/i);
+  });
+
+  test('speed-short-2 uses timing-only pass criteria', () => {
+    const desc = resolveTestDescription('speed-short-2', 'speed', 'Short run 2');
+    assert.ok(desc);
+    assert.match(desc.passCriteria, /non-empty/i);
+    assert.match(desc.passCriteria, /informational|chars/i);
+  });
+
+  test('tool-read_file dynamic entry', () => {
+    const desc = resolveTestDescription('tool-read_file', 'tools', 'Read file');
+    assert.ok(desc);
+    assert.match(desc.method, /read_file/);
+    assert.match(desc.passCriteria, /read_file/);
+  });
+
+  test('mode-build-positive dynamic entry', () => {
+    const desc = resolveTestDescription('mode-build-positive', 'modes', 'Build emits list_directory');
+    assert.ok(desc);
+    assert.match(desc.passCriteria, /list_directory/);
+  });
+
+  test('cap-usage documents skip semantics', () => {
+    const desc = resolveTestDescription('cap-usage', 'capability', 'Usage metadata');
+    assert.ok(desc);
+    assert.match(desc.passCriteria, /skip/i);
+  });
+
+  test('formatTestCardDescription includes pass line', () => {
+    const desc = resolveTestDescription('code-fizzbuzz', 'coding', 'FizzBuzz line');
+    assert.ok(desc);
+    const text = formatTestCardDescription(desc);
+    assert.match(text, /^.+ Pass: /);
+    assert.ok(text.length > desc.purpose.length);
+  });
+
+  test('unknown testId returns null', () => {
+    assert.equal(resolveTestDescription('not-a-real-test', 'capability', 'Nope'), null);
+  });
+});
+
+describe('SUITE_INTROS', () => {
+  test('every suite has intro copy', () => {
+    const suites = ['capability', 'speed', 'tools', 'skills', 'modes', 'coding'] as const;
+    for (const id of suites) {
+      assert.ok(SUITE_INTROS[id].trim().length > 20, id);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds static helper copy to every benchmark test card so users understand **purpose**, **method**, and **pass criteria**—separate from runtime `details` snippets.

## Changes

- **`src/benchmark/test-catalog.ts`** — central catalog with `resolveTestDescription()`, `formatTestCardDescription()`, `listExpectedTestsForSuites()`, and `SUITE_INTROS`
- **Static entries** for capability, speed (incl. `speed-short-*`), and coding probes
- **Dynamic templates** for `tool-*` (from `BUILT_IN_TOOLS`), `skill-*` (builtin manifest), and `mode-*` (mirrors modes suite probes)
- **`benchmark-page.ts`** — `.benchmark-test-card-desc` on live + history cards; `aria-labelledby` / `aria-describedby`; suite header blurbs
- **`benchmark-page.css`** — description clamp (3 lines), distinct styling for runtime details
- **Tests** — `test/benchmark/catalog-coverage.test.mts`, `test/benchmark/test-catalog.test.mts`
- **Docs** — `documentation/context.md`, plan marked shipped

## Verification

- `npm run test:benchmark` — all 76 tests pass
- No changes to scoring, persistence schema, or suite runner logic

## Out of scope (per plan)

- Pre-run placeholder cards (Phase 2)
- POLISH-005 transcript changes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-94](https://linear.app/minnowai/issue/MIN-94/polish-004-benchmark-test-descriptions)

<div><a href="https://cursor.com/agents/bc-5062c4a5-a7a8-4747-9b8d-e79482f6da4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5062c4a5-a7a8-4747-9b8d-e79482f6da4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

