### PR TITLE
🐛 Fix chat sessions disappearing across restarts (MIN-408)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -2022,7 +2022,7 @@ Order in `initApp()`:
 2. `await loadToolConfigFromStorage()` — read `tools.json` (or `minnow.tools`) **before** prompt/session UI so permission state is never stale on first paint; overlapping calls share one in-flight promise and the loader always resolves (falls back to `defaultToolConfig()` on unexpected errors, so Node tests never see a rejected load).
 3. `await initPromptSystem()` — built-in prompts + user registry from `/api/prompts/registry`.
 4. `await initWorkAgentSystem()` — work agents from glob + `/api/work-agents` overrides.
-5. `await loadSessionsFromStorage()` (no-op when already loaded from `startApp()`); `fillSystemPromptPresetSelect()` + `await loadSystemPromptSettings()`.
+5. `await loadSessionsFromStorage({ force: true })` when server mode (re-hydrates from `~/.minnow` after a localStorage boot race — **MIN-408**); otherwise no-op when already loaded from `startApp()`. `registerSessionPersistenceShutdownHandler()` flushes debounced saves on `pagehide` via `fetch` `keepalive`. Server PUT is blocked until a successful GET hydrates `sessionState` so an empty boot blob cannot clobber `sessions/state.json`.
 6. `fillToolsSection()` + `registerToolHandlers()`; `initAttachments()`; `initModeSelector()`; `initWorkAgentDevUi()`.
 7. `await detectLocalServer()` → `loadToolConfigIntoDrawer()` (server-required rows depend on ping).
 8. `applySidebarVisuals()` + `renderSidebar()`.

--- a/src/config/api-client.ts
+++ b/src/config/api-client.ts
@@ -93,6 +93,23 @@ export async function putSessions(state: SessionState): Promise<void> {
   await parseJsonResponse<{ ok: boolean }>(res);
 }
 
+/**
+ * Best-effort session save during `pagehide` / abrupt shutdown.
+ * `keepalive` lets the browser finish the request after the tab closes.
+ */
+export function putSessionsKeepalive(state: SessionState): void {
+  try {
+    void fetch('/api/config/sessions', {
+      method: 'PUT',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(state),
+      keepalive: true,
+    });
+  } catch {
+    /* ignore — nothing else we can do during unload */
+  }
+}
+
 /** GET /api/config/tools */
 export async function getTools(): Promise<ToolConfig> {
   const res = await fetch('/api/config/tools', { cache: 'no-store' });

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ import {
 } from './api/models';
 import { initWorkAgentSystem } from './agents/init-work-agents';
 import { initPromptSystem } from './chat/prompts/init-prompts';
-import { detectConfigServer, refreshConfigStorageBanner } from './config/storage-mode';
+import { detectConfigServer, isServerStorageMode, refreshConfigStorageBanner } from './config/storage-mode';
 import { runMigrationIfNeeded } from './config/migrate';
 import { detectLocalServer } from './tools/client';
 import { startSchedulerNotificationPoll } from './scheduler/notifications-poll';
@@ -99,6 +99,7 @@ import { loadAutopilotMeta } from './config/autopilot-meta';
 import {
   getActiveChat,
   loadSessionsFromStorage,
+  registerSessionPersistenceShutdownHandler,
   sessionState,
 } from './state/sessions';
 import { initChatScroll } from './ui/chat-scroll';
@@ -203,8 +204,9 @@ export async function initApp(): Promise<void> {
   await loadToolConfigFromStorage();
   await initPromptSystem();
   await initWorkAgentSystem();
-  await loadSessionsFromStorage();
+  await loadSessionsFromStorage(isServerStorageMode() ? { force: true } : undefined);
   registerOrchestrateBoardShutdownHandler();
+  registerSessionPersistenceShutdownHandler();
   const { loadBugsFromStorage, migrateBugsFromChats } = await import(
     './state/bug-board-store.ts'
   );

--- a/src/state/sessions.ts
+++ b/src/state/sessions.ts
@@ -3,7 +3,7 @@ import { abortChatTitleGeneration } from '../chat/titles/inflight';
 import { cleanupChatWorktreeOnDelete } from './chat-worktree';
 import { isPlaceholderChatName } from '../chat/titles/placeholder';
 import { setSaveTimer, saveTimer } from '../app-state';
-import { getSessions, putSessions } from '../config/api-client';
+import { getSessions, putSessions, putSessionsKeepalive } from '../config/api-client';
 import { defaultSessionState } from '../config/defaults';
 import { randomUUID } from '../lib/random-id.ts';
 import { isServerStorageMode } from '../config/storage-mode';
@@ -250,6 +250,14 @@ function ensureExpertSelection(raw: unknown): ExpertSelection {
 /** In-memory session blob mirrored to ~/.minnow or localStorage fallback. */
 export let sessionState: SessionState | null = null;
 
+/**
+ * Set after a successful GET from ~/.minnow. Blocks PUT until hydration so a boot-time
+ * localStorage fallback cannot clobber on-disk sessions (MIN-408).
+ */
+let sessionsHydratedFromServer = false;
+
+let sessionPersistenceShutdownRegistered = false;
+
 /** Resolves once `loadSessionsFromStorage()` has populated `sessionState`. */
 let resolveSessionsReady: () => void = () => undefined;
 export const sessionsReady: Promise<void> = new Promise((resolve) => {
@@ -271,7 +279,21 @@ export function setSessionStateForTests(state: SessionState | null): void {
   sessionState = state;
   if (state) {
     markSessionsReady();
+    sessionsHydratedFromServer = true;
+  } else {
+    sessionsHydratedFromServer = false;
   }
+}
+
+/** Reset persistence guards between unit tests. */
+export function resetSessionPersistenceForTests(): void {
+  sessionsHydratedFromServer = false;
+  sessionPersistenceShutdownRegistered = false;
+}
+
+/** Expose hydration guard for persistence unit tests. */
+export function isSessionsHydratedFromServerForTests(): boolean {
+  return sessionsHydratedFromServer;
 }
 
 export type SaveSessionsResult = 'ok' | 'quota_exceeded';
@@ -1614,12 +1636,22 @@ export async function loadSessionsFromStorage(options?: LoadSessionsOptions): Pr
         const remote = await getSessions();
         sessionState = parseSessionStateFromJson(remote);
         await runSessionCodeChangeBackfill(sessionState);
+        sessionsHydratedFromServer = true;
         return;
       } catch {
-        setStatus('err', 'Could not load sessions from ~/.minnow');
+        if (typeof document !== 'undefined') {
+          setStatus('err', 'Could not load sessions from ~/.minnow');
+        }
+        // Never fall through to localStorage when file-backed storage is active — that
+        // empty blob would later overwrite ~/.minnow on save (MIN-408).
+        if (!sessionState) {
+          sessionState = defaultSessionState();
+        }
+        return;
       }
     }
 
+    sessionsHydratedFromServer = false;
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
       if (!raw) {
@@ -1745,14 +1777,26 @@ function trimChatsIfNeeded(): void {
   }
 }
 
-export function saveSessionsNow(): SaveSessionsResult {
+export type SaveSessionsOptions = {
+  /** Use fetch keepalive for unload handlers (fire-and-forget). */
+  keepalive?: boolean;
+};
+
+export function saveSessionsNow(options?: SaveSessionsOptions): SaveSessionsResult {
   trimChatsIfNeeded();
   if (!sessionState) return 'ok';
 
   if (isServerStorageMode()) {
-    void putSessions(sessionState).catch(() => {
-      setStatus('err', 'Could not save sessions to ~/.minnow');
-    });
+    if (!sessionsHydratedFromServer) {
+      return 'ok';
+    }
+    if (options?.keepalive) {
+      putSessionsKeepalive(sessionState);
+    } else {
+      void putSessions(sessionState).catch(() => {
+        setStatus('err', 'Could not save sessions to ~/.minnow');
+      });
+    }
     void import('../ui/hub').then((m) => m.refreshHubLiveData());
     return 'ok';
   }
@@ -1786,6 +1830,24 @@ export function flushScheduledSessionSaveForTests(): void {
   clearTimeout(saveTimer);
   setSaveTimer(null);
   saveSessionsNow();
+}
+
+/** Flush debounced saves and persist immediately (pagehide / abrupt quit). */
+export function flushPendingSessionSaveOnShutdown(): void {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    setSaveTimer(null);
+  }
+  saveSessionsNow({ keepalive: true });
+}
+
+/** Register a one-time pagehide handler so debounced saves are not lost on quit. */
+export function registerSessionPersistenceShutdownHandler(): void {
+  if (sessionPersistenceShutdownRegistered || typeof window === 'undefined') return;
+  sessionPersistenceShutdownRegistered = true;
+  window.addEventListener('pagehide', () => {
+    flushPendingSessionSaveOnShutdown();
+  });
 }
 
 /** Create a chat, make it active, and persist (debounced). */

--- a/test/state/session-persistence.test.mts
+++ b/test/state/session-persistence.test.mts
@@ -1,0 +1,132 @@
+/**
+ * MIN-408: chats must survive restarts — boot hydration guard + shutdown flush.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+
+import { setStorageModeForTests } from '../../src/config/storage-mode.ts';
+import { defaultSessionState } from '../../src/config/defaults.ts';
+import {
+  flushPendingSessionSaveOnShutdown,
+  isSessionsHydratedFromServerForTests,
+  loadSessionsFromStorage,
+  resetSessionPersistenceForTests,
+  saveSessionsNow,
+  sessionState,
+  setSessionStateForTests,
+} from '../../src/state/sessions.ts';
+
+const SAVED_CHAT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+function restoreFetch(): void {
+  // @ts-expect-error test cleanup
+  delete globalThis.fetch;
+}
+
+describe('session persistence (MIN-408)', () => {
+  afterEach(() => {
+    restoreFetch();
+    setStorageModeForTests('localStorage');
+    resetSessionPersistenceForTests();
+    setSessionStateForTests(null);
+  });
+
+  test('server GET failure does not hydrate and blocks PUT clobber', async () => {
+    setStorageModeForTests('server');
+    resetSessionPersistenceForTests();
+    setSessionStateForTests(null);
+
+    globalThis.fetch = async () => {
+      throw new Error('config server unavailable');
+    };
+
+    await loadSessionsFromStorage();
+
+    assert.ok(sessionState);
+    assert.equal(isSessionsHydratedFromServerForTests(), false);
+
+    let putCalled = false;
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes('/api/config/sessions') && init?.method === 'PUT') {
+        putCalled = true;
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    saveSessionsNow();
+    assert.equal(putCalled, false);
+  });
+
+  test('force reload replaces stale in-memory sessions from ~/.minnow', async () => {
+    setStorageModeForTests('server');
+    setSessionStateForTests(defaultSessionState());
+    resetSessionPersistenceForTests();
+
+    const serverPayload = {
+      version: 5,
+      activeId: SAVED_CHAT_ID,
+      sidebarCollapsed: false,
+      chats: [
+        {
+          id: SAVED_CHAT_ID,
+          name: 'Persisted chat',
+          workspacePath: '',
+          modelId: 'test-model',
+          history: [{ role: 'user', content: 'hello' }],
+          updatedAt: 1,
+        },
+      ],
+    };
+
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes('/api/config/sessions') && (!init?.method || init.method === 'GET')) {
+        return new Response(JSON.stringify(serverPayload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    await loadSessionsFromStorage({ force: true });
+
+    assert.equal(sessionState?.activeId, SAVED_CHAT_ID);
+    assert.equal(sessionState?.chats.length, 1);
+    assert.equal(sessionState?.chats[0]?.name, 'Persisted chat');
+    assert.equal(isSessionsHydratedFromServerForTests(), true);
+  });
+
+  test('shutdown flush issues keepalive PUT when hydrated', async () => {
+    setStorageModeForTests('server');
+    setSessionStateForTests(defaultSessionState());
+    resetSessionPersistenceForTests();
+
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes('/api/config/sessions') && init?.method === 'GET') {
+        return new Response(JSON.stringify(defaultSessionState()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    await loadSessionsFromStorage({ force: true });
+
+    let keepalive = false;
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes('/api/config/sessions') && init?.method === 'PUT') {
+        keepalive = init.keepalive === true;
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    flushPendingSessionSaveOnShutdown();
+    assert.equal(keepalive, true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Regular chats and orchestrator board chats could disappear after Electron/`npm start` restarts. Users lost sidebar history and in-flight orchestrator context.

## Root cause

A boot-time race between `startApp()` and `initApp()`:

1. `startApp()` could probe the config server before it was ready → `localStorage` mode
2. `loadSessionsFromStorage()` then fell through to empty `localStorage` (cleared after migration) and seeded a default empty `SessionState`
3. `initApp()` later detected server mode but skipped reload (`sessionState` already set)
4. Debounced `PUT /api/config/sessions` could overwrite `~/.minnow/sessions/state.json` with that empty blob

A secondary issue: debounced saves (300ms) were not flushed on window quit, so recent changes could be lost on abrupt shutdown.

## Fix

- **Hydration guard:** block server `PUT` until a successful `GET` from `~/.minnow` hydrates memory (`sessionsHydratedFromServer`)
- **No localStorage fallback in server mode:** failed server reads no longer seed an empty blob that can clobber disk
- **Force reload in `initApp()`:** when file-backed storage is active (after migration), always re-fetch sessions from the server
- **Shutdown flush:** `registerSessionPersistenceShutdownHandler()` on `pagehide` flushes pending debounced saves via `fetch` `keepalive`

## Tests

Added `test/state/session-persistence.test.mts`:

- Server GET failure does not hydrate and blocks PUT
- Force reload replaces stale in-memory sessions from server payload
- Shutdown flush uses keepalive PUT

## Manual verification

1. Create a chat with messages (and/or an orchestrator board with member chats)
2. Quit the app immediately (within debounce window) or restart Electron/`npm start`
3. Relaunch → chat(s) and board folder should still appear with full history
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-408](https://linear.app/minnowai/issue/MIN-408/chats-disapearing)

<div><a href="https://cursor.com/agents/bc-e760c596-473d-4bfb-95b8-989babdccaef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e760c596-473d-4bfb-95b8-989babdccaef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

