### PR TITLE
🐛 Fix TypeScript errors blocking npm run build (MIN-382)

### DIFF
--- a/src/os/desktop-workspace-rail.ts
+++ b/src/os/desktop-workspace-rail.ts
@@ -325,7 +325,7 @@ export function wireDesktopWorkspaceRail(): void {
     tab.addEventListener('click', () => handleTabClick(def.tab));
   }
 
-  const segmentGroup = document.querySelector('.mn-os-workspace-rail-drawer-segments');
+  const segmentGroup = document.querySelector<HTMLElement>('.mn-os-workspace-rail-drawer-segments');
   if (segmentGroup && segmentGroup.dataset.bound !== '1') {
     segmentGroup.dataset.bound = '1';
     for (const def of TAB_DEFS) {

--- a/src/ui/file-tree.ts
+++ b/src/ui/file-tree.ts
@@ -57,9 +57,9 @@ const loadingDirs = new Set<string>();
 
 /** Git status letters keyed by repo-relative path (MIN-198 file tree badges). */
 let gitStatusMap = new Map<string, string>();
-let gitStatusPollTimer: number | undefined;
+let gitStatusPollTimer: ReturnType<typeof setTimeout> | undefined;
 let gitStatusPollCwd: string | undefined;
-let gitStatusPollDebounce: number | undefined;
+let gitStatusPollDebounce: ReturnType<typeof setTimeout> | undefined;
 let gitStatusPollInFlight = false;
 
 /** Update git badge map and re-render visible file rows. */
@@ -69,7 +69,7 @@ export function setFileTreeGitStatus(map: Map<string, string>): void {
 }
 
 /** Git poll timers must not block `node --test` process exit (happy-dom uses Node timers). */
-function unrefPollTimerIfSupported(timer: ReturnType<typeof setInterval> | undefined): void {
+function unrefPollTimerIfSupported(timer: ReturnType<typeof setTimeout> | undefined): void {
   if (timer !== undefined && typeof timer === 'object' && 'unref' in timer) {
     (timer as NodeJS.Timeout).unref();
   }
@@ -93,12 +93,12 @@ export function startFileTreeGitStatusPoll(cwd?: string): void {
   if (gitStatusPollDebounce !== undefined) {
     clearTimeout(gitStatusPollDebounce);
   }
-  gitStatusPollDebounce = window.setTimeout(() => {
+  gitStatusPollDebounce = setTimeout(() => {
     gitStatusPollDebounce = undefined;
     void pollFileTreeGitStatus();
   }, 200);
   unrefPollTimerIfSupported(gitStatusPollDebounce);
-  gitStatusPollTimer = window.setInterval(() => {
+  gitStatusPollTimer = setInterval(() => {
     void pollFileTreeGitStatus();
   }, 5000);
   unrefPollTimerIfSupported(gitStatusPollTimer);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes four TypeScript errors on `main` that blocked `npx tsc --noEmit` and `npm run build`.

Resolves MIN-382.

## Changes

- **`src/os/desktop-workspace-rail.ts`** — Narrow `document.querySelector` for the drawer segment group to `HTMLElement` so `.dataset` is valid.
- **`src/ui/file-tree.ts`** — Type git poll timers as `ReturnType<typeof setTimeout>` and align `unrefPollTimerIfSupported` + timer assignments (`setTimeout` / `setInterval`) so browser and Node timer typings agree.

## Verification

- [x] `npx tsc --noEmit` exits 0
- [x] `npm run build` completes and produces `dist/`
- [x] Pure type fixes — no runtime behavior change intended

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-382](https://linear.app/minnowai/issue/MIN-382/main-fails-typecheck-npm-run-build-is-broken-4-tsc-errors)

<div><a href="https://cursor.com/agents/bc-85fd42b6-b8bf-4fb1-a614-da00261eb314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85fd42b6-b8bf-4fb1-a614-da00261eb314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

