### PR TITLE
🐛 Fix chat snap-scroll when reading history (MIN-277)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -913,7 +913,7 @@ Code and Chat apps share send + history render paths via parameterized DOM surfa
 | Concern | Location |
 |---------|----------|
 | Composer surface | [`src/ui/composer-surface.ts`](../src/ui/composer-surface.ts) — `getActiveComposerSurface()`, `resolveComposerSurface()`, `registerComposerSurface()`; Code foreground → `#msgInput` / `#sendBtn` even when desktop chat state is still `chatActive`; desktop chat → `#desktopInput` / `#desktopSendBtn`; legacy Chat → `#chatAppInput` / `#chatAppSendBtn` |
-| Scroll / jump chip | [`src/ui/chat-scroll.ts`](../src/ui/chat-scroll.ts) — Code `#chatArea`; Chat `#chatAppArea`; desktop chat `.mn-os-chat-transcript` when `chatActive` and Code is not foreground |
+| Scroll / jump chip | [`src/ui/chat-scroll.ts`](../src/ui/chat-scroll.ts) — Code `#chatArea`; Chat `#chatAppArea`; desktop chat `.mn-os-chat-transcript` when `chatActive` and Code is not foreground. **MIN-277:** `scrollChatIfPinned()` only auto-scrolls when within 80px of bottom; new stream shells (`appendStreamingAssistantRow`) respect pin state instead of forcing tail; jump chip (`#chatJumpLatest` / `#chatAppJumpLatest`) when scrolled up |
 | Chat mount | [`src/ui/chat-mount.ts`](../src/ui/chat-mount.ts) — `resolveChatMount()`, `getActiveChatMountElement()`, `runWithChatMount()`; Chat foreground → `#chatAppMessageCol` |
 | History render | [`src/ui/messages.ts`](../src/ui/messages.ts) — `renderChatFromHistory(chat, mount?)` (default `#chatArea`); non-Code mounts skip hub/board/plan Code-only branches |
 | Send loop | [`src/tools/loop.ts`](../src/tools/loop.ts) — `sendMessageWithTools(composer?)`, `RunChatTurnOptions.composerSurface`; tool-call paint uses `getActiveChatMountElement()` |

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -37,7 +37,6 @@ import type {
   Usage,
 } from '../types';
 import {
-  pinChatScroll,
   scrollChatIfPinned,
   scrollChatToBottom,
 } from './chat-scroll';
@@ -587,8 +586,8 @@ export function appendStreamingAssistantRow(forChatId?: string): StreamingAssist
   wrap.appendChild(bubble);
   bubble.appendChild(cursor);
   getActiveChatMountElement().appendChild(wrap);
-  pinChatScroll();
-  scrollChatToBottom();
+  // Respect scroll pin: only follow the tail when the user is already near bottom.
+  scrollChatIfPinned();
   return { wrap, bubble, cursor, streamStatus };
 }
 

--- a/test/ui/messages-stream-row.test.mjs
+++ b/test/ui/messages-stream-row.test.mjs
@@ -9,6 +9,11 @@ const {
   appendStreamingAssistantRow,
   revealAssistantProseBubble,
 } = await import('../../src/ui/messages.ts');
+const {
+  initChatScroll,
+  isChatScrollPinned,
+  scrollChatToBottom,
+} = await import('../../src/ui/chat-scroll.ts');
 
 function setupChatDom() {
   const window = new Window();
@@ -16,7 +21,13 @@ function setupChatDom() {
   globalThis.HTMLElement = window.HTMLElement;
   globalThis.Node = window.Node;
   document.body.innerHTML =
-    '<main id="chatArea"><div id="emptyState">Empty</div></main>';
+    '<main id="chatArea"><div id="emptyState">Empty</div></main>' +
+    '<button id="chatJumpLatest" class="chat-jump-latest hidden"></button>';
+  globalThis.requestAnimationFrame = (cb) => {
+    cb();
+    return 0;
+  };
+  initChatScroll();
   const chat = createEmptyChatObject('');
   chat.id = 'chat-stream-row';
   setSessionStateForTests({
@@ -42,6 +53,56 @@ test('appendStreamingAssistantRow inserts stream-status before awaiting bubble',
   assert.equal(status?.nextElementSibling, bubble);
   assert.ok(wrap.classList.contains('msg--awaiting-prose'));
   assert.ok(bubble.classList.contains('msg-bubble--awaiting'));
+
+  streamStatus.dispose();
+});
+
+test('appendStreamingAssistantRow does not force scroll when user scrolled up', () => {
+  const win = setupChatDom();
+  const area = document.getElementById('chatArea');
+  Object.defineProperty(area, 'scrollHeight', { value: 1200, configurable: true });
+  Object.defineProperty(area, 'clientHeight', { value: 400, configurable: true });
+  let scrollTop = 0;
+  Object.defineProperty(area, 'scrollTop', {
+    get: () => scrollTop,
+    set: (v) => {
+      scrollTop = v;
+    },
+    configurable: true,
+  });
+
+  scrollChatToBottom();
+  assert.equal(isChatScrollPinned(), true);
+
+  scrollTop = 0;
+  area.dispatchEvent(new win.Event('scroll'));
+  assert.equal(isChatScrollPinned(), false);
+
+  const before = scrollTop;
+  const { streamStatus } = appendStreamingAssistantRow();
+  assert.equal(scrollTop, before, 'new stream shell must not snap scroll when detached');
+  assert.equal(isChatScrollPinned(), false);
+
+  streamStatus.dispose();
+});
+
+test('appendStreamingAssistantRow follows tail when pinned near bottom', () => {
+  setupChatDom();
+  const area = document.getElementById('chatArea');
+  Object.defineProperty(area, 'scrollHeight', { value: 1200, configurable: true });
+  Object.defineProperty(area, 'clientHeight', { value: 400, configurable: true });
+  let scrollTop = 0;
+  Object.defineProperty(area, 'scrollTop', {
+    get: () => scrollTop,
+    set: (v) => {
+      scrollTop = v;
+    },
+    configurable: true,
+  });
+
+  scrollChatToBottom();
+  const { streamStatus } = appendStreamingAssistantRow();
+  assert.equal(scrollTop, area.scrollHeight);
 
   streamStatus.dispose();
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes disruptive snap-to-bottom when a new assistant message or stream shell arrives while the user is scrolled up reviewing older messages.

**Root cause:** `appendStreamingAssistantRow()` unconditionally called `pinChatScroll()` + `scrollChatToBottom()` on every new stream shell (initial reply, tool-loop rounds, remounts). That re-pinned the viewport and jumped to the tail even when the user had scrolled away from the bottom.

**Fix:** Use `scrollChatIfPinned()` instead, which only scrolls when the user is already within the 80px pin threshold. Existing jump chip (`#chatJumpLatest` / `#chatAppJumpLatest`) continues to appear when scrolled up.

## Acceptance (MIN-277)

- [x] Scrolled-up user stays in place when new message arrives
- [x] Bottom-pinned user still auto-scrolls (streaming tokens + completed messages already use `scrollChatIfPinned` / `scrollBottom`)
- [x] Jump chip already implemented (optional per issue)

## Tests

- Added `appendStreamingAssistantRow does not force scroll when user scrolled up`
- Added `appendStreamingAssistantRow follows tail when pinned near bottom`
- Existing `chat-scroll` suite passes

```bash
node ./node_modules/tsx/dist/cli.mjs --experimental-test-module-mocks --import ./test/test-loader.mjs --test --test-force-exit test/ui/chat-scroll.test.mjs test/ui/messages-stream-row.test.mjs
```

## Files changed

- `src/ui/messages.ts` — stream shell mount respects scroll pin
- `test/ui/messages-stream-row.test.mjs` — regression coverage
- `documentation/context.md` — scroll behavior note
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-277](https://linear.app/minnowai/issue/MIN-277/remove-new-chats-snapping)

<div><a href="https://cursor.com/agents/bc-bcc4c333-ce52-4005-9281-db20d60a15ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcc4c333-ce52-4005-9281-db20d60a15ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

