### PR TITLE
🐛 Fix reload re-enabling orchestrate board auto mode (MIN-247)

### DIFF
--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -40,6 +40,7 @@ export { getBoardExecutionMode, isBoardAutoMode, isBoardRunning };
 import {
   createEmptyChatObject,
   findChatById,
+  saveSessionsNow,
   scheduleSaveSessions,
   sessionState,
   touchChat,
@@ -1123,7 +1124,12 @@ export function setBoardExecutionMode(
   board.executionMode = mode;
   if (mode === 'manual') board.autoRunning = false;
   board.lastUpdatedAt = Date.now();
-  scheduleSaveSessions();
+  // Flush stop state immediately so reload cannot resurrect auto execution.
+  if (mode === 'manual') {
+    saveSessionsNow();
+  } else {
+    scheduleSaveSessions();
+  }
   emitBoardChange(group.id);
 }
 
@@ -1223,7 +1229,8 @@ export function stopBoardAutoRun(group: ChatGroup, plannerChat: Chat): void {
     stopGeneration(board.finalTest.chatId);
   }
   stopGeneration(plannerChat.id);
-  scheduleSaveSessions();
+  // Flush stop state immediately so reload cannot resurrect auto execution.
+  saveSessionsNow();
   emitBoardChange(group.id);
 }
 

--- a/test/state/orchestrate-board-hydrate.test.mts
+++ b/test/state/orchestrate-board-hydrate.test.mts
@@ -3,13 +3,88 @@
  */
 
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
-import { hydrateSessionGroupsForTests } from '../../src/state/sessions.ts';
-import { isBoardRunning } from '../../src/state/orchestrate-board-store.ts';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { STORAGE_KEY } from '../../src/constants.ts';
+import {
+  stopBoardAutoRun,
+  setBoardExecutionMode,
+} from '../../src/state/orchestrate-board-actions.ts';
+import { initBoard, isBoardRunning } from '../../src/state/orchestrate-board-store.ts';
+import {
+  hydrateSessionGroupsForTests,
+  saveSessionsNow,
+  setSessionStateForTests,
+} from '../../src/state/sessions.ts';
+import type { Chat, ChatGroup } from '../../src/types.ts';
 
 const GROUP_ID = 'grp_11111111-1111-1111-1111-111111111111';
 const PLAN_PATH = 'documentation/plans/reload-persist.md';
 const PLANNER_ID = '11111111-1111-1111-1111-111111111111';
+
+function makePlanner(): Chat {
+  return {
+    id: PLANNER_ID,
+    name: 'Planner',
+    workspacePath: '/tmp/ws',
+    modeId: 'orchestrate',
+    modelId: 'm1',
+    history: [],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1,
+    orchestratePlanPath: PLAN_PATH,
+    boardGroupId: GROUP_ID,
+  };
+}
+
+function makeGroup(): ChatGroup {
+  return {
+    id: GROUP_ID,
+    name: 'Reload board',
+    workspacePath: '/tmp/ws',
+    collapsed: false,
+    order: 0,
+    createdAt: 1,
+    orchestratePlanPath: PLAN_PATH,
+    plannerChatId: PLANNER_ID,
+  };
+}
+
+function seedRunningBoard(executionMode: 'auto' | 'sequential' = 'auto') {
+  const planner = makePlanner();
+  const group = makeGroup();
+  initBoard(group, planner, {
+    planPath: PLAN_PATH,
+    waves: [{ id: 'W1' }],
+    tasks: [
+      {
+        id: 'W1-A',
+        title: 'First task',
+        wave: 'W1',
+        category: 'build',
+        build: 'Do work',
+      },
+    ],
+  });
+  const board = group.orchestrateBoard!;
+  board.executionMode = executionMode;
+  board.autoRunning = true;
+  setSessionStateForTests({
+    version: 5,
+    activeId: PLANNER_ID,
+    chats: [planner],
+    groups: [group],
+  });
+  return { planner, group };
+}
+
+/** Read persisted groups from localStorage without flushing debounced saves. */
+function readPersistedGroupsFromLocalStorage(): ChatGroup[] {
+  const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+  assert.ok(raw, 'expected session snapshot in localStorage');
+  const parsed = JSON.parse(raw) as { groups?: unknown };
+  return hydrateSessionGroupsForTests(parsed.groups ?? []);
+}
 
 /** Minimal persisted group blob with a running sequential board. */
 const PERSISTED_GROUP = {
@@ -90,5 +165,55 @@ describe('orchestrate board hydration', () => {
       },
     ]);
     assert.equal(isBoardRunning(group), false);
+  });
+});
+
+describe('orchestrate board stop persistence', () => {
+  beforeEach(async () => {
+    const { Window } = await import('happy-dom');
+    const window = new Window();
+    const g = globalThis as typeof globalThis & { localStorage: Storage };
+    g.localStorage = window.localStorage;
+    g.document = window.document;
+    g.HTMLElement = window.HTMLElement;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    setSessionStateForTests(null);
+    globalThis.localStorage?.clear?.();
+  });
+
+  test('stopBoardAutoRun persists stopped state without debounced flush', () => {
+    const { planner, group } = seedRunningBoard('auto');
+    saveSessionsNow();
+    assert.equal(
+      readPersistedGroupsFromLocalStorage()[0]?.orchestrateBoard?.autoRunning,
+      true,
+    );
+
+    stopBoardAutoRun(group, planner);
+
+    const [persisted] = readPersistedGroupsFromLocalStorage();
+    assert.ok(persisted);
+    assert.equal(persisted.orchestrateBoard?.autoRunning, undefined);
+    assert.equal(isBoardRunning(persisted), false);
+  });
+
+  test('setBoardExecutionMode manual persists stopped state without debounced flush', () => {
+    const { planner, group } = seedRunningBoard('sequential');
+    saveSessionsNow();
+    assert.equal(
+      readPersistedGroupsFromLocalStorage()[0]?.orchestrateBoard?.autoRunning,
+      true,
+    );
+
+    setBoardExecutionMode(group, 'manual', planner);
+
+    const [persisted] = readPersistedGroupsFromLocalStorage();
+    assert.ok(persisted);
+    assert.equal(persisted.orchestrateBoard?.executionMode, 'manual');
+    assert.equal(persisted.orchestrateBoard?.autoRunning, undefined);
+    assert.equal(isBoardRunning(persisted), false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes reload silently re-enabling orchestrate board auto/sequential execution after the user had stopped it.

**Root cause:** `stopBoardAutoRun` and manual-mode switches only scheduled a debounced session save (300ms). Reloading within that window discarded the pending write, leaving stale `autoRunning: true` in storage and causing boot resume to restart delegation.

**Fix:** Persist the stopped state immediately via `saveSessionsNow()` in:
- `stopBoardAutoRun`
- `setBoardExecutionMode` when switching to `manual`

`startBoardAutoRun` remains debounced — losing a *start* on reload fails safe (board stays stopped).

## Testing

- Added regression tests in `test/state/orchestrate-board-hydrate.test.mts` that assert stopped state is written to `localStorage` without flushing the debounced save timer.
- Ran orchestrate-related suites (49 tests, all passing):
  - `test/state/orchestrate-board-hydrate.test.mts`
  - `test/chat/orchestrate/board-boot-resume.test.mts`
  - `test/orchestrate/delegate-tasks.test.mts`
  - `test/orchestrate/task-stream-end.test.mts`
  - `test/orchestrate/task-testing.test.mts`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-247](https://linear.app/minnowai/issue/MIN-247/reload-page-turns-on-auto-mode)

<div><a href="https://cursor.com/agents/bc-29e00cbf-f7a6-490e-830b-53db4238ac81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29e00cbf-f7a6-490e-830b-53db4238ac81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

