### PR TITLE
🔗 Open console URL links in Minnow preview (MIN-290)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -1491,6 +1491,8 @@ Docked **bottom panel** in `.main-column`: **interactive PTY tabs** (xterm.js + 
 
 **PTY tab history (ArrowUp/ArrowDown):** Per-tab command history is stored in `sessionStorage` (`minnow.terminal.history.<tabId>`). Recall sends backspaces + the recalled line to the PTY WebSocket (shell redraws prompt/output) instead of writing local `\r\x1b[K` escape sequences into xterm — avoids corrupted lines like `[0[I[0[I` after the first shell row. Helpers: [`src/ui/terminal-history-nav.ts`](../src/ui/terminal-history-nav.ts); tests: `test/ui/terminal-history-nav.test.mts`.
 
+**Console URL links (MIN-290):** URLs in the interactive PTY (xterm `WebLinksAddon`) and in Agent/Dev server `<pre>` panes are clickable and open in the in-app preview via [`openUrlInPreviewPanel`](../src/ui/preview-panel.ts) ([`src/ui/terminal-console-links.ts`](../src/ui/terminal-console-links.ts)); tests: `test/ui/terminal-console-links.test.mts`.
+
 **Tests:** `node test/terminal-stream.test.mjs <baseUrl>`; `npm run test:terminal-pty`; unit `test/terminal/*.test.mjs`; `test/ui/terminal-tabs-dev-server.test.mts` (Agent → Dev server tab order, `isDevServerTabId`); `test/ui/terminal-history-nav.test.mts`. Verification: [`documentation/plans/verification/feature-06-09.md`](plans/verification/feature-06-09.md).
 
 **Executor extras (not in the 32-tool settings catalog):**

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -338,6 +338,19 @@
   color: var(--mn-danger);
 }
 
+.terminal-console-link {
+  color: var(--mn-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .terminal-console-link:hover {
+    color: var(--mn-fg);
+  }
+}
+
 @media (max-width: 768px) {
   .terminal-panel {
     max-height: 40vh;

--- a/src/ui/terminal-console-links.ts
+++ b/src/ui/terminal-console-links.ts
@@ -1,0 +1,71 @@
+/**
+ * Console URL links open in the Minnow in-app preview (MIN-290).
+ */
+
+/** Match http(s) URLs in streamed console text (aligned with xterm web-links). */
+const CONSOLE_URL_RE = /https?:\/\/[^\s"'<>]+/gi;
+
+/** Open a console link in the preview panel instead of an external tab. */
+export function openConsoleLinkInPreview(url: string): void {
+  const trimmed = url.trim();
+  if (!trimmed) return;
+  void import('./preview-panel').then(({ openUrlInPreviewPanel }) => {
+    void openUrlInPreviewPanel(trimmed);
+  });
+}
+
+/** xterm WebLinksAddon handler — route clicks to the preview panel. */
+export function handleTerminalWebLink(_event: MouseEvent, uri: string): void {
+  openConsoleLinkInPreview(uri);
+}
+
+function bindConsoleLinkAnchor(anchor: HTMLAnchorElement, url: string): void {
+  anchor.href = url;
+  anchor.textContent = url;
+  anchor.className = 'terminal-console-link';
+  anchor.addEventListener('click', (event) => {
+    event.preventDefault();
+    openConsoleLinkInPreview(url);
+  });
+}
+
+/**
+ * Append plain or stderr text to a console `<pre>`, turning URLs into preview links.
+ */
+export function appendConsoleOutputWithLinks(
+  parent: HTMLElement,
+  text: string,
+  options: { stderr?: boolean } = {},
+): void {
+  if (!text) return;
+
+  const wrapper = options.stderr ? document.createElement('span') : null;
+  if (wrapper) {
+    wrapper.className = 'stderr-line';
+  }
+
+  const target = wrapper ?? parent;
+  const fragment = document.createDocumentFragment();
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(CONSOLE_URL_RE)) {
+    const url = match[0];
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      fragment.appendChild(document.createTextNode(text.slice(lastIndex, index)));
+    }
+    const anchor = document.createElement('a');
+    bindConsoleLinkAnchor(anchor, url);
+    fragment.appendChild(anchor);
+    lastIndex = index + url.length;
+  }
+
+  if (lastIndex < text.length) {
+    fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+  }
+
+  target.appendChild(fragment);
+  if (wrapper) {
+    parent.appendChild(wrapper);
+  }
+}

--- a/src/ui/terminal-panel.ts
+++ b/src/ui/terminal-panel.ts
@@ -35,6 +35,7 @@ import {
   initTerminalXterm,
   isTerminalXtermReady,
 } from './terminal-xterm';
+import { appendConsoleOutputWithLinks } from './terminal-console-links';
 
 const MIN_HEIGHT_PX = 120;
 const MAX_HEIGHT_RATIO = 0.5;
@@ -174,14 +175,7 @@ function appendOutputText(text: string, stream: 'stdout' | 'stderr'): void {
   }
   displayBytes += addBytes;
 
-  if (stream === 'stderr') {
-    const span = document.createElement('span');
-    span.className = 'stderr-line';
-    span.textContent = plain;
-    outputEl.appendChild(span);
-  } else {
-    outputEl.appendChild(document.createTextNode(plain));
-  }
+  appendConsoleOutputWithLinks(outputEl, plain, { stderr: stream === 'stderr' });
   scrollOutputIfPinned();
 }
 
@@ -327,14 +321,7 @@ function appendDevServerOutputText(text: string, stream: 'stdout' | 'stderr'): v
   }
   devServerDisplayBytes += addBytes;
 
-  if (stream === 'stderr') {
-    const span = document.createElement('span');
-    span.className = 'stderr-line';
-    span.textContent = plain;
-    devServerOutputEl.appendChild(span);
-  } else {
-    devServerOutputEl.appendChild(document.createTextNode(plain));
-  }
+  appendConsoleOutputWithLinks(devServerOutputEl, plain, { stderr: stream === 'stderr' });
   scrollDevServerIfPinned();
 }
 

--- a/src/ui/terminal-xterm.ts
+++ b/src/ui/terminal-xterm.ts
@@ -24,6 +24,7 @@ import {
   buildHistoryReplaceInput,
   resolveHistoryNavigation,
 } from './terminal-history-nav';
+import { handleTerminalWebLink } from './terminal-console-links';
 
 const HISTORY_STORAGE_PREFIX = 'minnow.terminal.history.';
 const MAX_TAB_HISTORY = 500;
@@ -226,7 +227,7 @@ function ensureTerminal(): Terminal | null {
   });
   fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
-  term.loadAddon(new WebLinksAddon());
+  term.loadAddon(new WebLinksAddon(handleTerminalWebLink));
   applyXtermTheme();
   term.open(hostEl);
 

--- a/test/ui/terminal-console-links.test.mts
+++ b/test/ui/terminal-console-links.test.mts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+import {
+  appendConsoleOutputWithLinks,
+  openConsoleLinkInPreview,
+} from '../../src/ui/terminal-console-links.ts';
+
+describe('terminal-console-links', () => {
+  /** @type {Window | undefined} */
+  let win: Window | undefined;
+
+  beforeEach(() => {
+    win = new Window({ url: 'http://localhost:9473/' });
+    // @ts-expect-error test harness replaces globals
+    globalThis.window = win;
+    // @ts-expect-error test harness replaces globals
+    globalThis.document = win.document;
+  });
+
+  afterEach(() => {
+    win?.close();
+    win = undefined;
+  });
+
+  test('appendConsoleOutputWithLinks turns URLs into preview anchors', () => {
+    const parent = document.createElement('pre');
+    appendConsoleOutputWithLinks(parent, 'ready at http://localhost:5173/\n');
+
+    const anchor = parent.querySelector('a.terminal-console-link');
+    assert.ok(anchor);
+    assert.equal(anchor?.getAttribute('href'), 'http://localhost:5173/');
+    assert.equal(anchor?.textContent, 'http://localhost:5173/');
+    assert.equal(parent.textContent, 'ready at http://localhost:5173/\n');
+  });
+
+  test('appendConsoleOutputWithLinks wraps stderr URLs in stderr-line span', () => {
+    const parent = document.createElement('pre');
+    appendConsoleOutputWithLinks(parent, 'err https://example.com/path', { stderr: true });
+
+    const stderr = parent.querySelector('.stderr-line');
+    assert.ok(stderr);
+    const anchor = stderr?.querySelector('a.terminal-console-link');
+    assert.equal(anchor?.getAttribute('href'), 'https://example.com/path');
+  });
+
+  test('console link click prevents default navigation', () => {
+    const parent = document.createElement('pre');
+    appendConsoleOutputWithLinks(parent, 'see http://localhost:3000/app');
+
+    const anchor = parent.querySelector('a.terminal-console-link') as HTMLAnchorElement;
+    const event = new window.MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(event);
+
+    assert.equal(event.defaultPrevented, true);
+  });
+
+  test('openConsoleLinkInPreview ignores empty URLs', async () => {
+    let called = false;
+    window.minnow = {
+      preview: {
+        show: async () => {
+          called = true;
+        },
+      },
+    };
+
+    openConsoleLinkInPreview('   ');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(called, false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Console URL links now open in the Minnow in-app browser preview instead of an external tab.

## Changes

- Added `src/ui/terminal-console-links.ts` to centralize console link handling
- **PTY tabs (xterm):** `WebLinksAddon` now routes clicks through `openUrlInPreviewPanel`
- **Agent + Dev server console panes:** streamed output linkifies `http(s)://` URLs as clickable anchors that open the preview
- Added `.terminal-console-link` styling in `terminal.css`
- Documented behavior in `documentation/context.md`
- Added `test/ui/terminal-console-links.test.mts`

## Test plan

- [x] `npx tsx --import ./test/test-loader.mjs --test test/ui/terminal-console-links.test.mts`
- [ ] Manual: start dev server from hub, open **Console** tab, click a `http://localhost:…` URL → preview panel opens
- [ ] Manual: in an interactive PTY tab, Cmd/Ctrl+click a URL → preview panel opens
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-290](https://linear.app/minnowai/issue/MIN-290/links-open-to-minnow-browser)

<div><a href="https://cursor.com/agents/bc-de3515f1-7c89-433e-946e-518d8680b792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de3515f1-7c89-433e-946e-518d8680b792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

