### PR TITLE
Fix false Electron launch failure warning on npm start (MIN-264)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -1882,7 +1882,7 @@ Cursor-style **⋮ menu** on each history-backed user/assistant row (not on in-f
 
 | Command | What runs | Tools API | Typical use |
 |---------|-----------|-------------|---------------|
-| **`npm start`** | `node server.js` — Vite + `/api/tools` + auto-launches Electron via detached [`scripts/launch-electron-after-vite.mjs`](../scripts/launch-electron-after-vite.mjs) (separate process waits for Vite HTTP 200, then spawns shell; compiles `electron/dist/` on first run) | Yes | Default dev: tools, git/file ops, PDF attachments, server tool toggles enabled after ping |
+| **`npm start`** | `node server.js` — Vite + `/api/tools` + auto-launches Electron via detached [`scripts/launch-electron-after-vite.mjs`](../scripts/launch-electron-after-vite.mjs) (separate process waits for Vite HTTP 200, then spawns shell; compiles `electron/dist/` on first run). On Electron failure only, the launcher opens the system browser — `server.js` does not treat the detached launcher’s exit code as a launch failure (MIN-264). | Yes | Default dev: tools, git/file ops, PDF attachments, server tool toggles enabled after ping |
 | **`npm run dev`** | `vite` only | No | UI/HMR without Node tool handlers; server tools stay disabled in Settings |
 | **`npm run build`** | `tsc` + `vite build` → `dist/` | N/A (static deploy; no `server.js` in production unless you host it separately) |
 | **`npm run preview`** | `vite preview` | No | Smoke-test production bundle |

--- a/scripts/launch-electron-after-vite.mjs
+++ b/scripts/launch-electron-after-vite.mjs
@@ -6,7 +6,9 @@
 
 import { spawnElectronShell } from './spawn-electron.mjs';
 import { waitForMinnowDev } from './wait-for-minnow-dev.mjs';
+import { openBrowser } from './open-browser.mjs';
 import { resolveMinnowPort } from '../server/constants/minnow-port.js';
+import { readDevHostState } from '../server/runtime/dev-host-state.js';
 
 function readPortArg() {
   const idx = process.argv.indexOf('--port');
@@ -28,5 +30,9 @@ try {
 } catch (err) {
   const message = err instanceof Error ? err.message : String(err);
   console.error(`[electron] Launch failed: ${message}`);
+  const fallbackUrl =
+    readDevHostState()?.localUrl ?? `http://localhost:${preferredPort}/`;
+  console.warn(`[minnow] Opening system browser at ${fallbackUrl}`);
+  openBrowser(fallbackUrl);
   process.exit(1);
 }

--- a/scripts/open-browser.mjs
+++ b/scripts/open-browser.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Open the system default browser for a URL (platform-specific).
+ * Shared by server.js and the Electron launcher fallback path.
+ */
+
+import { spawn } from 'node:child_process';
+
+/**
+ * @param {string} url
+ */
+export function openBrowser(url) {
+  const platform = process.platform;
+  let command;
+  let args;
+
+  if (platform === 'win32') {
+    command = 'cmd';
+    args = ['/c', 'start', '', url];
+  } else if (platform === 'darwin') {
+    command = 'open';
+    args = [url];
+  } else {
+    command = 'xdg-open';
+    args = [url];
+  }
+
+  const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+  child.unref();
+}

--- a/scripts/spawn-electron.mjs
+++ b/scripts/spawn-electron.mjs
@@ -170,8 +170,18 @@ export async function spawnElectronShell(options = {}) {
     windowsHide: false,
   });
 
-  child.on('error', (err) => {
-    console.error('[electron] Failed to launch:', err.message || err);
+  await new Promise((resolve, reject) => {
+    let settled = false;
+    child.once('error', (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err instanceof Error ? err : new Error(String(err)));
+    });
+    child.once('spawn', () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    });
   });
 
   if (!foreground) {

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@
 import { createServer } from 'vite';
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
+import { openBrowser } from './scripts/open-browser.mjs';
 import path from 'node:path';
 import { attachPtyWebSocketServer } from './server/terminal/pty-ws.js';
 import { attachSttWebSocketServer } from './server/stt/stt-ws.js';
@@ -88,28 +89,11 @@ process.on('unhandledRejection', (reason) => {
   console.error('[minnow] unhandledRejection (kept alive):', reason);
 });
 
-/** Open default browser for the dev URL (platform-specific). */
-function openBrowser(url) {
-  const platform = process.platform;
-  let command;
-  let args;
-
-  if (platform === 'win32') {
-    command = 'cmd';
-    args = ['/c', 'start', '', url];
-  } else if (platform === 'darwin') {
-    command = 'open';
-    args = [url];
-  } else {
-    command = 'xdg-open';
-    args = [url];
-  }
-
-  const child = spawn(command, args, { detached: true, stdio: 'ignore' });
-  child.unref();
-}
-
-/** Launch Electron in a child process (avoids Vite self-fetch deadlock). */
+/**
+ * Launch Electron in a detached child process (avoids Vite self-fetch deadlock).
+ * Success/failure is handled inside the launcher — do not treat its exit code as
+ * Electron launch status (MIN-264: detached bootstrap can exit non-zero spuriously).
+ */
 function launchElectronShell(port, localUrl, appRoot) {
   const launcher = path.join(appRoot, 'scripts', 'launch-electron-after-vite.mjs');
   const child = spawn(process.execPath, [launcher, '--port', String(port)], {
@@ -121,15 +105,8 @@ function launchElectronShell(port, localUrl, appRoot) {
 
   child.on('error', (err) => {
     const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[minnow] Electron launch failed (${message}); opening system browser.`);
+    console.warn(`[minnow] Electron launcher could not start (${message}); opening system browser.`);
     openBrowser(localUrl);
-  });
-
-  child.on('exit', (code) => {
-    if (code !== 0 && code !== null) {
-      console.warn(`[minnow] Electron launch failed (exit ${code}); opening system browser.`);
-      openBrowser(localUrl);
-    }
   });
 
   child.unref();

--- a/test/electron/electron-launch-fallback.test.mjs
+++ b/test/electron/electron-launch-fallback.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const serverJs = fs.readFileSync(path.join(repoRoot, 'server.js'), 'utf8');
+const launcherJs = fs.readFileSync(
+  path.join(repoRoot, 'scripts', 'launch-electron-after-vite.mjs'),
+  'utf8',
+);
+
+// MIN-264: detached launcher exit codes are not a reliable Electron success signal.
+describe('electron launch fallback (MIN-264)', () => {
+  test('server.js does not treat launcher exit code as Electron failure', () => {
+    assert.doesNotMatch(
+      serverJs,
+      /child\.on\('exit'/,
+      'server must not listen for detached launcher exit codes',
+    );
+    assert.doesNotMatch(
+      serverJs,
+      /Electron launch failed \(exit/,
+      'misleading exit-code warning must not appear in server.js',
+    );
+  });
+
+  test('launcher opens the system browser only on its own failure path', () => {
+    assert.match(
+      launcherJs,
+      /openBrowser\(fallbackUrl\)/,
+      'launcher should open the browser when Electron cannot start',
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes MIN-264: `npm start` showed `[minnow] Electron launch failed (exit 1); opening system browser` even when the Electron shell launched successfully, which also opened an unwanted browser tab.

## Root cause

`server.js` treated the detached launcher process (`scripts/launch-electron-after-vite.mjs`) exit code as Electron launch success/failure. That bootstrap process spawns Electron detached and exits independently — its exit code is not a reliable signal that the desktop shell failed.

## Changes

- **Remove launcher `exit` handler from `server.js`** — no more false-positive warning or browser fallback on launcher exit.
- **Move browser fallback into `launch-electron-after-vite.mjs`** — only opens the system browser when Electron actually fails to start.
- **Extract `scripts/open-browser.mjs`** — shared by `server.js` (launcher spawn error + `MINNOW_BROWSER=1`) and the launcher fallback path.
- **Await Electron `spawn` confirmation in `spawn-electron.mjs`** — real spawn failures now propagate to the launcher catch block.
- **Add regression tests** in `test/electron/electron-launch-fallback.test.mjs`.

## Testing

- `node --test --test-force-exit test/electron/electron-launch-fallback.test.mjs`
- Manual: verified `spawnElectronShell` and `launch-electron-after-vite.mjs` exit 0 when the dev server is up.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-264](https://linear.app/minnowai/issue/MIN-264/electron-launch-error-shown-even-though-app-opens-successfully)

<div><a href="https://cursor.com/agents/bc-308b1bb5-350e-4744-9d4e-243655a70329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-308b1bb5-350e-4744-9d4e-243655a70329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

