### PR TITLE
🐛 Fix slash picker keyboard nav and Enter double-send (MIN-321)

### DIFF
--- a/src/os/concierge.ts
+++ b/src/os/concierge.ts
@@ -15,7 +15,7 @@ import {
   syncComposerFromStreamingState,
 } from '../ui/composer-send';
 import { isActiveChatStreaming } from '../chat/streaming-state';
-import { handleSkillPickerKeydown, isSkillPickerOpen } from '../ui/skill-picker';
+import { isSkillPickerOpen } from '../ui/skill-picker';
 import { handleDesktopResearchSubmit } from './research-desktop';
 import { MINNOW_GLYPH_HEADER_HTML } from '../ui/minnow-glyph';
 
@@ -169,7 +169,6 @@ export function renderConcierge(container: HTMLElement): void {
 
   field.addEventListener('input', () => syncUi());
   field.addEventListener('keydown', (e) => {
-    if (handleSkillPickerKeydown(e)) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       if (isSkillPickerOpen()) return;
       e.preventDefault();

--- a/src/ui/chat-app.ts
+++ b/src/ui/chat-app.ts
@@ -34,7 +34,7 @@ import {
   initComposerSteerInputListener,
   syncComposerFromStreamingState,
 } from './composer-send';
-import { handleSkillPickerKeydown, initComposerSlashPicker, isSkillPickerOpen } from './skill-picker';
+import { initComposerSlashPicker, isSkillPickerOpen } from './skill-picker';
 import { closeGlobalBugs } from './global-bugs-page';
 import { renderChatFromHistory } from './messages';
 import { closeSettings } from './settings-page';
@@ -423,7 +423,6 @@ function bindStaticControls(): void {
     syncComposerSendState();
   });
   input?.addEventListener('keydown', (e) => {
-    if (handleSkillPickerKeydown(e)) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       if (isSkillPickerOpen()) return;
       e.preventDefault();

--- a/src/ui/input.ts
+++ b/src/ui/input.ts
@@ -1,5 +1,5 @@
 import { scrollChatIfPinned } from './chat-scroll';
-import { handleSkillPickerKeydown, isSkillPickerOpen } from './skill-picker';
+import { isSkillPickerOpen } from './skill-picker';
 
 import {
   handleComposerPrimaryAction,
@@ -47,7 +47,6 @@ export function initComposerInput(el: HTMLTextAreaElement): void {
 }
 
 export function handleKey(e: KeyboardEvent): void {
-  if (handleSkillPickerKeydown(e)) return;
   if (e.key === 'Enter' && !e.shiftKey) {
     if (isSkillPickerOpen()) return;
     e.preventDefault();

--- a/src/ui/skill-picker.ts
+++ b/src/ui/skill-picker.ts
@@ -633,8 +633,19 @@ export function initComposerSlashPicker(composerInput: HTMLTextAreaElement): voi
     detectSlashContext();
   });
 
-  // Keydown is handled by each composer's outer handler (handleKey / chat-app / concierge)
-  // so ArrowDown/Up are not processed twice when the slash picker is open.
+  // Capture phase runs before inline onkeydown (e.g. handleKey on #msgInput) so picker keys
+  // are handled once; stopImmediatePropagation prevents a second handleSkillPickerKeydown
+  // pass that could skip two rows or send after Enter selection.
+  composerInput.addEventListener(
+    'keydown',
+    (e) => {
+      if (inputEl !== composerInput) bindActiveInput(composerInput);
+      if (handleSkillPickerKeydown(e)) {
+        e.stopImmediatePropagation();
+      }
+    },
+    true,
+  );
 
   composerInput.addEventListener('blur', () => {
     window.setTimeout(() => closePicker(), 150);

--- a/src/ui/skill-picker.ts
+++ b/src/ui/skill-picker.ts
@@ -601,6 +601,15 @@ export function handleSkillPickerKeydown(e: KeyboardEvent): boolean {
   return false;
 }
 
+/** @internal Reset module singleton between happy-dom document swaps in tests. */
+export function __resetSkillPickerForTests(): void {
+  closePicker();
+  pickerEl = null;
+  headerEl = null;
+  listEl = null;
+  inputEl = null;
+}
+
 /** Mount slash picker listeners on one composer textarea (idempotent). */
 export function initComposerSlashPicker(composerInput: HTMLTextAreaElement): void {
   if (composerInput.dataset.slashPickerBound === '1') return;
@@ -624,10 +633,8 @@ export function initComposerSlashPicker(composerInput: HTMLTextAreaElement): voi
     detectSlashContext();
   });
 
-  composerInput.addEventListener('keydown', (e) => {
-    if (inputEl !== composerInput) bindActiveInput(composerInput);
-    handleSkillPickerKeydown(e);
-  });
+  // Keydown is handled by each composer's outer handler (handleKey / chat-app / concierge)
+  // so ArrowDown/Up are not processed twice when the slash picker is open.
 
   composerInput.addEventListener('blur', () => {
     window.setTimeout(() => closePicker(), 150);

--- a/test/ui/skill-picker.test.mts
+++ b/test/ui/skill-picker.test.mts
@@ -11,7 +11,6 @@ const { refreshSkillCatalog } = await import('../../src/skills/client.ts');
 const { listSlashPickerRows } = await import('../../src/chat/slash-commands/picker-catalog.ts');
 const {
   __resetSkillPickerForTests,
-  handleSkillPickerKeydown,
   initComposerSlashPicker,
   isSkillPickerOpen,
 } = await import('../../src/ui/skill-picker.ts');
@@ -98,10 +97,6 @@ describe('skill-picker', () => {
 
     const input = mountComposer('arrowNavInput', 'input-wrap');
     initComposerSlashPicker(input);
-    // Code / Chat app / desktop composers call handleSkillPickerKeydown from their keydown handler.
-    input.addEventListener('keydown', (e) => {
-      handleSkillPickerKeydown(e);
-    });
 
     input.focus();
     input.value = '/';

--- a/test/ui/skill-picker.test.mts
+++ b/test/ui/skill-picker.test.mts
@@ -10,6 +10,8 @@ const { setStreaming } = await import('../../src/app-state.ts');
 const { refreshSkillCatalog } = await import('../../src/skills/client.ts');
 const { listSlashPickerRows } = await import('../../src/chat/slash-commands/picker-catalog.ts');
 const {
+  __resetSkillPickerForTests,
+  handleSkillPickerKeydown,
   initComposerSlashPicker,
   isSkillPickerOpen,
 } = await import('../../src/ui/skill-picker.ts');
@@ -81,6 +83,50 @@ describe('skill-picker', () => {
     assert.equal(isSkillPickerOpen(), true, 'picker should open during background stream');
 
     setStreaming(false, 'other-chat-id');
+  });
+
+  it('ArrowDown moves highlight by one row when wired like production composers', async () => {
+    const window = new Window();
+    globalThis.document = window.document;
+    globalThis.window = window as unknown as Window & typeof globalThis;
+    globalThis.HTMLElement = window.HTMLElement;
+    globalThis.Event = window.Event;
+    globalThis.KeyboardEvent = window.KeyboardEvent;
+
+    await refreshSkillCatalog();
+    __resetSkillPickerForTests();
+
+    const input = mountComposer('arrowNavInput', 'input-wrap');
+    initComposerSlashPicker(input);
+    // Code / Chat app / desktop composers call handleSkillPickerKeydown from their keydown handler.
+    input.addEventListener('keydown', (e) => {
+      handleSkillPickerKeydown(e);
+    });
+
+    input.focus();
+    input.value = '/';
+    input.setSelectionRange(1, 1);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    assert.equal(isSkillPickerOpen(), true);
+
+    const activeIndex = (): number => {
+      const items = document.querySelectorAll('.skill-picker__item');
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].classList.contains('skill-picker__item--active')) return i;
+      }
+      return -1;
+    };
+
+    assert.equal(activeIndex(), 0);
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    assert.equal(activeIndex(), 1, 'ArrowDown should advance exactly one row');
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    assert.equal(activeIndex(), 2, 'second ArrowDown should advance one more row');
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    assert.equal(activeIndex(), 1, 'ArrowUp should move back exactly one row');
   });
 
   it('lists /goal in the picker when filtering by goal', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes slash-command picker keyboard navigation (MIN-321):

- **ArrowDown/Up skipped two rows** — `handleSkillPickerKeydown` ran twice (picker listener + composer handler).
- **Enter could select and send** — after picking a skill, the composer could still send immediately, so the model often replied with reasoning/thinking instead of a normal message.

## Fix

- Handle picker keys once in `initComposerSlashPicker` (capture-phase `keydown` + `stopImmediatePropagation` when consumed).
- Remove duplicate `handleSkillPickerKeydown` calls from Code / Chat app / desktop send handlers; they only guard Enter when the picker is open.

## Testing

- Regression test: ArrowDown/ArrowUp move exactly one row.
- Existing impeccable multi-step picker tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-321](https://linear.app/minnowai/issue/MIN-321/command-tree-line-skip)

<div><a href="https://cursor.com/agents/bc-b223f4c6-f4b1-44a4-a026-fa040932041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b223f4c6-f4b1-44a4-a026-fa040932041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

