### PR TITLE
🔐 Encrypted credential storage (MIN-117)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -8,7 +8,7 @@ User-facing setup and quick start: [`README.md`](../README.md).
 
 ## Odysseus port plan pack
 
-Implementation-ready plans for the 13 selected Odysseus-to-Minnow candidate ports live in [`documentation/plans/Odysseus port/`](plans/Odysseus%20port/). Start with the folder [`README.md`](plans/Odysseus%20port/README.md) for dependency order and Linear tracking ([project](https://linear.app/minnowai/project/odysseus-to-minnow-port-9e0acc5cf9c9)). **Prompt-injection defense (shipped MIN-124):** [`src/lib/untrusted.mjs`](../src/lib/untrusted.mjs) + [`server/security/untrusted.js`](../server/security/untrusted.js) fence untrusted text with `<<<UNTRUSTED_SOURCE_DATA source="…">>>` … `<<<END_UNTRUSTED_SOURCE_DATA>>>`; policy in [`default.full.md`](../src/chat/prompts/base/default.full.md) / [`default.lite.md`](../src/chat/prompts/base/default.lite.md) and sub-agent prompts. Injection sites: memory retrieve (`server/memory/retrieve.js`), web fetch/RAG (`server/tools/fetch-web-content.js`), Deep Research extraction (`server/research/extractor.js`), `read_document` + composer text attachments, research report discuss (`src/research/panel.ts`), and server tool middleware (`server/runtime/tools-middleware.js` for web/search/MCP). Deferred v1: skill body injection, browser CDP text, sub-agent structured outcomes. Tests: `test/security/untrusted.test.mjs`, `test/memory/untrusted.test.mjs`. Encrypted secrets (`odysseus-port-12`) is next.
+Implementation-ready plans for the 13 selected Odysseus-to-Minnow candidate ports live in [`documentation/plans/Odysseus port/`](plans/Odysseus%20port/). Start with the folder [`README.md`](plans/Odysseus%20port/README.md) for dependency order and Linear tracking ([project](https://linear.app/minnowai/project/odysseus-to-minnow-port-9e0acc5cf9c9)). **Prompt-injection defense (shipped MIN-124):** [`src/lib/untrusted.mjs`](../src/lib/untrusted.mjs) + [`server/security/untrusted.js`](../server/security/untrusted.js) fence untrusted text with `<<<UNTRUSTED_SOURCE_DATA source="…">>>` … `<<<END_UNTRUSTED_SOURCE_DATA>>>`; policy in [`default.full.md`](../src/chat/prompts/base/default.full.md) / [`default.lite.md`](../src/chat/prompts/base/default.lite.md) and sub-agent prompts. Injection sites: memory retrieve (`server/memory/retrieve.js`), web fetch/RAG (`server/tools/fetch-web-content.js`), Deep Research extraction (`server/research/extractor.js`), `read_document` + composer text attachments, research report discuss (`src/research/panel.ts`), and server tool middleware (`server/runtime/tools-middleware.js` for web/search/MCP). Deferred v1: skill body injection, browser CDP text, sub-agent structured outcomes. Tests: `test/security/untrusted.test.mjs`, `test/memory/untrusted.test.mjs`. **Encrypted credential storage (shipped MIN-117):** [`server/security/secret-box.js`](../server/security/secret-box.js) — AES-256-GCM envelopes for secrets at rest; file key at `~/.minnow/.key` (`0o600` on Unix). Provider `secrets.json` files migrate from plaintext on first read via [`server/providers/store.js`](../server/providers/store.js). Shared helpers: `readEncryptedJsonFile` / `writeEncryptedJsonFile` for downstream webhook/email/calendar/voice/image stores. **Key loss:** deleting or rotating `.key` makes encrypted secrets unrecoverable — re-enter credentials in Settings → Providers. Tests: `test/security/secret-box.test.mjs`, `test/security/secret-migration.test.mjs`.
 
 ## Product backlog (features 01–29)
 
@@ -168,6 +168,7 @@ On first `npm start`, the server logs `Minnow data: <path>` and creates the layo
 
 ```text
 ~/.minnow/
+  .key                     # AES-256 secret-box key (32 random bytes, base64, 0o600; never in git)
   config.json              # schemaVersion, activeProviderId, toolSecurity.filesystemAccess, …
   sessions/state.json      # full SessionState blob (all chats — canonical)
   tools.json               # ToolConfig (permissions, mirrored enabled; legacy webSearchProvider + keys)
@@ -180,7 +181,7 @@ On first `npm start`, the server logs `Minnow data: <path>` and creates the layo
   providers/               # one dir per provider (Step 03)
     lm-studio-local/
       profile.json         # label, baseUrl, apiKind, paths, optional constrainedToolCalls override
-      secrets.json         # apiKey, bearerToken (0o600 on Unix; never in git)
+      secrets.json         # encrypted envelope (AES-256-GCM via secret-box; 0o600 on Unix; never in git)
       capabilities.json    # per-model matrix (MIN-48) + structured-output flags (#10)
   mcp/                     # scaffold (Step 18)
   lsp/                     # scaffold (Step 17)
@@ -930,7 +931,7 @@ Registered in [`server/providers/routes.js`](../server/providers/routes.js) befo
 | `POST` | `/api/providers` | Create provider dir + `profile.json` |
 | `PUT` | `/api/providers/:id` | Update profile (non-secret) |
 | `DELETE` | `/api/providers/:id` | Remove provider (**409** if last) |
-| `PUT` | `/api/providers/:id/secrets` | Update `secrets.json`; response redacts values |
+| `PUT` | `/api/providers/:id/secrets` | Update encrypted `secrets.json`; response redacts values |
 | `POST` | `/api/providers/:id/set-active` | Sets `config.json` `activeProviderId` |
 | `GET` | `/api/providers/:id/models` | Proxy upstream models (auth injected) |
 | `POST` | `/api/providers/:id/models/load` | Proxy model load (LM Studio v0) |

--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@
             <div class="field">
               <label for="settingsProvidersAddApiKey">API key (optional)</label>
               <input type="password" id="settingsProvidersAddApiKey" name="apiKey" autocomplete="off" spellcheck="false" placeholder="Leave empty if the server needs no key">
-              <p class="field-hint">Stored in <code>secrets.json</code> on the server only; never returned to the browser.</p>
+              <p class="field-hint">Stored encrypted in <code>secrets.json</code> on the server only; never returned to the browser. If you delete <code>~/.minnow/.key</code>, saved keys cannot be recovered — re-enter them here.</p>
             </div>
             <label class="settings-toggle-row">
               <input type="checkbox" id="settingsProvidersAddEnabled" name="enabled" checked>

--- a/server/providers/store.js
+++ b/server/providers/store.js
@@ -6,6 +6,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { getMinnowHome } from '../config/home.js';
 import { readConfigJson, writeConfigJson } from '../config/store.js';
+import {
+  readEncryptedJsonFile,
+  writeEncryptedJsonFile,
+} from '../security/secret-box.js';
 import { buildAuthHeaders, secretsFlags } from './auth-headers.js';
 import { getDefaultPaths, getProviderCapabilities } from './paths.js';
 import {
@@ -91,17 +95,26 @@ async function readProfile(id) {
   return JSON.parse(raw);
 }
 
+const EMPTY_SECRETS = { apiKey: '', bearerToken: '', headerOverrides: {} };
+
 /**
  * @param {string} id
  */
 async function readSecrets(id) {
   const file = path.join(providerDir(id), 'secrets.json');
   try {
-    const raw = await fs.readFile(file, 'utf8');
-    return JSON.parse(raw);
+    const secrets = await readEncryptedJsonFile(file, EMPTY_SECRETS);
+    return {
+      apiKey: typeof secrets.apiKey === 'string' ? secrets.apiKey : '',
+      bearerToken: typeof secrets.bearerToken === 'string' ? secrets.bearerToken : '',
+      headerOverrides:
+        secrets.headerOverrides && typeof secrets.headerOverrides === 'object'
+          ? secrets.headerOverrides
+          : {},
+    };
   } catch (err) {
     if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') {
-      return { apiKey: '', bearerToken: '', headerOverrides: {} };
+      return { ...EMPTY_SECRETS };
     }
     throw err;
   }
@@ -128,9 +141,7 @@ async function writeSecrets(id, secrets) {
   const dir = providerDir(id);
   await fs.mkdir(dir, { recursive: true });
   const file = path.join(dir, 'secrets.json');
-  const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
-  await fs.writeFile(tmp, `${JSON.stringify(secrets, null, 2)}\n`, 'utf8');
-  await fs.rename(tmp, file);
+  await writeEncryptedJsonFile(file, secrets);
   await chmodSecrets(file);
 }
 

--- a/server/security/secret-box.js
+++ b/server/security/secret-box.js
@@ -1,0 +1,299 @@
+/**
+ * AES-256-GCM encrypted secret storage for Minnow credentials at rest.
+ * Key file: ~/.minnow/.key (32-byte random, base64, mode 0o600 on Unix).
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getMinnowHome } from '../config/home.js';
+
+const ENVELOPE_VERSION = 1;
+const ALGORITHM = 'aes-256-gcm';
+const KEY_SOURCE_FILE = 'file';
+const IV_BYTES = 12;
+const KEY_BYTES = 32;
+
+/** Cached raw key bytes for this process. */
+let cachedKeyBytes = null;
+
+/** Whether the key file was created during this process. */
+let keyCreatedThisProcess = false;
+
+/**
+ * @returns {string}
+ */
+function secretKeyPath() {
+  return path.join(getMinnowHome(), '.key');
+}
+
+/**
+ * Best-effort restrictive permissions on Unix.
+ * @param {string} filePath
+ * @param {number} mode
+ */
+async function chmodSafe(filePath, mode) {
+  try {
+    await fs.chmod(filePath, mode);
+  } catch {
+    /* ignore on Windows or unsupported FS */
+  }
+}
+
+/**
+ * Load or create the file-based encryption key.
+ * @returns {Promise<Buffer>}
+ */
+async function loadFileKeyBytes() {
+  if (cachedKeyBytes) {
+    return cachedKeyBytes;
+  }
+
+  const keyPath = secretKeyPath();
+  try {
+    const raw = (await fs.readFile(keyPath, 'utf8')).trim();
+    const decoded = Buffer.from(raw, 'base64');
+    if (decoded.length !== KEY_BYTES) {
+      throw new Error('Secret encryption key has invalid length');
+    }
+    cachedKeyBytes = decoded;
+    return cachedKeyBytes;
+  } catch (err) {
+    if (/** @type {NodeJS.ErrnoException} */ (err).code !== 'ENOENT') {
+      throw err;
+    }
+  }
+
+  await fs.mkdir(getMinnowHome(), { recursive: true });
+  const key = crypto.randomBytes(KEY_BYTES);
+  const encoded = key.toString('base64');
+  await fs.writeFile(keyPath, `${encoded}\n`, 'utf8');
+  await chmodSafe(keyPath, 0o600);
+  keyCreatedThisProcess = true;
+  cachedKeyBytes = key;
+  return cachedKeyBytes;
+}
+
+/**
+ * Resolve the encryption key for a stored payload.
+ * @param {string} keySource
+ * @returns {Promise<Buffer>}
+ */
+async function resolveKeyForSource(keySource) {
+  if (keySource === KEY_SOURCE_FILE) {
+    return loadFileKeyBytes();
+  }
+  throw new Error(`Unsupported secret key source: ${keySource}`);
+}
+
+/**
+ * Build additional authenticated data bound into the GCM tag.
+ * @param {number} version
+ * @param {string} keySource
+ * @returns {Buffer}
+ */
+function buildAad(version, keySource) {
+  return Buffer.from(`${version}|${keySource}|${ALGORITHM}`, 'utf8');
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isEncryptedSecretPayload(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    /** @type {{ encrypted?: boolean, version?: number }} */ (value).encrypted === true &&
+    /** @type {{ version?: number }} */ (value).version === ENVELOPE_VERSION
+  );
+}
+
+/**
+ * Metadata about the active secret encryption key (no secret material).
+ * @returns {Promise<{ keySource: string, keyPath: string, exists: boolean, createdThisProcess: boolean }>}
+ */
+export async function loadSecretKeyMetadata() {
+  const keyPath = secretKeyPath();
+  let exists = false;
+  try {
+    await fs.access(keyPath);
+    exists = true;
+  } catch {
+    exists = false;
+  }
+
+  if (!exists) {
+    await loadFileKeyBytes();
+    exists = true;
+  }
+
+  return {
+    keySource: KEY_SOURCE_FILE,
+    keyPath,
+    exists,
+    createdThisProcess: keyCreatedThisProcess,
+  };
+}
+
+/**
+ * Encrypt a UTF-8 plaintext string into a versioned JSON envelope.
+ * @param {string} plaintext
+ * @returns {Promise<object>}
+ */
+export async function encryptSecretPayload(plaintext) {
+  if (typeof plaintext !== 'string') {
+    throw new TypeError('encryptSecretPayload expects a string');
+  }
+
+  const key = await loadFileKeyBytes();
+  const iv = crypto.randomBytes(IV_BYTES);
+  const aad = buildAad(ENVELOPE_VERSION, KEY_SOURCE_FILE);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  cipher.setAAD(aad);
+
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    version: ENVELOPE_VERSION,
+    encrypted: true,
+    keySource: KEY_SOURCE_FILE,
+    algorithm: ALGORITHM,
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+    ciphertext: ciphertext.toString('base64'),
+  };
+}
+
+/**
+ * Decrypt a versioned envelope back to UTF-8 plaintext.
+ * @param {object} box
+ * @returns {Promise<string>}
+ */
+export async function decryptSecretPayload(box) {
+  if (!isEncryptedSecretPayload(box)) {
+    throw new Error('Value is not an encrypted secret payload');
+  }
+
+  const keySource =
+    typeof box.keySource === 'string' && box.keySource.trim()
+      ? box.keySource.trim()
+      : KEY_SOURCE_FILE;
+
+  const ivRaw = typeof box.iv === 'string' ? box.iv : '';
+  const tagRaw = typeof box.tag === 'string' ? box.tag : '';
+  const ciphertextRaw = typeof box.ciphertext === 'string' ? box.ciphertext : '';
+  if (!ivRaw || !tagRaw || !ciphertextRaw) {
+    throw new Error('Encrypted secret payload is missing required fields');
+  }
+
+  if (box.algorithm !== ALGORITHM) {
+    throw new Error('Unsupported secret encryption algorithm');
+  }
+
+  const iv = Buffer.from(ivRaw, 'base64');
+  const tag = Buffer.from(tagRaw, 'base64');
+  const ciphertext = Buffer.from(ciphertextRaw, 'base64');
+  if (iv.length !== IV_BYTES) {
+    throw new Error('Encrypted secret payload has invalid IV');
+  }
+
+  const key = await resolveKeyForSource(keySource);
+  const aad = buildAad(ENVELOPE_VERSION, keySource);
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAAD(aad);
+  decipher.setAuthTag(tag);
+
+  try {
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+  } catch {
+    throw new Error('Stored credentials could not be decrypted (wrong key or corrupt data)');
+  }
+}
+
+/**
+ * Read JSON from disk, decrypting when the file uses the secret envelope.
+ * Plaintext legacy files are migrated to encrypted form on read.
+ * @param {string} filePath
+ * @param {object} [defaults]
+ * @returns {Promise<object>}
+ */
+export async function readEncryptedJsonFile(filePath, defaults = {}) {
+  let rawText;
+  try {
+    rawText = await fs.readFile(filePath, 'utf8');
+  } catch (err) {
+    if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') {
+      return { ...defaults };
+    }
+    throw err;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    throw new Error('Secret file contains invalid JSON');
+  }
+
+  if (isEncryptedSecretPayload(parsed)) {
+    const plaintext = await decryptSecretPayload(parsed);
+    try {
+      return JSON.parse(plaintext);
+    } catch {
+      throw new Error('Decrypted secret file contains invalid JSON');
+    }
+  }
+
+  if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    await writeEncryptedJsonFile(filePath, parsed);
+    return parsed;
+  }
+
+  throw new Error('Secret file has unsupported format');
+}
+
+/**
+ * Encrypt and atomically write JSON to disk.
+ * @param {string} filePath
+ * @param {object} value
+ * @returns {Promise<void>}
+ */
+export async function writeEncryptedJsonFile(filePath, value) {
+  const plaintext = JSON.stringify(value);
+  const envelope = await encryptSecretPayload(plaintext);
+  const content = `${JSON.stringify(envelope, null, 2)}\n`;
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.writeFile(tmp, content, 'utf8');
+
+  const written = await fs.readFile(tmp, 'utf8');
+  const verify = JSON.parse(written);
+  if (!isEncryptedSecretPayload(verify)) {
+    throw new Error('Failed to verify encrypted secret write');
+  }
+  await decryptSecretPayload(verify);
+
+  await fs.rename(tmp, filePath);
+  await chmodSafe(filePath, 0o600);
+}
+
+/** Reset cached key state (tests only). */
+export function resetSecretBoxCacheForTests() {
+  cachedKeyBytes = null;
+  keyCreatedThisProcess = false;
+}
+
+/**
+ * Inject a fixed key for tests (tests only).
+ * @param {Buffer} keyBytes
+ */
+export function setSecretKeyBytesForTests(keyBytes) {
+  if (!Buffer.isBuffer(keyBytes) || keyBytes.length !== KEY_BYTES) {
+    throw new Error('Test secret key must be a 32-byte Buffer');
+  }
+  cachedKeyBytes = Buffer.from(keyBytes);
+  keyCreatedThisProcess = false;
+}

--- a/src/ui/settings-providers.ts
+++ b/src/ui/settings-providers.ts
@@ -391,7 +391,9 @@ function buildProviderEditForm(provider: ProviderPublic): HTMLFormElement {
   const keyHint = el(
     'p',
     'field-hint',
-    provider.hasApiKey ? 'A key is saved on the server (not shown here).' : 'No API key saved yet.',
+    provider.hasApiKey
+      ? 'A key is saved on the server (not shown here). Keys are encrypted at rest; deleting ~/.minnow/.key makes them unrecoverable.'
+      : 'No API key saved yet. Keys are encrypted at rest under ~/.minnow/.key.',
   );
   keyField.append(keyHint);
   form.append(keyField);

--- a/test/security/secret-box.test.mjs
+++ b/test/security/secret-box.test.mjs
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for server/security/secret-box.js (Odysseus port #12).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { resetMinnowHomeCache } from '../../server/config/home.js';
+import {
+  decryptSecretPayload,
+  encryptSecretPayload,
+  isEncryptedSecretPayload,
+  loadSecretKeyMetadata,
+  readEncryptedJsonFile,
+  resetSecretBoxCacheForTests,
+  setSecretKeyBytesForTests,
+  writeEncryptedJsonFile,
+} from '../../server/security/secret-box.js';
+
+const FIXED_KEY_A = Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'utf8');
+const FIXED_KEY_B = Buffer.from('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'utf8');
+const PLAINTEXT_FIXTURE = '{"apiKey":"sk-fixed-test","bearerToken":""}';
+
+function setTestHome() {
+  resetMinnowHomeCache();
+  resetSecretBoxCacheForTests();
+  const dir = path.join('/tmp', `minnow-secret-box-${process.pid}-${Date.now()}`);
+  process.env.MINNOW_HOME = dir;
+  return dir;
+}
+
+async function rmTestHome(dir) {
+  resetMinnowHomeCache();
+  resetSecretBoxCacheForTests();
+  delete process.env.MINNOW_HOME;
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+describe('isEncryptedSecretPayload', () => {
+  test('returns true for version 1 envelope', () => {
+    assert.equal(
+      isEncryptedSecretPayload({ version: 1, encrypted: true, keySource: 'file' }),
+      true,
+    );
+  });
+
+  test('returns false for plaintext secrets object', () => {
+    assert.equal(isEncryptedSecretPayload({ apiKey: 'x', bearerToken: '' }), false);
+  });
+
+  test('returns false for wrong version', () => {
+    assert.equal(isEncryptedSecretPayload({ version: 2, encrypted: true }), false);
+  });
+});
+
+describe('encryptSecretPayload / decryptSecretPayload', () => {
+  /** @type {string | undefined} */
+  let home;
+
+  beforeEach(() => {
+    home = setTestHome();
+    setSecretKeyBytesForTests(FIXED_KEY_A);
+  });
+
+  afterEach(async () => {
+    if (home) await rmTestHome(home);
+  });
+
+  test('round-trip preserves plaintext', async () => {
+    const plaintext = PLAINTEXT_FIXTURE;
+    const box = await encryptSecretPayload(plaintext);
+    assert.equal(isEncryptedSecretPayload(box), true);
+    assert.equal(box.algorithm, 'aes-256-gcm');
+    assert.equal(box.keySource, 'file');
+    const decrypted = await decryptSecretPayload(box);
+    assert.equal(decrypted, plaintext);
+  });
+
+  test('tampered ciphertext fails decrypt', async () => {
+    const box = await encryptSecretPayload(PLAINTEXT_FIXTURE);
+    const bytes = Buffer.from(box.ciphertext, 'base64');
+    bytes[0] ^= 0xff;
+    const tampered = { ...box, ciphertext: bytes.toString('base64') };
+    await assert.rejects(
+      () => decryptSecretPayload(tampered),
+      /could not be decrypted/,
+    );
+  });
+
+  test('tampered auth tag fails decrypt', async () => {
+    const box = await encryptSecretPayload(PLAINTEXT_FIXTURE);
+    const bytes = Buffer.from(box.tag, 'base64');
+    bytes[0] ^= 0xff;
+    const tampered = { ...box, tag: bytes.toString('base64') };
+    await assert.rejects(
+      () => decryptSecretPayload(tampered),
+      /could not be decrypted/,
+    );
+  });
+
+  test('wrong key fails decrypt', async () => {
+    const box = await encryptSecretPayload(PLAINTEXT_FIXTURE);
+    setSecretKeyBytesForTests(FIXED_KEY_B);
+    await assert.rejects(
+      () => decryptSecretPayload(box),
+      /could not be decrypted/,
+    );
+  });
+
+  test('malformed envelope missing fields throws', async () => {
+    await assert.rejects(
+      () => decryptSecretPayload({ version: 1, encrypted: true, keySource: 'file' }),
+      /missing required fields/,
+    );
+  });
+
+  test('unsupported algorithm throws', async () => {
+    const box = await encryptSecretPayload(PLAINTEXT_FIXTURE);
+    await assert.rejects(
+      () => decryptSecretPayload({ ...box, algorithm: 'aes-128-gcm' }),
+      /Unsupported secret encryption algorithm/,
+    );
+  });
+});
+
+describe('readEncryptedJsonFile / writeEncryptedJsonFile', () => {
+  /** @type {string | undefined} */
+  let home;
+
+  beforeEach(() => {
+    home = setTestHome();
+    setSecretKeyBytesForTests(FIXED_KEY_A);
+  });
+
+  afterEach(async () => {
+    if (home) await rmTestHome(home);
+  });
+
+  test('missing file returns defaults', async () => {
+    const file = path.join(home, 'missing.json');
+    const value = await readEncryptedJsonFile(file, { apiKey: '', bearerToken: '' });
+    assert.deepEqual(value, { apiKey: '', bearerToken: '' });
+  });
+
+  test('write then read round-trip', async () => {
+    const file = path.join(home, 'secrets.json');
+    const payload = { apiKey: 'sk-fixed', bearerToken: 'tok-fixed', headerOverrides: {} };
+    await writeEncryptedJsonFile(file, payload);
+    const raw = JSON.parse(await fs.readFile(file, 'utf8'));
+    assert.equal(isEncryptedSecretPayload(raw), true);
+    const readBack = await readEncryptedJsonFile(file, {});
+    assert.deepEqual(readBack, payload);
+  });
+});
+
+describe('loadSecretKeyMetadata', () => {
+  /** @type {string | undefined} */
+  let home;
+
+  beforeEach(() => {
+    home = setTestHome();
+  });
+
+  afterEach(async () => {
+    if (home) await rmTestHome(home);
+  });
+
+  test('creates key file on first use', async () => {
+    const meta = await loadSecretKeyMetadata();
+    assert.equal(meta.keySource, 'file');
+    assert.equal(meta.exists, true);
+    assert.equal(meta.createdThisProcess, true);
+    const raw = (await fs.readFile(meta.keyPath, 'utf8')).trim();
+    const decoded = Buffer.from(raw, 'base64');
+    assert.equal(decoded.length, 32);
+  });
+
+  test('generated key uses restrictive permissions when supported', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+    const meta = await loadSecretKeyMetadata();
+    const stat = await fs.stat(meta.keyPath);
+    assert.equal(stat.mode & 0o777, 0o600);
+  });
+});
+
+describe('key generation', () => {
+  /** @type {string | undefined} */
+  let home;
+
+  beforeEach(() => {
+    home = setTestHome();
+    resetSecretBoxCacheForTests();
+  });
+
+  afterEach(async () => {
+    if (home) await rmTestHome(home);
+  });
+
+  test('creates random 32-byte key', async () => {
+    await encryptSecretPayload('test');
+    const keyPath = path.join(home, '.key');
+    const raw = (await fs.readFile(keyPath, 'utf8')).trim();
+    const decoded = Buffer.from(raw, 'base64');
+    assert.equal(decoded.length, 32);
+  });
+});

--- a/test/security/secret-migration.test.mjs
+++ b/test/security/secret-migration.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Provider secrets migration tests (plaintext → encrypted at rest).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { resetMinnowHomeCache } from '../../server/config/home.js';
+import { buildAuthHeaders, secretsFlags } from '../../server/providers/auth-headers.js';
+import { getProviderRuntime, listProviders } from '../../server/providers/store.js';
+import { isEncryptedSecretPayload, resetSecretBoxCacheForTests } from '../../server/security/secret-box.js';
+
+const PROVIDER_ID = 'test-provider-fixed';
+const PLAINTEXT_SECRETS = {
+  apiKey: 'sk-migration-fixed-key',
+  bearerToken: '',
+  headerOverrides: { 'X-Test-Override': 'override-fixed' },
+};
+
+function setTestHome() {
+  resetMinnowHomeCache();
+  resetSecretBoxCacheForTests();
+  const dir = path.join('/tmp', `minnow-secret-migration-${process.pid}-${Date.now()}`);
+  process.env.MINNOW_HOME = dir;
+  return dir;
+}
+
+async function rmTestHome(dir) {
+  resetMinnowHomeCache();
+  resetSecretBoxCacheForTests();
+  delete process.env.MINNOW_HOME;
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+async function seedProvider(home) {
+  const dir = path.join(home, 'providers', PROVIDER_ID);
+  await fs.mkdir(dir, { recursive: true });
+  const now = '2026-01-01T00:00:00.000Z';
+  await fs.writeFile(
+    path.join(dir, 'profile.json'),
+    `${JSON.stringify(
+      {
+        id: PROVIDER_ID,
+        label: 'Test Provider',
+        baseUrl: 'http://127.0.0.1:1234',
+        apiKind: 'openai-v1',
+        enabled: true,
+        authStyle: 'bearer',
+        modelsPath: '/v1/models',
+        chatCompletionsPath: '/v1/chat/completions',
+        customHeaders: {},
+        createdAt: now,
+        updatedAt: now,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  );
+  await fs.writeFile(
+    path.join(dir, 'secrets.json'),
+    `${JSON.stringify(PLAINTEXT_SECRETS, null, 2)}\n`,
+    'utf8',
+  );
+  await fs.writeFile(
+    path.join(home, 'config.json'),
+    `${JSON.stringify({ schemaVersion: 1, activeProviderId: PROVIDER_ID }, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+describe('provider secrets migration', () => {
+  /** @type {string | undefined} */
+  let home;
+
+  beforeEach(async () => {
+    home = setTestHome();
+    await seedProvider(home);
+  });
+
+  afterEach(async () => {
+    if (home) await rmTestHome(home);
+  });
+
+  test('plaintext secrets.json migrates to encrypted on read', async () => {
+    const secretsPath = path.join(home, 'providers', PROVIDER_ID, 'secrets.json');
+    const before = JSON.parse(await fs.readFile(secretsPath, 'utf8'));
+    assert.equal(isEncryptedSecretPayload(before), false);
+
+    const { providers } = await listProviders();
+    const row = providers.find((p) => p.id === PROVIDER_ID);
+    assert.ok(row);
+    assert.equal(row.hasApiKey, true);
+    assert.equal(row.hasBearer, false);
+
+    const after = JSON.parse(await fs.readFile(secretsPath, 'utf8'));
+    assert.equal(isEncryptedSecretPayload(after), true);
+  });
+
+  test('auth headers still work after migration', async () => {
+    await listProviders();
+    const runtime = await getProviderRuntime(PROVIDER_ID);
+    const expectedHeaders = {
+      Authorization: 'Bearer sk-migration-fixed-key',
+      'X-Test-Override': 'override-fixed',
+    };
+    assert.deepEqual(buildAuthHeaders(runtime.profile, runtime.secrets), expectedHeaders);
+    assert.deepEqual(secretsFlags(runtime.secrets), { hasApiKey: true, hasBearer: false });
+  });
+
+  test('corrupt encrypted secrets fail without leaking values', async () => {
+    await listProviders();
+    const secretsPath = path.join(home, 'providers', PROVIDER_ID, 'secrets.json');
+    const envelope = JSON.parse(await fs.readFile(secretsPath, 'utf8'));
+    const bytes = Buffer.from(envelope.ciphertext, 'base64');
+    bytes[0] ^= 0xff;
+    envelope.ciphertext = bytes.toString('base64');
+    await fs.writeFile(secretsPath, `${JSON.stringify(envelope, null, 2)}\n`, 'utf8');
+
+    await assert.rejects(
+      () => getProviderRuntime(PROVIDER_ID),
+      (err) => {
+        assert.match(String(err.message), /could not be decrypted/i);
+        assert.ok(!String(err.message).includes('sk-migration-fixed-key'));
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Odysseus Port 12 — encrypted credential storage for Minnow (Linear MIN-117).

- Adds `server/security/secret-box.js` with AES-256-GCM encryption using a file key at `~/.minnow/.key`
- Routes provider `secrets.json` read/write through encrypted helpers with transparent plaintext migration on first read
- Exports reusable `readEncryptedJsonFile` / `writeEncryptedJsonFile` for downstream webhook/email/calendar integrations
- Adds Settings copy warning that deleting `.key` makes saved credentials unrecoverable

## Changes

| Area | Detail |
|------|--------|
| `server/security/secret-box.js` | Versioned JSON envelope, key management, encrypt/decrypt helpers |
| `server/providers/store.js` | Encrypted secrets I/O + auto-migration from legacy plaintext |
| Tests | `test/security/secret-box.test.mjs`, `test/security/secret-migration.test.mjs` |
| Docs/UI | `documentation/context.md`, Settings → Providers key-loss hints |

## Verification

- `node --test test/security/secret-box.test.mjs test/security/secret-migration.test.mjs` — pass
- `node --test test/providers/*.test.js` — pass (including CRUD + secrets redaction)
- `npx tsc --noEmit` — pass

## Acceptance criteria

- [x] Existing plaintext provider secrets migrate to encrypted JSON on next read
- [x] Provider auth still works after migration
- [x] Tampering with ciphertext or tag causes decrypt to fail closed
- [x] Missing secret files return empty defaults
- [x] No decrypted secrets in logs, errors, or API responses
- [x] Works in standalone Node server (`npm start`, `minnow run`) via file-key strategy
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-117](https://linear.app/minnowai/issue/MIN-117/odysseus-port-12-encrypted-credential-storage)

<div><a href="https://cursor.com/agents/bc-37004ef1-6741-4ea3-bae5-9498899e3e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37004ef1-6741-4ea3-bae5-9498899e3e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

