### PR TITLE
🐛 Fix slash picker ArrowDown skipping two rows (MIN-321)

### DIFF
--- a/src/ui/skill-picker.ts
+++ b/src/ui/skill-picker.ts
@@ -601,6 +601,15 @@ export function handleSkillPickerKeydown(e: KeyboardEvent): boolean {
   return false;
 }
 
+/** @internal Reset module singleton between happy-dom document swaps in tests. */
+export function __resetSkillPickerForTests(): void {
+  closePicker();
+  pickerEl = null;
+  headerEl = null;
+  listEl = null;
+  inputEl = null;
+}
+
 /** Mount slash picker listeners on one composer textarea (idempotent). */
 export function initComposerSlashPicker(composerInput: HTMLTextAreaElement): void {
   if (composerInput.dataset.slashPickerBound === '1') return;
@@ -624,10 +633,8 @@ export function initComposerSlashPicker(composerInput: HTMLTextAreaElement): voi
     detectSlashContext();
   });
 
-  composerInput.addEventListener('keydown', (e) => {
-    if (inputEl !== composerInput) bindActiveInput(composerInput);
-    handleSkillPickerKeydown(e);
-  });
+  // Keydown is handled by each composer's outer handler (handleKey / chat-app / concierge)
+  // so ArrowDown/Up are not processed twice when the slash picker is open.
 
   composerInput.addEventListener('blur', () => {
     window.setTimeout(() => closePicker(), 150);

--- a/test/ui/skill-picker.test.mts
+++ b/test/ui/skill-picker.test.mts
@@ -10,6 +10,8 @@ const { setStreaming } = await import('../../src/app-state.ts');
 const { refreshSkillCatalog } = await import('../../src/skills/client.ts');
 const { listSlashPickerRows } = await import('../../src/chat/slash-commands/picker-catalog.ts');
 const {
+  __resetSkillPickerForTests,
+  handleSkillPickerKeydown,
   initComposerSlashPicker,
   isSkillPickerOpen,
 } = await import('../../src/ui/skill-picker.ts');
@@ -81,6 +83,50 @@ describe('skill-picker', () => {
     assert.equal(isSkillPickerOpen(), true, 'picker should open during background stream');
 
     setStreaming(false, 'other-chat-id');
+  });
+
+  it('ArrowDown moves highlight by one row when wired like production composers', async () => {
+    const window = new Window();
+    globalThis.document = window.document;
+    globalThis.window = window as unknown as Window & typeof globalThis;
+    globalThis.HTMLElement = window.HTMLElement;
+    globalThis.Event = window.Event;
+    globalThis.KeyboardEvent = window.KeyboardEvent;
+
+    await refreshSkillCatalog();
+    __resetSkillPickerForTests();
+
+    const input = mountComposer('arrowNavInput', 'input-wrap');
+    initComposerSlashPicker(input);
+    // Code / Chat app / desktop composers call handleSkillPickerKeydown from their keydown handler.
+    input.addEventListener('keydown', (e) => {
+      handleSkillPickerKeydown(e);
+    });
+
+    input.focus();
+    input.value = '/';
+    input.setSelectionRange(1, 1);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    assert.equal(isSkillPickerOpen(), true);
+
+    const activeIndex = (): number => {
+      const items = document.querySelectorAll('.skill-picker__item');
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].classList.contains('skill-picker__item--active')) return i;
+      }
+      return -1;
+    };
+
+    assert.equal(activeIndex(), 0);
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    assert.equal(activeIndex(), 1, 'ArrowDown should advance exactly one row');
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    assert.equal(activeIndex(), 2, 'second ArrowDown should advance one more row');
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    assert.equal(activeIndex(), 1, 'ArrowUp should move back exactly one row');
   });
 
   it('lists /goal in the picker when filtering by goal', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes slash-command picker keyboard navigation: pressing **Down** (or **Up**) advanced the highlight by **two** rows instead of one.

## Root cause

`handleSkillPickerKeydown` was invoked **twice** per key press:

1. From `initComposerSlashPicker` (internal `keydown` listener on the textarea)
2. From each composer's outer handler (`handleKey` in Code, `chat-app.ts`, `concierge.ts`)

Each call incremented `activeIndex`, so ArrowDown/Up moved two items.

## Fix

Remove the redundant `keydown` listener from `initComposerSlashPicker`. Parent composers already route keyboard events through `handleSkillPickerKeydown` before Enter/send handling.

## Testing

- Added regression test: `ArrowDown moves highlight by one row when wired like production composers`
- Existing impeccable multi-step picker tests still pass
- `handleSkillPickerKeydown` still returns `false` when the picker is closed, so Up-arrow prompt history is unaffected when the menu is closed

## Acceptance

- [x] Down/Up move one item at a time
- [x] Enter selects highlighted item (unchanged; covered by existing impeccable test)
- [x] No conflict with composer prompt history when menu closed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-321](https://linear.app/minnowai/issue/MIN-321/command-tree-line-skip)

<div><a href="https://cursor.com/agents/bc-b223f4c6-f4b1-44a4-a026-fa040932041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b223f4c6-f4b1-44a4-a026-fa040932041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

