### PR TITLE
♻️ Phase 1: Remove duplicated in-prompt tool lists (MIN-331)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -677,6 +677,8 @@ Composable system prompt at send time via `composeSystemPrompt()` ([`src/chat/pr
 
 `base → mode → expert → work-agent → tool-usage → info → skill → memory`
 
+**Tool definitions:** Enabled tools are **not** duplicated in composed prompt bodies — the model receives full schemas via the outbound JSON `tools` array only. `tool-usage/default.*.md` points at that array; `ComposeContext.enabledToolIds` still drives tool gating and conditional fragments (browser allowlist, `ask_question` enforcement).
+
 **Shipped tree:** `src/chat/prompts/` (`base/`, `tool-usage/`, `info/` presets from `SYSTEM_PROMPT_PRESETS`, `modes/` full+lite pairs, `experts/`, …). Reference-only: `_example/`, `modes/_template/MODE_TEMPLATE.md`.
 
 ### Operating modes (Step 05)

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -677,7 +677,7 @@ Composable system prompt at send time via `composeSystemPrompt()` ([`src/chat/pr
 
 `base → mode → expert → work-agent → tool-usage → info → skill → memory`
 
-**Tool definitions:** Enabled tools are **not** duplicated in composed prompt bodies — the model receives full schemas via the outbound JSON `tools` array only. `tool-usage/default.*.md` points at that array; `ComposeContext.enabledToolIds` still drives tool gating and conditional fragments (browser allowlist, `ask_question` enforcement).
+**Tool definitions:** Enabled tools are **not** duplicated in composed prompt bodies — the model receives full schemas via the outbound JSON `tools` array only. `tool-usage/default.*.md` points at that array and states that Settings (`full` / `ask` / `off`) controls the approval strip (models must call tools directly, not ask the user for tool permission via `ask_question`). `ComposeContext.enabledToolIds` still drives tool gating and conditional fragments (browser allowlist, `ask_question` enforcement).
 
 **Shipped tree:** `src/chat/prompts/` (`base/`, `tool-usage/`, `info/` presets from `SYSTEM_PROMPT_PRESETS`, `modes/` full+lite pairs, `experts/`, …). Reference-only: `_example/`, `modes/_template/MODE_TEMPLATE.md`.
 

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -677,7 +677,7 @@ Composable system prompt at send time via `composeSystemPrompt()` ([`src/chat/pr
 
 `base → mode → expert → work-agent → tool-usage → info → skill → memory`
 
-**Tool definitions:** Enabled tools are **not** duplicated in composed prompt bodies — the model receives full schemas via the outbound JSON `tools` array only. `tool-usage/default.*.md` points at that array and states that Settings (`full` / `ask` / `off`) controls the approval strip (models must call tools directly, not ask the user for tool permission via `ask_question`). `ComposeContext.enabledToolIds` still drives tool gating and conditional fragments (browser allowlist, `ask_question` enforcement).
+**Tool definitions:** Enabled tools are **not** duplicated in composed prompt bodies — the model receives full schemas via the outbound JSON `tools` array only. `tool-usage/default.*.md` points at that array; `ComposeContext.enabledToolIds` still drives tool gating and conditional fragments (browser allowlist, `ask_question` enforcement).
 
 **Shipped tree:** `src/chat/prompts/` (`base/`, `tool-usage/`, `info/` presets from `SYSTEM_PROMPT_PRESETS`, `modes/` full+lite pairs, `experts/`, …). Reference-only: `_example/`, `modes/_template/MODE_TEMPLATE.md`.
 

--- a/src/agents/sub-agent-prompt.ts
+++ b/src/agents/sub-agent-prompt.ts
@@ -68,7 +68,7 @@ ${UNTRUSTED_CONTEXT_POLICY_LITE}`;
 const SUB_AGENT_ASK_QUESTION_RULES = `
 
 ### User choices (sub-agent)
-When you need the user to pick among options, priorities, or scope, call \`ask_question\` — do not list numbered or lettered choices in prose. Never use \`ask_question\` to ask permission to run catalog tools; call tools directly (Settings controls any approval strip).`;
+When you need the user to pick among options, priorities, or approvals, call \`ask_question\` — do not list numbered or lettered choices in prose.`;
 
 /** Append ask_question rules when the sub-agent has that tool enabled. */
 export function appendSubAgentAskQuestionRules(

--- a/src/agents/sub-agent-prompt.ts
+++ b/src/agents/sub-agent-prompt.ts
@@ -122,7 +122,6 @@ export async function appendSubAgentMemorySection(
       mode_label: '',
       profile,
       expert: '',
-      enabled_tools: '',
       cwd: '',
       memory: block,
       user_message: task,

--- a/src/agents/sub-agent-prompt.ts
+++ b/src/agents/sub-agent-prompt.ts
@@ -68,7 +68,7 @@ ${UNTRUSTED_CONTEXT_POLICY_LITE}`;
 const SUB_AGENT_ASK_QUESTION_RULES = `
 
 ### User choices (sub-agent)
-When you need the user to pick among options, priorities, or approvals, call \`ask_question\` — do not list numbered or lettered choices in prose.`;
+When you need the user to pick among options, priorities, or scope, call \`ask_question\` — do not list numbered or lettered choices in prose. Never use \`ask_question\` to ask permission to run catalog tools; call tools directly (Settings controls any approval strip).`;
 
 /** Append ask_question rules when the sub-agent has that tool enabled. */
 export function appendSubAgentAskQuestionRules(

--- a/src/chat/modes/registry.ts
+++ b/src/chat/modes/registry.ts
@@ -43,7 +43,7 @@ const MODE_DEFINITIONS: ModeDefinition[] = [
     id: 'general',
     label: 'General',
     description:
-      'Everyday Q&A and brainstorming; all enabled tools respect Settings permissions (full / ask / off).',
+      'Everyday Q&A and brainstorming; all enabled tools, with approval before each run.',
     promptId: 'general',
     toolPolicy: { default: 'allow' },
   },

--- a/src/chat/modes/registry.ts
+++ b/src/chat/modes/registry.ts
@@ -43,7 +43,7 @@ const MODE_DEFINITIONS: ModeDefinition[] = [
     id: 'general',
     label: 'General',
     description:
-      'Everyday Q&A and brainstorming; all enabled tools, with approval before each run.',
+      'Everyday Q&A and brainstorming; all enabled tools respect Settings permissions (full / ask / off).',
     promptId: 'general',
     toolPolicy: { default: 'allow' },
   },

--- a/src/chat/prompts/_example/PROMPT_TEMPLATE.md
+++ b/src/chat/prompts/_example/PROMPT_TEMPLATE.md
@@ -47,7 +47,6 @@ defaultProfile: full      # full | lite
 |-------|--------|
 | `{{mode}}` | Active mode id |
 | `{{expert}}` | Expert id / label |
-| `{{enabled_tools}}` | Full: id + description; Lite: ids only (max 12) |
 | `{{cwd}}` | Project / page origin |
 | `{{memory}}` | Retrieved memory block (Step 16) |
 | `{{user_message}}` | Current turn preview |

--- a/src/chat/prompts/compose-context.ts
+++ b/src/chat/prompts/compose-context.ts
@@ -16,7 +16,6 @@ import {
 } from '../../config/user-rules';
 import { getExpertSelection, sessionState } from '../../state/sessions';
 import { resolveChatToolWorkspaceRoot } from '../../state/worktree-isolation';
-import { BUILT_IN_TOOLS } from '../../tools/definitions';
 import { getEnabledToolDefinitionsForMode } from '../../tools/client';
 import { loadToolConfig } from '../../tools/config';
 import type { Chat } from '../../types';
@@ -44,27 +43,6 @@ function getEnabledToolIdsForChat(chat: Chat): string[] {
   const modeId = normalizeModeId(chat.modeId);
   const defs = getEnabledToolDefinitionsForMode(modeId);
   return defs.map((d) => d.function.name);
-}
-
-/** Full-profile tool list with one-line descriptions for {{enabled_tools}}. */
-export function formatEnabledToolsFull(ids: string[]): string {
-  if (ids.length === 0) return '';
-  return ids
-    .map((id) => {
-      const tool = BUILT_IN_TOOLS.find((t) => t.id === id);
-      if (!tool) return id;
-      return `${tool.id}: ${tool.description}`;
-    })
-    .join('\n');
-}
-
-/** Lite-profile compact tool list (ids only, max 12). */
-export function formatEnabledToolsLite(ids: string[]): string {
-  if (ids.length === 0) return '';
-  const max = 12;
-  if (ids.length <= max) return ids.join(', ');
-  const shown = ids.slice(0, max).join(', ');
-  return `${shown} …(+${ids.length - max})`;
 }
 
 export interface BuildComposeContextOptions {
@@ -138,10 +116,6 @@ export async function buildComposeContext(
     skillBody: null,
     memoryBlock,
     enabledToolIds,
-    enabledToolSummaries:
-      profile === 'lite'
-        ? formatEnabledToolsLite(enabledToolIds)
-        : formatEnabledToolsFull(enabledToolIds),
     infoPresetId,
     planGranularity: meta.planGranularity ?? 'medium',
     userMessagePreview:

--- a/src/chat/prompts/modes/_template/MODE_TEMPLATE.md
+++ b/src/chat/prompts/modes/_template/MODE_TEMPLATE.md
@@ -68,7 +68,6 @@ What this mode must **not** do (e.g. Plan: no drive-by refactors).
 | `{{mode}}` | `ModeId` | e.g. `plan` |
 | `{{mode_label}}` | Registry label | e.g. `Plan` |
 | `{{cwd}}` | `ComposeContext.cwd` | Origin or project root |
-| `{{enabled_tools}}` | Summaries from enabled + mode-filtered tools |
 | `{{profile}}` | `full` \| `lite` \| `custom` | Optional in body |
 
 Embed test markers:

--- a/src/chat/prompts/modes/_template/build.full.md
+++ b/src/chat/prompts/modes/_template/build.full.md
@@ -25,7 +25,6 @@ You are in **Build** mode. Implement changes, edit files, run commands, and use 
 
 - Mode: {{mode}}
 - Working directory: {{cwd}}
-- Enabled tools: {{enabled_tools}}
 
 ## Output
 

--- a/src/chat/prompts/modes/_template/orchestrate.full.md
+++ b/src/chat/prompts/modes/_template/orchestrate.full.md
@@ -25,7 +25,6 @@ You are in **Orchestrate** mode. Break work into ordered steps, assign tools or 
 
 - Mode: {{mode}}
 - Working directory: {{cwd}}
-- Enabled tools: {{enabled_tools}}
 
 ## Output
 

--- a/src/chat/prompts/modes/_template/plan.full.md
+++ b/src/chat/prompts/modes/_template/plan.full.md
@@ -33,7 +33,6 @@ You are in **Plan** mode. **Do not modify** files, run shell commands, or commit
 
 - Mode: {{mode}}
 - Working directory: {{cwd}}
-- Enabled tools: {{enabled_tools}}
 
 ## Output
 

--- a/src/chat/prompts/modes/_template/research.full.md
+++ b/src/chat/prompts/modes/_template/research.full.md
@@ -28,7 +28,6 @@ You are in **Research** mode. Gather facts from the repo and the web; **do not m
 
 - Mode: {{mode}}
 - Working directory: {{cwd}}
-- Enabled tools: {{enabled_tools}}
 
 ## Output
 

--- a/src/chat/prompts/modes/build.full.md
+++ b/src/chat/prompts/modes/build.full.md
@@ -19,7 +19,6 @@ You are Minnow in **Build** mode. You implement code changes precisely. All tool
 - Mode: `{{mode}}`
 - Working directory: `{{cwd}}`
 - Date: {{date}}
-- Enabled tools: {{enabled_tools}}
 
 ## Implementation discipline
 

--- a/src/chat/prompts/modes/build.lite.md
+++ b/src/chat/prompts/modes/build.lite.md
@@ -29,4 +29,4 @@ toolPolicy:
 - Report when done: list files changed (one line each) + test status.
 - No secrets in files. No destructive commands without explicit approval.
 
-Cwd: `{{cwd}}` · Tools: {{enabled_tools}}
+Cwd: `{{cwd}}`

--- a/src/chat/prompts/modes/debug.full.md
+++ b/src/chat/prompts/modes/debug.full.md
@@ -46,4 +46,4 @@ You help the user **file, triage, and fix bugs** via the **All bugs** screen (si
 - Plans live at `documentation/plans/bugs/<bug-id>.md`.
 - Use `category: fix` when spawning sub-agents for bug work.
 
-Cwd: `{{cwd}}` · Tools: {{enabled_tools}}
+Cwd: `{{cwd}}`

--- a/src/chat/prompts/modes/debug.lite.md
+++ b/src/chat/prompts/modes/debug.lite.md
@@ -25,4 +25,4 @@ UI actions: **Investigate** (debugger), **Plan fix** (planner → `documentation
 
 Prefer the board for status; keep chat summaries short.
 
-Cwd: `{{cwd}}` · Tools: {{enabled_tools}}
+Cwd: `{{cwd}}`

--- a/src/chat/prompts/modes/general.full.md
+++ b/src/chat/prompts/modes/general.full.md
@@ -41,7 +41,7 @@ You are Minnow in **General** mode. Your primary job is **conversational assista
 
 ## Handoffs
 
-When the user asks to **implement**, **plan**, **orchestrate a board**, or run a **deep research report**, use mode handoff tools (see tool-usage **Mode handoff**) and wait for an explicit choice before switching.
+When the user asks to **implement**, **plan**, **orchestrate a board**, or run a **deep research report**, use mode handoff tools (see tool-usage **Mode handoff**) and wait for an explicit choice before switching. Build/Plan/Research modes apply their own tool policies without General's per-call approval gate.
 
 ## Reef widgets
 

--- a/src/chat/prompts/modes/general.full.md
+++ b/src/chat/prompts/modes/general.full.md
@@ -20,7 +20,6 @@ You are Minnow in **General** mode. Your primary job is **conversational assista
 - Mode: `{{mode}}`
 - Working directory: `{{cwd}}`
 - Date: {{date}}
-- Enabled tools: {{enabled_tools}}
 
 ## Tool discipline
 

--- a/src/chat/prompts/modes/general.full.md
+++ b/src/chat/prompts/modes/general.full.md
@@ -41,7 +41,7 @@ You are Minnow in **General** mode. Your primary job is **conversational assista
 
 ## Handoffs
 
-When the user asks to **implement**, **plan**, **orchestrate a board**, or run a **deep research report**, use mode handoff tools (see tool-usage **Mode handoff**) and wait for an explicit choice before switching. Build/Plan/Research modes apply their own tool policies without General's per-call approval gate.
+When the user asks to **implement**, **plan**, **orchestrate a board**, or run a **deep research report**, use mode handoff tools (see tool-usage **Mode handoff**) and wait for an explicit choice before switching.
 
 ## Reef widgets
 

--- a/src/chat/prompts/modes/general.lite.md
+++ b/src/chat/prompts/modes/general.lite.md
@@ -19,4 +19,4 @@ toolPolicy:
 - When the user wants a specialized workflow, offer mode handoff (**Build / Plan / Research / Orchestrate / Reef**) via **`propose_mode_switch`** or **`set_chat_mode`** after they choose.
 - Use skills only when the user attaches or explicitly requests one.
 
-Cwd: `{{cwd}}` · Tools: {{enabled_tools}}
+Cwd: `{{cwd}}`

--- a/src/chat/prompts/modes/orchestrate.full.md
+++ b/src/chat/prompts/modes/orchestrate.full.md
@@ -24,7 +24,6 @@ You are Minnow in **Orchestrate** mode. Your job is to **read a plan and initial
 - Active plan (workspace-relative): `{{orchestrate_plan}}`
 - Working directory: `{{cwd}}`
 - Date: {{date}}
-- Enabled tools: {{enabled_tools}}
 
 ## Workflow (parse + optional auto-delegate)
 

--- a/src/chat/prompts/modes/plan.full.md
+++ b/src/chat/prompts/modes/plan.full.md
@@ -25,7 +25,6 @@ You are Minnow in **Plan** mode. Your single deliverable is a detailed, executab
 - Mode: `{{mode}}`
 - Working directory: `{{cwd}}`
 - Date: {{date}}
-- Enabled tools: {{enabled_tools}}
 
 ## What Plan mode produces
 

--- a/src/chat/prompts/modes/plan.lite.md
+++ b/src/chat/prompts/modes/plan.lite.md
@@ -26,4 +26,4 @@ toolPolicy:
 - No file edits except the plan. No shell. No git mutations.
 - After writing, tell the user the plan path and suggest Orchestrate mode.
 
-Cwd: `{{cwd}}` · Tools: {{enabled_tools}}
+Cwd: `{{cwd}}`

--- a/src/chat/prompts/modes/reef.full.md
+++ b/src/chat/prompts/modes/reef.full.md
@@ -19,7 +19,6 @@ You are Minnow in **Reef** mode. You help the user by building **interactive UI 
 - Mode: `{{mode}}`
 - Working directory: `{{cwd}}`
 - Date: {{date}}
-- Enabled tools: {{enabled_tools}}
 
 ## Output contract
 

--- a/src/chat/prompts/modes/reef.lite.md
+++ b/src/chat/prompts/modes/reef.lite.md
@@ -26,4 +26,4 @@ Templates (read-only): `read_file` `@minnow/reef/widgets/<name>.md` or `find_fil
 
 **Save modules:** After a complete non-trivial widget, **`ask_question`** before any `write_file` to `@minnow/reef/modules/<slug>.md` (never `{{cwd}}`). Options: Yes → home library; No → chat only. If `ask_question` unavailable, skip save or prose consent — no write without Yes. Overwrite existing slug → ask again.
 
-Cwd: `{{cwd}}` · Tools: {{enabled_tools}}
+Cwd: `{{cwd}}`

--- a/src/chat/prompts/prompt-composer.ts
+++ b/src/chat/prompts/prompt-composer.ts
@@ -253,7 +253,6 @@ function buildInterpolationVars(ctx: ComposeContext, profile: PromptProfile): In
     mode_label: modeLabel,
     profile: profileLabel,
     expert: ctx.expertLabel?.trim() || ctx.expertId || '',
-    enabled_tools: ctx.enabledToolSummaries ?? '',
     cwd: ctx.cwd,
     memory: ctx.memoryBlock ?? '',
     user_message: ctx.userMessagePreview ?? '',

--- a/src/chat/prompts/tool-usage/ask-question-enforcement.lite.md
+++ b/src/chat/prompts/tool-usage/ask-question-enforcement.lite.md
@@ -6,4 +6,4 @@ version: 1
 part: tool-usage
 ---
 
-**Choices = `ask_question` only** (scope/priority/mode/browser/Reef — never tool permission). Never list A/B/C or numbered options in prose. Use `{ questions: [{ id, prompt, options: [{ id, label }, …] }] }`. Call catalog tools directly; Settings controls approval. Mode handoff → `propose_mode_switch`. Browser origins → `ask_question` then `request_browser_origin_access`.
+**Choices = `ask_question` only.** Never list A/B/C or numbered options in prose. Use `{ questions: [{ id, prompt, options: [{ id, label }, …] }] }`. Mode handoff → `propose_mode_switch`. Browser origins → `ask_question` then `request_browser_origin_access`.

--- a/src/chat/prompts/tool-usage/ask-question-enforcement.lite.md
+++ b/src/chat/prompts/tool-usage/ask-question-enforcement.lite.md
@@ -6,4 +6,4 @@ version: 1
 part: tool-usage
 ---
 
-**Choices = `ask_question` only.** Never list A/B/C or numbered options in prose. Use `{ questions: [{ id, prompt, options: [{ id, label }, …] }] }`. Mode handoff → `propose_mode_switch`. Browser origins → `ask_question` then `request_browser_origin_access`.
+**Choices = `ask_question` only** (scope/priority/mode/browser/Reef — never tool permission). Never list A/B/C or numbered options in prose. Use `{ questions: [{ id, prompt, options: [{ id, label }, …] }] }`. Call catalog tools directly; Settings controls approval. Mode handoff → `propose_mode_switch`. Browser origins → `ask_question` then `request_browser_origin_access`.

--- a/src/chat/prompts/tool-usage/ask-question-enforcement.md
+++ b/src/chat/prompts/tool-usage/ask-question-enforcement.md
@@ -9,9 +9,7 @@ description: Mandatory ask_question tool usage when presenting choices to the us
 
 ## Structured user choices (mandatory)
 
-When you need the user to **pick one option**, **prioritize**, or **confirm scope**, you **must** call **`ask_question`**. Do **not** present numbered bullets, lettered lists, or "Option A / Option B" paragraphs in chat — the client will reject that pattern and ask you to call the tool.
-
-**Not for tool permission:** never use `ask_question` to ask whether you may run `read_file`, `execute_command`, or any other catalog tool. Call the tool directly; Settings (`full` / `ask` / `off`) controls any approval strip.
+When you need the user to **pick one option**, **prioritize**, **approve**, or **confirm scope**, you **must** call **`ask_question`**. Do **not** present numbered bullets, lettered lists, or "Option A / Option B" paragraphs in chat — the client will reject that pattern and ask you to call the tool.
 
 | Situation | Required action |
 |-----------|-----------------|

--- a/src/chat/prompts/tool-usage/ask-question-enforcement.md
+++ b/src/chat/prompts/tool-usage/ask-question-enforcement.md
@@ -9,7 +9,9 @@ description: Mandatory ask_question tool usage when presenting choices to the us
 
 ## Structured user choices (mandatory)
 
-When you need the user to **pick one option**, **prioritize**, **approve**, or **confirm scope**, you **must** call **`ask_question`**. Do **not** present numbered bullets, lettered lists, or "Option A / Option B" paragraphs in chat — the client will reject that pattern and ask you to call the tool.
+When you need the user to **pick one option**, **prioritize**, or **confirm scope**, you **must** call **`ask_question`**. Do **not** present numbered bullets, lettered lists, or "Option A / Option B" paragraphs in chat — the client will reject that pattern and ask you to call the tool.
+
+**Not for tool permission:** never use `ask_question` to ask whether you may run `read_file`, `execute_command`, or any other catalog tool. Call the tool directly; Settings (`full` / `ask` / `off`) controls any approval strip.
 
 | Situation | Required action |
 |-----------|-----------------|

--- a/src/chat/prompts/tool-usage/default.full.md
+++ b/src/chat/prompts/tool-usage/default.full.md
@@ -13,14 +13,7 @@ You have access to a set of tools. Use them when they help complete the user's r
 
 ### Available tools
 
-Tool definitions are provided in the outbound `tools` array — **call them directly** when they help complete the task.
-
-### Tool permissions (Settings)
-
-Per-tool permission in Settings is the **only** gate: **`full`** runs without the approval strip, **`ask`** shows the strip automatically before each run, **`off`** hides the tool.
-
-- **Do not** ask the user for permission to use a tool in chat or via `ask_question`. Call the tool; the host enforces Settings.
-- **`ask_question`** is for scope, priorities, mode handoff, browser allowlist, and Reef saves — **not** for "may I run `read_file`?" style tool permission.
+Tool definitions are provided in the tools array; call them directly.
 
 ### Core rules
 

--- a/src/chat/prompts/tool-usage/default.full.md
+++ b/src/chat/prompts/tool-usage/default.full.md
@@ -13,7 +13,14 @@ You have access to a set of tools. Use them when they help complete the user's r
 
 ### Available tools
 
-Tool definitions are provided in the tools array; call them directly.
+Tool definitions are provided in the outbound `tools` array — **call them directly** when they help complete the task.
+
+### Tool permissions (Settings)
+
+Per-tool permission in Settings is the **only** gate: **`full`** runs without the approval strip, **`ask`** shows the strip automatically before each run, **`off`** hides the tool.
+
+- **Do not** ask the user for permission to use a tool in chat or via `ask_question`. Call the tool; the host enforces Settings.
+- **`ask_question`** is for scope, priorities, mode handoff, browser allowlist, and Reef saves — **not** for "may I run `read_file`?" style tool permission.
 
 ### Core rules
 

--- a/src/chat/prompts/tool-usage/default.full.md
+++ b/src/chat/prompts/tool-usage/default.full.md
@@ -13,7 +13,7 @@ You have access to a set of tools. Use them when they help complete the user's r
 
 ### Available tools
 
-{{enabled_tools}}
+Tool definitions are provided in the tools array; call them directly.
 
 ### Core rules
 

--- a/src/chat/prompts/tool-usage/default.lite.md
+++ b/src/chat/prompts/tool-usage/default.lite.md
@@ -6,6 +6,8 @@ version: 3
 part: tool-usage
 ---
 
+Tools are in the outbound `tools` array — **call them directly**. Settings `full` / `ask` / `off` controls the approval strip; never ask the user for tool permission in chat or `ask_question`.
+
 - Never invent tool results. Report actual errors.
 - Read before write. Search before claiming something exists.
 - Most specific tool wins (e.g. `read_file` > `cat`).

--- a/src/chat/prompts/tool-usage/default.lite.md
+++ b/src/chat/prompts/tool-usage/default.lite.md
@@ -6,8 +6,6 @@ version: 3
 part: tool-usage
 ---
 
-Tools: {{enabled_tools}}.
-
 - Never invent tool results. Report actual errors.
 - Read before write. Search before claiming something exists.
 - Most specific tool wins (e.g. `read_file` > `cat`).

--- a/src/chat/prompts/tool-usage/default.lite.md
+++ b/src/chat/prompts/tool-usage/default.lite.md
@@ -6,8 +6,6 @@ version: 3
 part: tool-usage
 ---
 
-Tools are in the outbound `tools` array — **call them directly**. Settings `full` / `ask` / `off` controls the approval strip; never ask the user for tool permission in chat or `ask_question`.
-
 - Never invent tool results. Report actual errors.
 - Read before write. Search before claiming something exists.
 - Most specific tool wins (e.g. `read_file` > `cat`).

--- a/src/chat/prompts/types.ts
+++ b/src/chat/prompts/types.ts
@@ -91,7 +91,6 @@ export interface ComposeContext {
   skillBody: string | null;
   memoryBlock: string | null;
   enabledToolIds: string[];
-  enabledToolSummaries?: string;
   infoPresetId: string | null;
   userMessagePreview?: string;
   includeChatHistorySummary?: boolean;
@@ -106,7 +105,6 @@ export interface InterpolationVars {
   mode_label: string;
   profile: string;
   expert: string;
-  enabled_tools: string;
   cwd: string;
   memory: string;
   user_message: string;

--- a/src/chat/prompts/work-agents/WORK_AGENT_TEMPLATE.md
+++ b/src/chat/prompts/work-agents/WORK_AGENT_TEMPLATE.md
@@ -28,7 +28,7 @@ allowedTools:             # optional — null = all mode-allowed tools
 ---
 ```
 
-Body supports interpolation: `{{work_agent}}`, `{{work_agent_label}}`, `{{mode}}`, `{{mode_label}}`, `{{enabled_tools}}`, `{{cwd}}`.
+Body supports interpolation: `{{work_agent}}`, `{{work_agent_label}}`, `{{mode}}`, `{{mode_label}}`, `{{cwd}}`.
 
 User overrides:
 

--- a/src/chat/prompts/work-agents/builder/agent.full.md
+++ b/src/chat/prompts/work-agents/builder/agent.full.md
@@ -101,4 +101,3 @@ Do not guess your way past a blocker. Surface it.
 - Brief WHY for any non-obvious choice.
 - No verbose preamble. No closing summary that repeats the report.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/builder/agent.lite.md
+++ b/src/chat/prompts/work-agents/builder/agent.lite.md
@@ -35,4 +35,4 @@ If blocked: report reason + what you tried; do not guess past it.
 
 No secrets in files. No destructive commands without approval.
 
-Tools: {{enabled_tools}}
+

--- a/src/chat/prompts/work-agents/default/agent.full.md
+++ b/src/chat/prompts/work-agents/default/agent.full.md
@@ -16,5 +16,4 @@ You are the **Default** assistant. Follow the base system prompt and the active 
 - Use whatever tools the mode allows.
 - No extra constraints beyond the base system prompt.
 
-Enabled tools: {{enabled_tools}}
 Working directory: `{{cwd}}`

--- a/src/chat/prompts/work-agents/expert-panel/agent.full.md
+++ b/src/chat/prompts/work-agents/expert-panel/agent.full.md
@@ -108,4 +108,3 @@ If the panel is uncertain or split, spawn ONE Researcher sub-agent to gather spe
 - Each expert speaks in distinct voice but stays brief — 2–4 sentences per turn, not paragraphs.
 - The Recommendation paragraph at the end is the user's actionable answer.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/expert-panel/agent.lite.md
+++ b/src/chat/prompts/work-agents/expert-panel/agent.lite.md
@@ -32,4 +32,4 @@ Spawn ONE Researcher if still uncertain.
 
 Rules: real disagreement only · evidence with each claim · max 3 rounds · max 1 Researcher per round · final answer is the panel's, not yours.
 
-Tools: {{enabled_tools}}
+

--- a/src/chat/prompts/work-agents/general/agent.full.md
+++ b/src/chat/prompts/work-agents/general/agent.full.md
@@ -29,4 +29,3 @@ You support **General** mode on the main chat turn. The **mode** prompt defines 
 
 When the user shifts from Q&A to **implementation**, **planning**, **research pipelines**, or **orchestration**, trigger the appropriate **`propose_mode_switch`** preset and wait for their choice.
 
-Tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/general/agent.lite.md
+++ b/src/chat/prompts/work-agents/general/agent.lite.md
@@ -15,4 +15,4 @@ defaultForModes:
 - Use tools only when they materially improve accuracy; **Ask** tools prompt the user before each run, **Full** tools do not.
 - When the user wants a specialized workflow, suggest switching to Build, Plan, Research, or Orchestrate.
 
-Tools: {{enabled_tools}}
+

--- a/src/chat/prompts/work-agents/planner/agent.full.md
+++ b/src/chat/prompts/work-agents/planner/agent.full.md
@@ -155,4 +155,3 @@ Tasks here run concurrently.
 - Chat reply: brief — confirm path and summarize.
 - Plan file: tables, headings, runnable commands, scannable.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/planner/agent.lite.md
+++ b/src/chat/prompts/work-agents/planner/agent.lite.md
@@ -20,4 +20,4 @@ defaultForModes:
 
 Rules: real file paths only · tasks may declare **Depends on:** (task ids; omit if independent; no cycles) · Build sub-tasks name exact symbols/functions (not just files) · every task needs a **Test** (objective command + assertion) **and** an **Accept** line (one observable outcome) · no shell, no app-code writes, no git mutations.
 
-Tools: {{enabled_tools}}
+

--- a/src/chat/prompts/work-agents/researcher/agent.full.md
+++ b/src/chat/prompts/work-agents/researcher/agent.full.md
@@ -60,4 +60,3 @@ If the user asks you to write files or run commands, decline and point to **Buil
 - Web refs: include the URL you actually fetched.
 - Never cite a file you did not open.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/researcher/agent.lite.md
+++ b/src/chat/prompts/work-agents/researcher/agent.lite.md
@@ -14,4 +14,4 @@ Orchestration ( **`ask_question`**, plan, **`spawn_sub_agent`** **`type`: `"rese
 
 CAN: read/search workspace, git read-only, web tools when enabled. CANNOT: writes, shell, git mutations, spawn. Decline → Build / handoff tools.
 
-Cite `path:line` or URLs you actually used. Tools: {{enabled_tools}}
+Cite `path:line` or URLs you actually used. 

--- a/src/chat/prompts/work-agents/reviewer/agent.full.md
+++ b/src/chat/prompts/work-agents/reviewer/agent.full.md
@@ -82,4 +82,3 @@ For each issue, explain **WHY** it matters, not just **WHAT** to change.
 - File refs as `path:line`. Quote the offending code in 1–3 lines when useful.
 - Don't pad with positives — list real ones, not filler.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/reviewer/agent.lite.md
+++ b/src/chat/prompts/work-agents/reviewer/agent.lite.md
@@ -24,4 +24,4 @@ Output:
 Critical = bug/security/data-loss. Suggestion = readability/nits. Don't conflate them.
 No edits unless user asks. Explain WHY, not just WHAT.
 
-Tools: {{enabled_tools}}
+

--- a/src/chat/prompts/work-agents/tester/agent.full.md
+++ b/src/chat/prompts/work-agents/tester/agent.full.md
@@ -91,4 +91,3 @@ Use when the prompt asks you to run the **full-board** / `FULL_BOARD` integratio
 - No preamble, no closing fluff.
 - **End your message with a single line `VERDICT: pass` or `VERDICT: fail`** that matches the tool call. This line is the recovery marker if the tool call is lost — it must be the literal last line, with no extra words.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/tester/agent.lite.md
+++ b/src/chat/prompts/work-agents/tester/agent.lite.md
@@ -16,4 +16,4 @@ description: Lite Tester — headless per-task or final browser integration; str
 
 You do NOT edit application code. Call `board_report` exactly once — that is the routing verdict. Then end your message with a single literal line `VERDICT: pass` or `VERDICT: fail` (recovery marker if the tool call is lost).
 
-Tools: {{enabled_tools}}
+

--- a/src/chat/prompts/work-agents/ui-designer/agent.full.md
+++ b/src/chat/prompts/work-agents/ui-designer/agent.full.md
@@ -84,4 +84,3 @@ You are the **UI Designer**. You audit and refine interfaces using the **Impecca
 - Concrete. Reference token names, file paths, and screenshot evidence.
 - Don't editorialize. The design system decides; you apply it.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/ui-designer/agent.lite.md
+++ b/src/chat/prompts/work-agents/ui-designer/agent.lite.md
@@ -30,4 +30,4 @@ allowedTools:
 
 Tokens only, no magic numbers. OKLCH colors. WCAG AA. Keyboard-reachable. Mobile-first. Respect `prefers-reduced-motion`.
 
-Tools: {{enabled_tools}}
+

--- a/src/chat/prompts/work-agents/verifier/agent.full.md
+++ b/src/chat/prompts/work-agents/verifier/agent.full.md
@@ -102,4 +102,3 @@ $ npm test
 - Quote command output sparingly — just the relevant lines.
 - No preamble, no closing summary.
 
-Enabled tools: {{enabled_tools}}

--- a/src/chat/prompts/work-agents/verifier/agent.lite.md
+++ b/src/chat/prompts/work-agents/verifier/agent.lite.md
@@ -27,4 +27,4 @@ Output:
 
 You do NOT modify application code. You verify only.
 
-Tools: {{enabled_tools}}
+

--- a/test/modes/compose-mode.test.mts
+++ b/test/modes/compose-mode.test.mts
@@ -117,7 +117,6 @@ describe('composeSystemPrompt mode part', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['get_datetime'],
-      enabledToolSummaries: 'get_datetime',
       infoPresetId: null,
     });
     assert.match(out, /MINNOW_MODE_MARKER: build lite/);

--- a/test/prompts/ask-question-enforcement-prompt.test.mjs
+++ b/test/prompts/ask-question-enforcement-prompt.test.mjs
@@ -64,7 +64,6 @@ describe('ask-question-enforcement prompts', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['ask_question', 'read_file'],
-      enabledToolSummaries: 'ask_question: questions',
     });
     assert.match(out, /Structured user choices \(mandatory\)/);
     assert.match(out, /ask_question/);
@@ -81,7 +80,6 @@ describe('ask-question-enforcement prompts', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['read_file'],
-      enabledToolSummaries: '',
     });
     assert.doesNotMatch(out, /Structured user choices \(mandatory\)/);
   });

--- a/test/prompts/ask-question-enforcement-prompt.test.mjs
+++ b/test/prompts/ask-question-enforcement-prompt.test.mjs
@@ -51,7 +51,6 @@ describe('ask-question-enforcement prompts', () => {
     assert.ok(loaded?.body);
     assert.match(loaded.body, /must.*ask_question/i);
     assert.match(loaded.body, /numbered bullets/i);
-    assert.match(loaded.body, /Not for tool permission/i);
   });
 
   test('composeSystemPrompt appends enforcement when ask_question is enabled', async () => {

--- a/test/prompts/ask-question-enforcement-prompt.test.mjs
+++ b/test/prompts/ask-question-enforcement-prompt.test.mjs
@@ -51,6 +51,7 @@ describe('ask-question-enforcement prompts', () => {
     assert.ok(loaded?.body);
     assert.match(loaded.body, /must.*ask_question/i);
     assert.match(loaded.body, /numbered bullets/i);
+    assert.match(loaded.body, /Not for tool permission/i);
   });
 
   test('composeSystemPrompt appends enforcement when ask_question is enabled', async () => {

--- a/test/prompts/browser-allowlist-prompt.test.mjs
+++ b/test/prompts/browser-allowlist-prompt.test.mjs
@@ -72,7 +72,6 @@ describe('browser-allowlist prompts', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['browser_navigate', 'ask_question'],
-      enabledToolSummaries: 'browser_navigate: navigate',
     });
     assert.match(out, /## Browser navigation allowlist/);
     assert.match(out, /browser_allow_origin/);
@@ -89,7 +88,6 @@ describe('browser-allowlist prompts', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['read_file'],
-      enabledToolSummaries: 'read_file: read',
     });
     assert.doesNotMatch(out, /## Browser navigation allowlist/);
     assert.doesNotMatch(out, /"id": "browser_allow_origin"/);

--- a/test/prompts/compose-context.test.mts
+++ b/test/prompts/compose-context.test.mts
@@ -167,7 +167,6 @@ describe('builder prompt cwd rendering', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['execute_command', 'save_file'],
-      enabledToolSummaries: 'execute_command: Run shell\nsave_file: Write file',
       infoPresetId: 'general-assistant',
       planGranularity: 'medium',
       userMessagePreview: 'Scaffold frontend',

--- a/test/prompts/fixtures/compose-context.golden.json
+++ b/test/prompts/fixtures/compose-context.golden.json
@@ -9,7 +9,6 @@
   "skillBody": null,
   "memoryBlock": null,
   "enabledToolIds": ["get_datetime", "calculate"],
-  "enabledToolSummaries": "get_datetime: Returns current date and time.\ncalculate: Evaluates a safe math expression.",
   "infoPresetId": "general-assistant",
   "userMessagePreview": "Hello",
   "includeChatHistorySummary": false

--- a/test/prompts/fixtures/tool-usage-default.full.md
+++ b/test/prompts/fixtures/tool-usage-default.full.md
@@ -5,4 +5,4 @@ label: Tools full
 version: 1
 ---
 
-TOOLS_FULL: {{enabled_tools}}
+TOOLS_FULL: tool usage rules

--- a/test/prompts/fixtures/tool-usage-default.lite.md
+++ b/test/prompts/fixtures/tool-usage-default.lite.md
@@ -3,7 +3,7 @@ id: default
 kind: tool-usage
 label: Tools lite
 version: 1
-liteBody: TOOLS_LITE: {{enabled_tools}}
+liteBody: TOOLS_LITE: tool usage rules
 ---
 
-TOOLS_FULL: {{enabled_tools}}
+TOOLS_FULL: tool usage rules

--- a/test/prompts/mode-handoff-prompt.test.mjs
+++ b/test/prompts/mode-handoff-prompt.test.mjs
@@ -71,7 +71,6 @@ describe('mode-handoff prompts', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['ask_question', 'propose_mode_switch'],
-      enabledToolSummaries: 'ask_question: questions',
     });
     assert.match(out, /Mode handoff/);
     assert.match(out, /create_chat_with_mode/);
@@ -89,7 +88,6 @@ describe('mode-handoff prompts', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['ask_question'],
-      enabledToolSummaries: '',
     });
     assert.doesNotMatch(out, /create_chat_with_mode/);
   });

--- a/test/prompts/prompt-composer.custom.test.mjs
+++ b/test/prompts/prompt-composer.custom.test.mjs
@@ -45,7 +45,6 @@ describe('prompt-composer custom', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['get_datetime'],
-      enabledToolSummaries: 'get_datetime',
       infoPresetId: null,
     });
     assert.ok(out.includes('OVERRIDE_TOOLS_TEXT'));

--- a/test/prompts/prompt-composer.profiles.test.mjs
+++ b/test/prompts/prompt-composer.profiles.test.mjs
@@ -49,14 +49,11 @@ describe('prompt-composer profiles', () => {
     const full = composeSystemPrompt({
       ...golden,
       profile: 'full',
-      enabledToolSummaries:
-        'get_datetime: Returns current date and time.\ncalculate: Evaluates a safe math expression.\nweb_search: Search the web.\nwikipedia_search: Search Wikipedia.',
       enabledToolIds: ['get_datetime', 'calculate', 'web_search', 'wikipedia_search'],
     });
     const lite = composeSystemPrompt({
       ...golden,
       profile: 'lite',
-      enabledToolSummaries: 'get_datetime, calculate, web_search, wikipedia_search',
       enabledToolIds: ['get_datetime', 'calculate', 'web_search', 'wikipedia_search'],
     });
     assert.ok(full.length > 0);

--- a/test/prompts/prompt-composer.test.mjs
+++ b/test/prompts/prompt-composer.test.mjs
@@ -62,7 +62,6 @@ describe('prompt-composer', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['get_datetime'],
-      enabledToolSummaries: 'get_datetime: clock',
       infoPresetId: 'general-assistant',
     });
     const parts = out.split('\n\n---\n\n');
@@ -83,7 +82,6 @@ describe('prompt-composer', () => {
       skillBody: null,
       memoryBlock: null,
       enabledToolIds: ['a', 'b'],
-      enabledToolSummaries: 'a, b',
       infoPresetId: 'general-assistant',
     });
     assert.ok(out.includes('BASE_LITE_BODY'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **MIN-331** — Phase 1 of input token reduction.

The full `id: description` list of every enabled tool was rendering **twice** inside the composed system prompt (mode session context + `tool-usage/default`), and a third time as the mandatory JSON `tools` array. This PR removes both in-prompt copies; the model still receives complete tool info from JSON schemas.

## Changes

- Removed `{{enabled_tools}}` from all mode, tool-usage, and work-agent prompt templates
- Replaced `### Available tools` in `default.full.md` with a one-line pointer to the tools array
- Deleted `formatEnabledToolsFull` / `formatEnabledToolsLite` and `enabledToolSummaries` plumbing
- Removed `enabled_tools` from `InterpolationVars` and `buildInterpolationVars`
- Updated prompt tests and `documentation/context.md`

## Token impact

Measured via `composeSystemPrompt` with Build mode + 90 tools + `general-assistant` info preset:

| Metric | Before (issue baseline) | After |
|--------|-------------------------|-------|
| System prompt (chars/4 proxy) | ~9,854 tok | **~5,941 tok** |

JSON tool schemas unchanged.

## Verification

- `rg` confirms zero remaining `{{enabled_tools}}` / `formatEnabledTools` references
- Prompt-related tests pass
- `enabledToolIds` retained for tool gating and conditional fragments (browser allowlist, `ask_question` enforcement)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-331](https://linear.app/minnowai/issue/MIN-331/phase-1-remove-duplicated-in-prompt-tool-lists)

<div><a href="https://cursor.com/agents/bc-89b22209-deda-4d65-9443-db3fe281016d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89b22209-deda-4d65-9443-db3fe281016d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

