### PR TITLE
✨ Build-mode todo checklist (MIN-273)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -1831,6 +1831,22 @@ While the loop is active (`activeGoal` and not `achieved`), **tool approvals aut
 
 **Tests:** `test/chat/goal-parse-response.test.mts`, `test/chat/goal-parse-command.test.mts`, `test/chat/goal-command.test.mts`, `test/chat/goal-evaluate.test.mts`, `test/chat/goal-completion-text.test.mts`, `test/server/validate-sessions-v2.test.mjs` (activeGoal round-trip).
 
+## Build progress checklist (`todo_write`, MIN-273)
+
+Claude Code–style **per-chat step tracking** for **regular Build-mode chats** (not Orchestrate board task chats). The agent calls client-side **`todo_write`** with replace-all semantics; the user sees a collapsible **Checklist** panel pinned above the composer.
+
+| Concern | Location |
+|---------|----------|
+| Tool + validation | [`src/tools/todo-tools.ts`](../src/tools/todo-tools.ts) — `validateTodoWriteArgs`, `executeTodoWrite` |
+| Catalog entry | [`src/tools/definitions.ts`](../src/tools/definitions.ts) — `todo_write` (agents group, label “Updating todo list”) |
+| Mode gating | [`src/chat/modes/tool-groups.ts`](../src/chat/modes/tool-groups.ts) — `todo` group on **build** + **debug** only; stripped on board via [`orchestrate-tool-filter.ts`](../src/chat/modes/orchestrate-tool-filter.ts) |
+| State | [`src/state/sessions.ts`](../src/state/sessions.ts) — `Chat.todos`, `setChatTodos`, `clearChatTodos`, `getChatTodos`; cleared on **`clearChat`** with `activeGoal` |
+| UI | [`src/ui/todo-panel.ts`](../src/ui/todo-panel.ts) — `syncTodoPanel`, `deriveTodoPanelView` |
+| Prompts | [`build.full.md`](../src/chat/prompts/modes/build.full.md) v7 — **Progress todos** section (conditional on tool availability) |
+| Headless | [`src/headless/execute-tool.ts`](../src/headless/execute-tool.ts) — build/debug only |
+
+**Tests:** `test/tools/todo-tools.test.mts`, `test/ui/todo-panel.test.mts`, `test/state/chat-todos.test.mts`, `test/tools/board-member-tool-filter.test.mts` (gating).
+
 ## Message actions (Epic C2 — features 15–17)
 
 Cursor-style **⋮ menu** on each history-backed user/assistant row (not on in-flight streaming shells).

--- a/src/chat/modes/orchestrate-tool-filter.ts
+++ b/src/chat/modes/orchestrate-tool-filter.ts
@@ -18,6 +18,7 @@ const BOARD_MEMBER_STRIPPED_TOOLS = new Set([
   'board_update_task',
   'board_set_autonomy',
   'delegate_tasks',
+  'todo_write',
 ]);
 
 /**

--- a/src/chat/modes/tool-groups.ts
+++ b/src/chat/modes/tool-groups.ts
@@ -102,6 +102,7 @@ export const TOOL_GROUP_IDS = {
   calendar: ['manage_calendar'],
   reef: ['check_reef_widget'],
   impeccable: ['load_impeccable_context', 'run_impeccable'],
+  todo: ['todo_write'],
 } as const;
 
 export type ToolGroupId = keyof typeof TOOL_GROUP_IDS;
@@ -161,6 +162,7 @@ export const MODE_ALLOWED_GROUPS: Record<ModeId, readonly ToolGroupId[]> = {
     'brain',
     'recall',
     'impeccable',
+    'todo',
   ],
   plan: [
     'util-basic',
@@ -219,6 +221,7 @@ export const MODE_ALLOWED_GROUPS: Record<ModeId, readonly ToolGroupId[]> = {
     'brain',
     'recall',
     'impeccable',
+    'todo',
   ],
 };
 

--- a/src/chat/prompts/modes/build.full.md
+++ b/src/chat/prompts/modes/build.full.md
@@ -2,7 +2,7 @@
 id: build
 kind: mode
 label: Build
-version: 6
+version: 7
 description: Full implementation mode with broad tool access.
 profileBodies: split
 toolPolicy:
@@ -14,6 +14,10 @@ toolPolicy:
 # Operating mode: Build ({{mode_label}})
 
 You are Minnow in **Build** mode. You implement code changes precisely. All tools are available, including file writes, shell execution, and git operations.
+
+## Progress todos
+
+If the `todo_write` tool is available, right after you understand the task call it with **3–8 concrete steps**. Keep **exactly one** item `in_progress` at a time. Update the list as steps complete — batch updates alongside your next tool call, never a lone update-only turn. Mark everything `completed` before your final report. If scope changes mid-task, rewrite the list once rather than thrashing. Skip `todo_write` for trivial one-step edits.
 
 ## Implementation discipline
 

--- a/src/chat/prompts/modes/build.lite.md
+++ b/src/chat/prompts/modes/build.lite.md
@@ -2,7 +2,7 @@
 id: build
 kind: mode
 label: Build
-version: 4
+version: 5
 description: Lite Build mode — implement with broad tool access.
 profileBodies: split
 toolPolicy:
@@ -13,6 +13,8 @@ toolPolicy:
 <!-- LITE -->
 
 **Build mode.** Implement precisely. All tools available.
+
+- When `todo_write` is available: plan 3–8 steps after understanding the task; keep one `in_progress`; update as you go; mark all `completed` before reporting. Skip for trivial one-step edits.
 
 - For external library/API work, confirm via Context7 and/or web tools before coding; grep repo for existing patterns.
 - Use `repo_map` / `find_symbol` to locate definitions; run `who_calls` before changing any shared signature — update all call sites.

--- a/src/headless/execute-tool.ts
+++ b/src/headless/execute-tool.ts
@@ -25,6 +25,7 @@ import { headlessApiUrl } from './server-context';
 import { validateToolRequiredArgs } from '../tools/validate-tool-required-args';
 import { resolveWebSearchExecution } from '../tools/web-search-routing';
 import { isLocalServerAvailable } from '../tools/config';
+import { executeTodoWrite } from '../tools/todo-tools';
 
 /** Browser-catalog tools that run on the server when the tool server is up (BUG-011). */
 const SERVER_PROXY_BROWSER_TOOLS = new Set(['fetch_web_content', 'rag_web_content']);
@@ -59,9 +60,13 @@ function isBrowserOnlyTool(name: string): boolean {
 
 /** Tools exposed to the model in headless mode (server-capable + policy). */
 export function getHeadlessToolDefinitions(modeId: ModeId): OpenAIFunctionDefinition[] {
+  const normalized = normalizeModeId(modeId);
   const catalog = BUILT_IN_TOOLS.filter((tool) => {
     if (!isToolEnabled(tool.id)) return false;
     const fn = tool.definition.function.name;
+    if (fn === 'todo_write') {
+      return normalized === 'build' || normalized === 'debug';
+    }
     if (SERVER_PROXY_BROWSER_TOOLS.has(fn)) return true;
     if (tool.previewRequired) return false;
     if (!tool.serverRequired && isBrowserOnlyTool(fn)) {
@@ -141,6 +146,11 @@ export async function executeHeadlessTool(
           'Error: ask_question is not available in non-interactive headless mode. Proceed without user input or split the task.',
       };
     }
+  }
+
+  if (name === 'todo_write') {
+    const text = executeTodoWrite(args, { chatId: context.chatId });
+    return { content: text };
   }
 
   if (isBrowserOnlyTool(name) && (!tool || tool.previewRequired || !tool.serverRequired)) {

--- a/src/headless/runner.ts
+++ b/src/headless/runner.ts
@@ -341,6 +341,7 @@ export async function runHeadless(options: RunHeadlessOptions): Promise<Headless
             {
               modeId,
               workAgentId: workAgentId ?? undefined,
+              chatId: chat.id,
             },
             approvalOpts,
           );

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,6 +150,7 @@ import { bindExpertsSettingsCheckbox } from './ui/experts-settings';
 import { initReefBridge } from './chat/reef/index.ts';
 import { syncComposerPinnedSkillFromActiveChat } from './ui/composer-pinned-skill';
 import { syncGoalActiveHint } from './ui/goal-active-hint';
+import { syncTodoPanel } from './ui/todo-panel';
 import {
   initOrchestratePlanSelector,
   syncOrchestratePlanStripFromActiveChat,
@@ -414,6 +415,7 @@ export async function initApp(): Promise<void> {
   syncComposerPinnedSkillFromActiveChat();
   syncViewModeToggleFromActiveChat();
   syncGoalActiveHint();
+  syncTodoPanel();
   renderSidebar();
   bootstrapActiveChatOpenedTimestamp();
 

--- a/src/state/sessions.ts
+++ b/src/state/sessions.ts
@@ -92,6 +92,7 @@ import type {
   ActiveGoalState,
   Chat,
   ChatGroup,
+  ChatTodo,
   ExpertSelection,
   Message,
   OrchestrateBoardState,
@@ -1071,6 +1072,32 @@ function ensurePersistedSubAgentRuns(
   return out.length ? out : undefined;
 }
 
+const MAX_CHAT_TODO_ITEMS = 20;
+const MAX_CHAT_TODO_TEXT_CHARS = 140;
+
+function normalizeChatTodoStatus(raw: unknown): ChatTodo['status'] {
+  if (raw === 'completed' || raw === 'in_progress' || raw === 'pending') return raw;
+  return 'pending';
+}
+
+/** Sanitize persisted todos — drop malformed rows and cap length. */
+function ensureChatTodos(raw: unknown): ChatTodo[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: ChatTodo[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const row = item as Record<string, unknown>;
+    const text = typeof row.text === 'string' ? row.text.trim().slice(0, MAX_CHAT_TODO_TEXT_CHARS) : '';
+    if (!text) continue;
+    out.push({
+      text,
+      status: normalizeChatTodoStatus(row.status),
+    });
+    if (out.length >= MAX_CHAT_TODO_ITEMS) break;
+  }
+  return out.length ? out : undefined;
+}
+
 function ensureActiveGoal(raw: unknown): ActiveGoalState | undefined {
   if (!raw || typeof raw !== 'object') return undefined;
   const goal = raw as Record<string, unknown>;
@@ -1119,6 +1146,13 @@ export function ensureChatShape(raw: Partial<Chat> | null | undefined): Chat {
   }
   const pinnedSkill = ensurePinnedSkill(raw.pinnedSkill);
   const activeGoal = ensureActiveGoal(raw.activeGoal);
+  const todos = ensureChatTodos(raw.todos);
+  const todosUpdatedAt =
+    typeof raw.todosUpdatedAt === 'number' &&
+    Number.isFinite(raw.todosUpdatedAt) &&
+    raw.todosUpdatedAt > 0
+      ? raw.todosUpdatedAt
+      : undefined;
   const pendingMessageQueue = ensurePendingMessageQueue(raw.pendingMessageQueue);
   const pendingSteerMessage =
     typeof raw.pendingSteerMessage === 'string' && raw.pendingSteerMessage.trim()
@@ -1213,6 +1247,8 @@ export function ensureChatShape(raw: Partial<Chat> | null | undefined): Chat {
       : {}),
     ...(pinnedSkill ? { pinnedSkill } : {}),
     ...(activeGoal ? { activeGoal } : {}),
+    ...(todos ? { todos } : {}),
+    ...(todos && todosUpdatedAt ? { todosUpdatedAt } : {}),
     ...(pendingMessageQueue ? { pendingMessageQueue } : {}),
     ...(pendingSteerMessage ? { pendingSteerMessage } : {}),
   };
@@ -1586,6 +1622,31 @@ export function clearActiveGoal(chat: Chat): void {
   chat.activeGoal = undefined;
   touchChat(chat);
   scheduleSaveSessions();
+}
+
+/** Replace the build-agent progress checklist on a chat (todo_write). */
+export function setChatTodos(chat: Chat, todos: ChatTodo[]): void {
+  chat.todos = todos.slice(0, MAX_CHAT_TODO_ITEMS).map((item) => ({
+    text: item.text.trim().slice(0, MAX_CHAT_TODO_TEXT_CHARS),
+    status: normalizeChatTodoStatus(item.status),
+  }));
+  chat.todosUpdatedAt = Date.now();
+  touchChat(chat);
+  scheduleSaveSessions();
+}
+
+/** Clear build-agent todos (/clear or empty todo_write). */
+export function clearChatTodos(chat: Chat): void {
+  if (!chat.todos?.length && chat.todosUpdatedAt === undefined) return;
+  chat.todos = undefined;
+  chat.todosUpdatedAt = undefined;
+  touchChat(chat);
+  scheduleSaveSessions();
+}
+
+/** Read persisted build-agent todos. */
+export function getChatTodos(chat: Chat): ChatTodo[] | undefined {
+  return chat.todos?.length ? chat.todos : undefined;
 }
 
 /** Read persisted goal state (may be achieved but still visible until cleared). */

--- a/src/styles/composer-controls.css
+++ b/src/styles/composer-controls.css
@@ -93,6 +93,100 @@
   display: none;
 }
 
+.composer-todo-panel {
+  margin: 0 0 8px;
+  border: 1px solid var(--mn-border-subtle);
+  border-radius: 8px;
+  background: var(--mn-bg-elevated);
+  overflow: hidden;
+}
+
+.composer-todo-panel.hidden {
+  display: none;
+}
+
+.composer-todo-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--mn-fg);
+  font-size: 0.74rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.composer-todo-panel__header:hover {
+  background: var(--mn-bg-hover);
+}
+
+.composer-todo-panel__title {
+  flex: 0 0 auto;
+  font-weight: 600;
+}
+
+.composer-todo-panel__progress {
+  flex: 1 1 auto;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--mn-border-subtle);
+  overflow: hidden;
+}
+
+.composer-todo-panel__progress-fill {
+  display: block;
+  height: 100%;
+  background: var(--mn-accent);
+  border-radius: inherit;
+  transition: width 0.2s ease;
+}
+
+.composer-todo-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0 10px 8px;
+}
+
+.composer-todo-panel__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  padding: 3px 0;
+  min-width: 0;
+}
+
+.composer-todo-panel__glyph {
+  flex: 0 0 auto;
+  width: 1rem;
+  text-align: center;
+}
+
+.composer-todo-panel__text {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-todo-panel__item--completed .composer-todo-panel__text {
+  color: var(--mn-fg-subtle);
+  text-decoration: line-through;
+}
+
+.composer-todo-panel__item--in_progress .composer-todo-panel__glyph,
+.composer-todo-panel__item--in_progress .composer-todo-panel__text {
+  color: var(--mn-accent);
+}
+
+.composer-todo-panel__item--pending .composer-todo-panel__glyph {
+  color: var(--mn-fg-subtle);
+}
+
 .composer-background-stream-hint__link {
   border: none;
   background: none;

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -5,6 +5,7 @@
 
 import { executeBrowserTool } from './browser-executor';
 import { executeBoardTool } from './board-tools';
+import { executeTodoWrite } from './todo-tools';
 import { executeBugBoardTool } from './bug-board-tools';
 import { executeSubAgentTool } from './sub-agent-executor';
 import { runCommandWithTerminalStream } from '../ui/terminal-panel';
@@ -334,6 +335,13 @@ async function executeToolInner(
     const text = await executeBoardTool(name, args, {
       chatId: context?.chatId,
     });
+    return { content: text };
+  }
+
+  if (name === 'todo_write') {
+    const blocked = await maybeBlockToolForUserApproval(name, args, context, name);
+    if (blocked) return blocked;
+    const text = executeTodoWrite(args, { chatId: context?.chatId });
     return { content: text };
   }
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1074,6 +1074,37 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
     ),
   },
   {
+    id: 'todo_write',
+    label: 'Updating todo list',
+    description:
+      'Replace the build progress checklist with an ordered list of steps (max 20). Keep exactly one item in_progress.',
+    category: 'agents',
+    serverRequired: false,
+    definition: toolSchema(
+      'todo_write',
+      'Update the visible build progress checklist. Pass the full ordered list each call (replace-all). Use 3–8 concrete steps; mark completed items as you finish.',
+      {
+        todos: {
+          type: 'array',
+          description: 'Full replacement checklist (empty clears the list)',
+          items: {
+            type: 'object',
+            properties: {
+              text: { type: 'string', description: 'Step description (max 140 chars)' },
+              status: {
+                type: 'string',
+                enum: ['pending', 'in_progress', 'completed'],
+                description: 'Step status',
+              },
+            },
+            required: ['text', 'status'],
+          },
+        },
+      },
+      ['todos'],
+    ),
+  },
+  {
     id: 'bug_add',
     label: 'Bug add',
     description: 'Add a bug card to the Reported column (All bugs screen).',

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -123,6 +123,7 @@ import {
 } from '../ui/composer-send';
 import { syncComposerMessageQueue } from '../ui/composer-message-queue';
 import { syncGoalActiveHint } from '../ui/goal-active-hint';
+import { syncTodoPanel } from '../ui/todo-panel';
 import {
   clearComposerInput,
   resolveComposerSurface,
@@ -2387,6 +2388,7 @@ export async function sendMessageWithTools(
   syncComposerPinnedSkillFromActiveChat();
   scheduleSaveSessions();
   syncGoalActiveHint();
+  syncTodoPanel();
 
   await runChatTurn({
     chat,

--- a/src/tools/todo-tools.ts
+++ b/src/tools/todo-tools.ts
@@ -1,0 +1,161 @@
+/**
+ * Client-side todo_write tool — build-mode progress checklist (MIN-273).
+ */
+
+import {
+  clearChatTodos,
+  findChatById,
+  getChatTodos,
+  setChatTodos,
+} from '../state/sessions';
+import type { Chat, ChatTodo } from '../types';
+import { syncTodoPanel } from '../ui/todo-panel';
+
+const MAX_TODO_ITEMS = 20;
+const MAX_TODO_TEXT_CHARS = 140;
+
+export type TodoWriteArgs = {
+  todos: ChatTodo[];
+};
+
+export type ValidateTodoWriteResult =
+  | { ok: true; args: TodoWriteArgs }
+  | { ok: false; error: string };
+
+/** Coerce JSON array fields some models stringify or wrap in tool arguments. */
+function coerceToolArrayField(value: unknown): unknown[] | null {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(parsed)) return parsed;
+      if (typeof parsed === 'object' && parsed !== null) return [parsed];
+      return null;
+    } catch {
+      return null;
+    }
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    if ('item' in obj) return coerceToolArrayField(obj.item);
+    if ('items' in obj) return coerceToolArrayField(obj.items);
+  }
+  return null;
+}
+
+/** Normalize status synonyms from smaller models (tolerant, never rejects). */
+export function normalizeTodoStatus(raw: unknown): ChatTodo['status'] {
+  if (typeof raw !== 'string') return 'pending';
+  const v = raw.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (!v) return 'pending';
+  if (/^(done|complete|completed|finished|finish)$/.test(v)) return 'completed';
+  if (/^(active|current|doing|in_progress|inprogress|working|progress)$/.test(v)) {
+    return 'in_progress';
+  }
+  if (/^(todo|open|not_started|notstarted|pending|waiting)$/.test(v)) return 'pending';
+  if (v === 'completed' || v === 'in_progress' || v === 'pending') {
+    return v as ChatTodo['status'];
+  }
+  return 'pending';
+}
+
+/** Normalize todo_write payload shape before validation. */
+export function normalizeTodoWriteArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const todos = coerceToolArrayField(args.todos);
+  return {
+    ...args,
+    ...(todos ? { todos } : {}),
+  };
+}
+
+/** Validate and sanitize todo_write arguments (exported for tests). */
+export function validateTodoWriteArgs(args: Record<string, unknown>): ValidateTodoWriteResult {
+  const normalized = normalizeTodoWriteArgs(args);
+  const rawTodos = normalized.todos;
+
+  if (rawTodos === undefined) {
+    return { ok: false, error: 'Error: todo_write requires "todos" array' };
+  }
+  if (!Array.isArray(rawTodos)) {
+    return { ok: false, error: 'Error: todo_write requires "todos" array' };
+  }
+
+  const parsed: ChatTodo[] = [];
+  for (const item of rawTodos.slice(0, MAX_TODO_ITEMS)) {
+    if (!item || typeof item !== 'object') continue;
+    const row = item as Record<string, unknown>;
+    const textRaw = typeof row.text === 'string' ? row.text : String(row.text ?? '');
+    const text = textRaw.trim().slice(0, MAX_TODO_TEXT_CHARS);
+    if (!text) continue;
+    parsed.push({
+      text,
+      status: normalizeTodoStatus(row.status),
+    });
+  }
+
+  let sawInProgress = false;
+  const todos: ChatTodo[] = parsed.map((item) => {
+    if (item.status !== 'in_progress') return item;
+    if (!sawInProgress) {
+      sawInProgress = true;
+      return item;
+    }
+    return { ...item, status: 'pending' as const };
+  });
+
+  return { ok: true, args: { todos } };
+}
+
+export type TodoWriteExecutorContext = {
+  chatId?: string;
+};
+
+function formatTodoProgress(todos: ChatTodo[]): string {
+  const completed = todos.filter((t) => t.status === 'completed').length;
+  return `${completed}/${todos.length}`;
+}
+
+/** Execute todo_write — writes to the active chat and refreshes the checklist UI. */
+export function executeTodoWrite(
+  args: Record<string, unknown>,
+  context: TodoWriteExecutorContext = {},
+): string {
+  const validated = validateTodoWriteArgs(args);
+  if (validated.ok === false) return validated.error;
+
+  const chatId = context.chatId?.trim();
+  if (!chatId) {
+    return 'Error: todo_write requires an active chat context';
+  }
+
+  const chat = findChatById(chatId);
+  if (!chat) {
+    return 'Error: active chat not found';
+  }
+
+  if (chat.boardTaskId?.trim()) {
+    return 'Error: todo_write is not available on orchestrate board task chats';
+  }
+
+  const { todos } = validated.args;
+  if (todos.length === 0) {
+    clearChatTodos(chat);
+  } else {
+    setChatTodos(chat, todos);
+  }
+
+  syncTodoPanel();
+
+  return JSON.stringify({
+    progress: formatTodoProgress(getChatTodos(chat) ?? []),
+    todos: getChatTodos(chat) ?? [],
+  });
+}
+
+/** Defense helper for tests — whether todo_write may run on this chat. */
+export function isTodoWriteAllowedForChat(chat: Chat | null | undefined): boolean {
+  if (!chat) return false;
+  return !chat.boardTaskId?.trim();
+}

--- a/src/tools/validate-tool-required-args.ts
+++ b/src/tools/validate-tool-required-args.ts
@@ -47,6 +47,9 @@ export function validateToolRequiredArgs(
 
   const missing: string[] = [];
   for (const key of required) {
+    if (toolName === 'todo_write' && key === 'todos' && Array.isArray(args.todos)) {
+      continue;
+    }
     if (toolName === 'execute_command' && key === 'command') {
       if (args.background === true || args.stop === true) continue;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,12 @@ export interface UserMessage {
   goalAchieved?: boolean;
 }
 
+/** One build-agent progress item (todo_write). */
+export interface ChatTodo {
+  text: string;
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
 /** Persistent /goal loop state on a chat (Claude Code–style completion condition). */
 export interface ActiveGoalState {
   /** Completion condition text (max 4000 chars). */
@@ -785,6 +791,10 @@ export interface Chat {
   pendingMessageQueue?: QueuedComposerMessage[];
   /** Active /goal completion loop; persists across reload until cleared. */
   activeGoal?: ActiveGoalState;
+  /** Build-agent progress checklist (todo_write); replace-all, cleared on /clear. */
+  todos?: ChatTodo[];
+  /** Epoch ms when todos were last written via todo_write. */
+  todosUpdatedAt?: number;
   /** Queued mode switch from set_chat_mode during streaming (last write wins; flushed on stream end). */
   pendingModeId?: ModeId;
   /** Sidebar: green dot on inactive rows until the user opens this chat again. */

--- a/src/ui/composer-send.ts
+++ b/src/ui/composer-send.ts
@@ -13,6 +13,7 @@ import { setStatus } from './status';
 import { refreshActiveBoardIfMounted } from './orchestrate-board';
 import { syncBackgroundStreamHint } from './composer-stream-hint';
 import { syncGoalActiveHint } from './goal-active-hint';
+import { syncTodoPanel } from './todo-panel';
 import {
   syncComposerFollowUpPlaceholder,
   syncComposerMessageQueue,
@@ -141,6 +142,7 @@ export function syncComposerFromStreamingState(): void {
   syncComposerMessageQueue();
   syncComposerFollowUpPlaceholder(isActiveChatStreaming());
   syncGoalActiveHint();
+  syncTodoPanel();
   refreshActiveBoardIfMounted();
   void import('./composer-run-target').then((m) => m.refreshComposerRunTargetDisabled());
 }

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -22,6 +22,7 @@ import { setAssistantBubbleContent } from '../markdown/renderer';
 import { getActiveBoardGroup } from '../state/chat-groups';
 import {
   clearActiveGoal,
+  clearChatTodos,
   getActiveChat,
   touchChat,
   scheduleSaveSessions,
@@ -57,6 +58,7 @@ import { updateWorkspaceCodeChangeDisplay } from './workspace-code-change';
 import { resetTokenLedger } from '../usage/token-ledger';
 import { updateCodeChangeStrip } from './code-change-strip';
 import { renderSidebar } from './sidebar';
+import { syncTodoPanel } from './todo-panel';
 import { renderThoughtsToggle } from './thought-bubbles';
 import { renderToolCall, renderToolResult } from './tool-messages';
 import { attachShellKillUi } from './shell-run-ui';
@@ -666,6 +668,7 @@ export function clearChat(): void {
   if (!confirm('Clear all messages in this chat? The chat stays in your sidebar.')) return;
   const chat = getActiveChat();
   clearActiveGoal(chat);
+  clearChatTodos(chat);
   chat.history = [];
   resetTokenLedger(chat);
   resetCodeChangeTotals(chat);
@@ -682,5 +685,6 @@ export function clearChat(): void {
   renderStatsForChat(chat);
   renderSidebar();
   scheduleSaveSessions();
+  syncTodoPanel();
   closeDrawer();
 }

--- a/src/ui/sidebar.ts
+++ b/src/ui/sidebar.ts
@@ -22,6 +22,7 @@ import { createBoardCategoryIcon } from './board-category-icons';
 import { isChatAppForeground } from './chat-mount';
 import { syncComposerFromStreamingState } from './composer-send';
 import { syncGoalActiveHint } from './goal-active-hint';
+import { syncTodoPanel } from './todo-panel';
 import {
   createEmptyChatObject,
   getActiveChat,
@@ -1162,6 +1163,7 @@ export function switchChat(id: string): void {
   syncWorkAgentDevFromActiveChat();
   syncReefWidgetSettingsFromActiveChat();
   syncGoalActiveHint();
+  syncTodoPanel();
   onModelRoutingActiveChatChanged(chat.id);
   void refreshTerminalHistoryForActiveChat();
   syncComposerFromStreamingState();

--- a/src/ui/todo-panel.ts
+++ b/src/ui/todo-panel.ts
@@ -1,0 +1,170 @@
+/**
+ * Build-mode progress checklist pinned above the composer (todo_write).
+ */
+
+import { getActiveChat } from '../state/sessions';
+import { getChatTodos } from '../state/sessions';
+import type { Chat, ChatTodo } from '../types';
+
+export type TodoPanelItemView = {
+  text: string;
+  status: ChatTodo['status'];
+  marker: 'completed' | 'in_progress' | 'pending';
+};
+
+export type TodoPanelView = {
+  hidden: boolean;
+  progressLabel: string;
+  progressRatio: number;
+  items: TodoPanelItemView[];
+  defaultCollapsed: boolean;
+};
+
+/** Per-chat user collapse overrides survive syncTodoPanel re-renders. */
+const collapsedOverrideByChatId = new Set<string>();
+
+function markerForStatus(status: ChatTodo['status']): TodoPanelItemView['marker'] {
+  if (status === 'completed') return 'completed';
+  if (status === 'in_progress') return 'in_progress';
+  return 'pending';
+}
+
+/** Pure display helper for the checklist panel (unit-tested without DOM). */
+export function deriveTodoPanelView(chat: Chat | null | undefined): TodoPanelView {
+  const todos = chat ? (getChatTodos(chat) ?? []) : [];
+  if (!todos.length) {
+    return {
+      hidden: true,
+      progressLabel: '',
+      progressRatio: 0,
+      items: [],
+      defaultCollapsed: true,
+    };
+  }
+
+  const completed = todos.filter((t) => t.status === 'completed').length;
+  const hasOpen = todos.some((t) => t.status === 'pending' || t.status === 'in_progress');
+  const allComplete = completed === todos.length && todos.length > 0;
+  const progressLabel = allComplete ? `${completed}/${todos.length} ✓` : `${completed}/${todos.length}`;
+  const progressRatio = todos.length ? completed / todos.length : 0;
+
+  return {
+    hidden: false,
+    progressLabel,
+    progressRatio,
+    items: todos.map((item) => ({
+      text: item.text,
+      status: item.status,
+      marker: markerForStatus(item.status),
+    })),
+    defaultCollapsed: allComplete,
+  };
+}
+
+function isPanelCollapsed(chatId: string, view: TodoPanelView): boolean {
+  if (collapsedOverrideByChatId.has(chatId)) return true;
+  return view.defaultCollapsed;
+}
+
+/** Show, hide, or refresh the collapsible checklist above the composer. */
+export function syncTodoPanel(): void {
+  if (typeof document === 'undefined') return;
+
+  const chat = getActiveChat();
+  const chatId = chat?.id ?? '';
+  const view = deriveTodoPanelView(chat);
+
+  let el = document.getElementById('composerTodoPanel');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'composerTodoPanel';
+    el.className = 'composer-todo-panel hidden';
+    el.setAttribute('role', 'region');
+    el.setAttribute('aria-label', 'Build progress checklist');
+    const host = document.querySelector('.input-bar-composer');
+    if (host) {
+      host.insertBefore(el, host.firstChild);
+    } else {
+      document.body.appendChild(el);
+    }
+  }
+
+  if (view.hidden || !chat) {
+    el.classList.add('hidden');
+    el.replaceChildren();
+    return;
+  }
+
+  el.classList.remove('hidden');
+  const collapsed = isPanelCollapsed(chatId, view);
+
+  el.replaceChildren();
+
+  const header = document.createElement('button');
+  header.type = 'button';
+  header.className = 'composer-todo-panel__header';
+  header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+
+  const title = document.createElement('span');
+  title.className = 'composer-todo-panel__title';
+  title.textContent = `Checklist ${view.progressLabel}`;
+
+  const bar = document.createElement('span');
+  bar.className = 'composer-todo-panel__progress';
+  bar.setAttribute('aria-hidden', 'true');
+  const fill = document.createElement('span');
+  fill.className = 'composer-todo-panel__progress-fill';
+  fill.style.width = `${Math.round(view.progressRatio * 100)}%`;
+  bar.appendChild(fill);
+
+  header.appendChild(title);
+  header.appendChild(bar);
+
+  header.addEventListener('click', () => {
+    if (collapsedOverrideByChatId.has(chatId)) {
+      collapsedOverrideByChatId.delete(chatId);
+    } else {
+      collapsedOverrideByChatId.add(chatId);
+    }
+    syncTodoPanel();
+  });
+
+  el.appendChild(header);
+
+  if (!collapsed) {
+    const list = document.createElement('ul');
+    list.className = 'composer-todo-panel__list';
+
+    for (const item of view.items) {
+      const row = document.createElement('li');
+      row.className = `composer-todo-panel__item composer-todo-panel__item--${item.marker}`;
+      row.title = item.text;
+
+      const glyph = document.createElement('span');
+      glyph.className = 'composer-todo-panel__glyph';
+      glyph.setAttribute('aria-hidden', 'true');
+      glyph.textContent =
+        item.marker === 'completed' ? '✓' : item.marker === 'in_progress' ? '●' : '○';
+
+      const text = document.createElement('span');
+      text.className = 'composer-todo-panel__text';
+      text.textContent = item.text;
+
+      row.appendChild(glyph);
+      row.appendChild(text);
+      list.appendChild(row);
+    }
+
+    el.appendChild(list);
+  }
+}
+
+/** Test helper — read collapse override state for a chat. */
+export function isTodoPanelCollapsedOverride(chatId: string): boolean {
+  return collapsedOverrideByChatId.has(chatId);
+}
+
+/** Test helper — reset module collapse overrides. */
+export function resetTodoPanelCollapseOverridesForTests(): void {
+  collapsedOverrideByChatId.clear();
+}

--- a/test/state/chat-todos.test.mts
+++ b/test/state/chat-todos.test.mts
@@ -1,0 +1,60 @@
+/**
+ * Chat todos persistence via sessions (MIN-273).
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+import {
+  clearChatTodos,
+  createEmptyChatObject,
+  ensureChatShape,
+  flushScheduledSessionSaveForTests,
+  getChatTodos,
+  setChatTodos,
+  setSessionStateForTests,
+} from '../../src/state/sessions.ts';
+
+afterEach(() => {
+  flushScheduledSessionSaveForTests();
+  setSessionStateForTests(null);
+});
+
+describe('chat todos sessions', () => {
+  test('setChatTodos and clearChatTodos mutate chat state', () => {
+    const chat = createEmptyChatObject('m1');
+    setChatTodos(chat, [
+      { text: 'Step one', status: 'in_progress' },
+      { text: 'Step two', status: 'pending' },
+    ]);
+    assert.equal(getChatTodos(chat)?.length, 2);
+    assert.ok(typeof chat.todosUpdatedAt === 'number');
+
+    clearChatTodos(chat);
+    assert.equal(getChatTodos(chat), undefined);
+    assert.equal(chat.todosUpdatedAt, undefined);
+  });
+
+  test('ensureChatShape restores and sanitizes todos', () => {
+    const restored = ensureChatShape({
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'Test',
+      workspacePath: '',
+      modelId: '',
+      history: [],
+      lastStats: null,
+      modelInfo: {},
+      updatedAt: 1,
+      lastMessageAt: 1,
+      todos: [
+        { text: '  keep me  ', status: 'completed' },
+        { text: '', status: 'pending' },
+        { text: 'y'.repeat(200), status: 'bogus' },
+      ],
+      todosUpdatedAt: 99,
+    });
+    assert.equal(restored.todos?.length, 2);
+    assert.equal(restored.todos?.[0]?.text, 'keep me');
+    assert.equal(restored.todos?.[1]?.text.length, 140);
+    assert.equal(restored.todosUpdatedAt, 99);
+  });
+});

--- a/test/tools/board-member-tool-filter.test.mts
+++ b/test/tools/board-member-tool-filter.test.mts
@@ -156,6 +156,20 @@ describe('applyBoardMemberToolFilter', () => {
     assert.ok(!names.includes('board_init'));
     assert.ok(!names.includes('board_update_task'));
     assert.ok(!names.includes('delegate_tasks'));
+    assert.ok(!names.includes('todo_write'), 'todo_write should be stripped on board task chats');
+  });
+
+  test('todo_write is available for plain build chats but not orchestrate', () => {
+    seedBoardSession();
+    const plainBuild = createEmptyChatObject('', '');
+    plainBuild.modeId = 'build';
+    const buildNames = getEnabledToolDefinitionsForChat(plainBuild).map((d) => d.function.name);
+    assert.ok(buildNames.includes('todo_write'));
+
+    const planner = createEmptyChatObject('', '');
+    planner.modeId = 'orchestrate';
+    const orchestrateNames = getEnabledToolDefinitionsForChat(planner).map((d) => d.function.name);
+    assert.ok(!orchestrateNames.includes('todo_write'));
   });
 
   test('strips planner-only board tools for board task chats', () => {

--- a/test/tools/todo-tools.test.mts
+++ b/test/tools/todo-tools.test.mts
@@ -1,0 +1,174 @@
+/**
+ * todo_write validation and execution (MIN-273).
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+import {
+  executeTodoWrite,
+  normalizeTodoStatus,
+  validateTodoWriteArgs,
+} from '../../src/tools/todo-tools.ts';
+import {
+  createEmptyChatObject,
+  flushScheduledSessionSaveForTests,
+  getChatTodos,
+  setSessionStateForTests,
+} from '../../src/state/sessions.ts';
+
+const CHAT_ID = '11111111-1111-1111-1111-111111111111';
+
+function seedChat(overrides: { boardTaskId?: string } = {}) {
+  const chat = createEmptyChatObject('m1');
+  chat.id = CHAT_ID;
+  chat.modeId = 'build';
+  if (overrides.boardTaskId) chat.boardTaskId = overrides.boardTaskId;
+  setSessionStateForTests({
+    version: 5,
+    activeId: chat.id,
+    sidebarCollapsed: false,
+    chats: [chat],
+  });
+  return chat;
+}
+
+afterEach(() => {
+  flushScheduledSessionSaveForTests();
+  setSessionStateForTests(null);
+});
+
+describe('validateTodoWriteArgs', () => {
+  test('accepts a valid ordered list', () => {
+    const result = validateTodoWriteArgs({
+      todos: [
+        { text: 'Read code', status: 'completed' },
+        { text: 'Implement feature', status: 'in_progress' },
+        { text: 'Run tests', status: 'pending' },
+      ],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.args.todos.length, 3);
+    assert.equal(result.args.todos[1]?.status, 'in_progress');
+  });
+
+  test('empty list clears the checklist', () => {
+    const result = validateTodoWriteArgs({ todos: [] });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.args.todos, []);
+  });
+
+  test('caps at 20 items', () => {
+    const todos = Array.from({ length: 25 }, (_, i) => ({
+      text: `Step ${i + 1}`,
+      status: 'pending',
+    }));
+    const result = validateTodoWriteArgs({ todos });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.args.todos.length, 20);
+  });
+
+  test('truncates long text to 140 chars', () => {
+    const long = 'x'.repeat(200);
+    const result = validateTodoWriteArgs({
+      todos: [{ text: long, status: 'pending' }],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.args.todos[0]?.text.length, 140);
+  });
+
+  test('normalizes status synonyms', () => {
+    assert.equal(normalizeTodoStatus('done'), 'completed');
+    assert.equal(normalizeTodoStatus('ACTIVE'), 'in_progress');
+    assert.equal(normalizeTodoStatus('not started'), 'pending');
+
+    const result = validateTodoWriteArgs({
+      todos: [
+        { text: 'A', status: 'finished' },
+        { text: 'B', status: 'doing' },
+        { text: 'C', status: 'open' },
+      ],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(
+      result.args.todos.map((t) => t.status),
+      ['completed', 'in_progress', 'pending'],
+    );
+  });
+
+  test('demotes extra in_progress items to pending', () => {
+    const result = validateTodoWriteArgs({
+      todos: [
+        { text: 'A', status: 'in_progress' },
+        { text: 'B', status: 'in_progress' },
+        { text: 'C', status: 'in_progress' },
+      ],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(
+      result.args.todos.map((t) => t.status),
+      ['in_progress', 'pending', 'pending'],
+    );
+  });
+
+  test('coerces stringified todos array', () => {
+    const payload = JSON.stringify([
+      { text: 'Parse me', status: 'pending' },
+    ]);
+    const result = validateTodoWriteArgs({ todos: payload });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.args.todos[0]?.text, 'Parse me');
+  });
+});
+
+describe('executeTodoWrite', () => {
+  test('writes todos to the active chat and returns progress', () => {
+    const chat = seedChat();
+    const out = executeTodoWrite(
+      {
+        todos: [
+          { text: 'One', status: 'completed' },
+          { text: 'Two', status: 'in_progress' },
+          { text: 'Three', status: 'pending' },
+        ],
+      },
+      { chatId: CHAT_ID },
+    );
+    const parsed = JSON.parse(out) as { progress: string; todos: unknown[] };
+    assert.equal(parsed.progress, '1/3');
+    assert.equal(getChatTodos(chat)?.length, 3);
+  });
+
+  test('empty list clears todos', () => {
+    const chat = seedChat();
+    executeTodoWrite(
+      { todos: [{ text: 'Only step', status: 'pending' }] },
+      { chatId: CHAT_ID },
+    );
+    assert.equal(getChatTodos(chat)?.length, 1);
+    const out = executeTodoWrite({ todos: [] }, { chatId: CHAT_ID });
+    assert.match(out, /"progress":"0\/0"/);
+    assert.equal(getChatTodos(chat), undefined);
+  });
+
+  test('errors when chat is missing', () => {
+    setSessionStateForTests(null);
+    const out = executeTodoWrite({ todos: [] }, { chatId: CHAT_ID });
+    assert.match(out, /^Error: active chat not found/);
+  });
+
+  test('rejects board task chats', () => {
+    seedChat({ boardTaskId: 'W1-A' });
+    const out = executeTodoWrite(
+      { todos: [{ text: 'Nope', status: 'pending' }] },
+      { chatId: CHAT_ID },
+    );
+    assert.match(out, /not available on orchestrate board task chats/);
+  });
+});

--- a/test/ui/todo-panel.test.mts
+++ b/test/ui/todo-panel.test.mts
@@ -1,0 +1,44 @@
+/**
+ * deriveTodoPanelView display helper (MIN-273).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { createEmptyChatObject } from '../../src/state/sessions.ts';
+import { setChatTodos } from '../../src/state/sessions.ts';
+import { deriveTodoPanelView } from '../../src/ui/todo-panel.ts';
+
+describe('deriveTodoPanelView', () => {
+  test('hidden when chat has no todos', () => {
+    const chat = createEmptyChatObject('m1');
+    const view = deriveTodoPanelView(chat);
+    assert.equal(view.hidden, true);
+    assert.equal(view.items.length, 0);
+  });
+
+  test('expanded while work remains', () => {
+    const chat = createEmptyChatObject('m1');
+    setChatTodos(chat, [
+      { text: 'Done', status: 'completed' },
+      { text: 'Now', status: 'in_progress' },
+      { text: 'Later', status: 'pending' },
+    ]);
+    const view = deriveTodoPanelView(chat);
+    assert.equal(view.hidden, false);
+    assert.equal(view.defaultCollapsed, false);
+    assert.equal(view.progressLabel, '1/3');
+    assert.equal(view.items[1]?.marker, 'in_progress');
+  });
+
+  test('collapsed label when all complete', () => {
+    const chat = createEmptyChatObject('m1');
+    setChatTodos(chat, [
+      { text: 'A', status: 'completed' },
+      { text: 'B', status: 'completed' },
+    ]);
+    const view = deriveTodoPanelView(chat);
+    assert.equal(view.defaultCollapsed, true);
+    assert.equal(view.progressLabel, '2/2 ✓');
+    assert.equal(view.progressRatio, 1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **MIN-273**: a Claude Code–style progress checklist for regular **Build** (and **Debug**) chats.

- Adds client-side `todo_write` tool with replace-all semantics, tolerant validation (synonyms, stringified arrays, text truncation, single `in_progress`)
- Persists `Chat.todos` / `todosUpdatedAt` through the existing session pipeline; cleared on chat clear alongside `activeGoal`
- Renders a collapsible **Checklist** panel above the composer (`syncTodoPanel`) that live-updates during agent turns
- Tool is available in build/debug mode for plain chats only — excluded from orchestrate board task chats via tool-group gating + `BOARD_MEMBER_STRIPPED_TOOLS`
- Updates Build mode prompts (full v7 / lite v5) to instruct agents to maintain the checklist when the tool is available
- Headless CLI supports `todo_write` in build/debug runs

## Test plan

- [x] `npx tsx --import ./test/test-loader.mjs --test test/tools/todo-tools.test.mts --test-force-exit`
- [x] `npx tsx --import ./test/test-loader.mjs --test test/ui/todo-panel.test.mts --test-force-exit`
- [x] `npx tsx --import ./test/test-loader.mjs --test test/state/chat-todos.test.mts --test-force-exit`
- [x] `npx tsx --import ./test/test-loader.mjs --test test/tools/board-member-tool-filter.test.mts --test-force-exit`
- [x] `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-273](https://linear.app/minnowai/issue/MIN-273/todo-list-within-builder)

<div><a href="https://cursor.com/agents/bc-25364d0d-6aa5-435d-a316-9885a2ec9749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25364d0d-6aa5-435d-a316-9885a2ec9749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

