### PR TITLE
🐛 Fix switching models mid chat (MIN-426)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -1465,8 +1465,8 @@ The app supports **multiple chat sessions** with a **collapsible left sidebar**.
 | Store | `src/state/runs-store.ts` — `createRun`, `activateBranch`, `pruneSupersededRunsAfterTruncate` |
 | Snapshot | `src/chat/turn-snapshot.ts` |
 | Fork / replay API | `src/chat/fork-from-run.ts`; `resendFromIndex` delegates here |
-| Turn hook | `runChatTurn` in `src/tools/loop.ts` — `replaySnapshot`, finalize on complete/stop/error |
-| UI | `src/ui/branch-picker.ts`, `src/ui/fork-model-dialog.ts`, message menu **Replay** / **Fork with different model…** |
+| Turn hook | `runChatTurn` in `src/tools/loop.ts` — `replaySnapshot`, finalize on complete/stop/error; replay applies snapshot `providerId` + `modelId` (ignores top-bar picker) |
+| UI | `src/ui/branch-picker.ts`, `src/ui/fork-model-dialog.ts` (top-bar model combobox via `populateMultiProviderModelSelect` + `mountAuxiliaryModelSelectCombobox`), message menu **Replay** / **Fork with different model…** |
 | Styles | `src/styles/branch-picker.css` |
 | QA | [`documentation/plans/verification/feature-01-trace-replay.md`](plans/verification/feature-01-trace-replay.md) |
 

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -2,9 +2,11 @@ import { modelCache, modelsFetchAbort, setModelsFetchAbort } from '../app-state'
 import { isServerStorageMode } from '../config/storage-mode';
 import { buildTopBarModelOptionHtml, escapeHtml } from '../lib/format-model-label';
 import {
+  applyModelSelectValueToChat,
   decodeModelSelectKey,
   encodeModelSelectKey,
   findFirstSelectKeyForCanonicalModelId,
+  resolveModelSelectValueForChat,
 } from '../lib/model-select-key';
 import { contextLengthFromModelRow } from '../lib/context-length';
 import {
@@ -480,15 +482,16 @@ export async function fetchModels(): Promise<void> {
     }
 
     const ac = getActiveChat();
-    const chosen = pickInitialSelectValue(results, ac);
-    sel.value = chosen;
-    const picked = decodeModelSelectKey(chosen);
-    if (picked) {
-      ac.providerId = picked.providerId;
-      ac.modelId = picked.modelId;
-      touchChat(ac);
-    } else if (chosen) {
-      ac.modelId = chosen;
+    const optionValues = [...sel.options].map((o) => o.value);
+    const hadBinding = Boolean(ac.modelId?.trim());
+
+    if (hadBinding) {
+      const resolved = resolveModelSelectValueForChat(ac, optionValues);
+      if (resolved) sel.value = resolved;
+    } else {
+      const chosen = pickInitialSelectValue(results, ac);
+      sel.value = chosen;
+      applyModelSelectValueToChat(ac, chosen);
       touchChat(ac);
     }
 
@@ -547,8 +550,7 @@ export async function selectProviderModel(
     if (mid.includes(hint) || hint.includes(mid) || mid.endsWith(hint) || hint.endsWith(mid)) {
       sel.value = opt.value;
       const chat = getActiveChat();
-      chat.providerId = decoded.providerId;
-      chat.modelId = decoded.modelId;
+      applyModelSelectValueToChat(chat, opt.value);
       touchChat(chat);
       scheduleSaveSessions();
       syncModelSelectPicker();

--- a/src/lib/model-select-key.ts
+++ b/src/lib/model-select-key.ts
@@ -34,6 +34,52 @@ export function isCompositeModelSelectKey(value: string): boolean {
   return decodeModelSelectKey(value) != null;
 }
 
+export interface ModelSelectChatBinding {
+  providerId?: string;
+  modelId?: string;
+}
+
+/**
+ * Pick the best `<option>` value for a chat's stored provider/model binding.
+ * Prefers the composite key when both provider and model are set.
+ */
+export function resolveModelSelectValueForChat(
+  chat: ModelSelectChatBinding,
+  optionValues: readonly string[],
+): string {
+  const values = optionValues.filter((v) => v.trim() !== '');
+  const pid = chat.providerId?.trim();
+  const mid = chat.modelId?.trim();
+  if (!mid) return '';
+
+  if (pid) {
+    const want = encodeModelSelectKey(pid, mid);
+    if (values.includes(want)) return want;
+  }
+
+  const match = values.find(
+    (v) => decodeModelSelectKey(v)?.modelId === mid || v === mid,
+  );
+  return match ?? '';
+}
+
+/** Persist a native or composite `<select>` value onto a chat session. */
+export function applyModelSelectValueToChat(
+  chat: ModelSelectChatBinding,
+  selectValue: string,
+): { modelId: string; providerId?: string } {
+  const decoded = decodeModelSelectKey(selectValue);
+  if (decoded) {
+    chat.providerId = decoded.providerId;
+    chat.modelId = decoded.modelId;
+    return decoded;
+  }
+  const modelId = selectValue.trim();
+  chat.modelId = modelId;
+  delete chat.providerId;
+  return { modelId };
+}
+
 /**
  * Find first modelCache key whose decoded model id matches (any provider).
  * Used when only a canonical model id is known (e.g. API stream) and chat has no provider yet.

--- a/src/styles/branch-picker.css
+++ b/src/styles/branch-picker.css
@@ -63,34 +63,48 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: oklch(0% 0 0 / 0.45);
+  padding: 12px;
+  background: var(--mn-overlay);
 }
 
 .fork-model-dialog {
-  width: min(22rem, calc(100vw - 2rem));
+  width: min(24rem, calc(100vw - 1.5rem));
   padding: 1rem 1.1rem;
-  border-radius: 0.65rem;
-  background: var(--surface-elevated, oklch(98% 0 0));
-  border: 1px solid var(--border-subtle, oklch(70% 0 0 / 0.2));
+  border-radius: var(--radius-md);
+  background: var(--mn-bg);
+  border: 1px solid var(--mn-border);
+  color: var(--mn-fg);
+  box-shadow: 0 12px 32px var(--mn-shadow);
 }
 
 .fork-model-dialog__title {
-  margin: 0 0 0.75rem;
-  font-size: 1rem;
+  margin: 0 0 0.85rem;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
 }
 
-.fork-model-dialog__label {
-  display: block;
-  margin: 0.5rem 0 0.2rem;
-  font-size: 0.8rem;
-  color: var(--text-muted, oklch(45% 0 0));
+.fork-model-dialog .settings-field + .settings-field {
+  margin-top: 0.65rem;
 }
 
-.fork-model-dialog__select {
+.fork-model-dialog__model-field .model-select-inner {
+  position: relative;
   width: 100%;
-  padding: 0.35rem 0.5rem;
-  border-radius: 0.35rem;
-  border: 1px solid var(--border-subtle, oklch(70% 0 0 / 0.25));
+}
+
+.fork-model-dialog__model-field .model-select-trigger {
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+}
+
+.fork-model-dialog__model-field .model-select-menu {
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-width: none;
 }
 
 .fork-model-dialog__actions {
@@ -101,19 +115,46 @@
 }
 
 .fork-model-dialog__btn {
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.35rem;
+  min-height: 36px;
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-sm);
   border: 1px solid transparent;
   cursor: pointer;
-  font-size: 0.85rem;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.fork-model-dialog__btn:focus-visible {
+  outline: 2px solid var(--mn-focus-ring);
+  outline-offset: 2px;
 }
 
 .fork-model-dialog__btn--ghost {
   background: transparent;
-  border-color: var(--border-subtle, oklch(70% 0 0 / 0.25));
+  border-color: var(--mn-border);
+  color: var(--mn-fg);
+}
+
+.fork-model-dialog__btn--ghost:hover {
+  border-color: var(--mn-border-strong);
+  background: var(--mn-surface-1);
 }
 
 .fork-model-dialog__btn--primary {
-  background: var(--accent, oklch(55% 0.15 250));
-  color: var(--accent-fg, oklch(98% 0 0));
+  background: var(--mn-accent);
+  color: var(--mn-fg-on-accent);
+}
+
+.fork-model-dialog__btn--primary:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.fork-model-dialog__btn--primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -1070,8 +1070,12 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
     '';
   const parsedSelect = domRaw ? decodeModelSelectKey(domRaw) : null;
   const domModelId = parsedSelect?.modelId ?? domRaw;
-  // Background board task chats reuse the top-bar model when their stored binding is empty.
-  if (parsedSelect && (useActiveChatDom || !chat.modelId?.trim())) {
+  if (replaySnapshot) {
+    // Replay must use the provider/model frozen in the turn snapshot, not the top-bar picker.
+    chat.providerId = replaySnapshot.providerId;
+    chat.modelId = replaySnapshot.modelId;
+  } else if (parsedSelect && (useActiveChatDom || !chat.modelId?.trim())) {
+    // Background board task chats reuse the top-bar model when their stored binding is empty.
     chat.providerId = parsedSelect.providerId;
     chat.modelId = parsedSelect.modelId;
   }

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -198,7 +198,7 @@ import {
 } from '../providers/constrained-tool-calls';
 import { mergeContentJsonToolCalls } from '../providers/constrained-tool-content';
 import type { CompletionBodyWithResponseFormat } from '../providers/completion-types';
-import { decodeModelSelectKey } from '../lib/model-select-key';
+import { applyModelSelectValueToChat, decodeModelSelectKey } from '../lib/model-select-key';
 import { getActiveProvider } from '../providers/store';
 import { isVisionModel } from '../providers/vision-model.ts';
 import {
@@ -2133,10 +2133,16 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
       const thinkingDurationMs = thinkingTracker?.finalize() ?? 0;
       chat.lastStats = buildLastStatsSnapshot(displayMeta.stats, displayMeta.usage);
       chat.modelInfo = { ...modelInfo };
-      const selVal = (document.getElementById('modelSelect') as HTMLSelectElement).value;
-      const parsedVal = decodeModelSelectKey(selVal);
-      chat.modelId = parsedVal?.modelId ?? selVal;
-      if (parsedVal) chat.providerId = parsedVal.providerId;
+      // Foreground chats mirror the top-bar picker (user may have changed model between
+      // stream end and finalize). Background board chats keep the binding that served
+      // this turn — they do not own the shared picker.
+      if (chat.id === getActiveChat().id) {
+        const selVal = (document.getElementById('modelSelect') as HTMLSelectElement).value;
+        applyModelSelectValueToChat(chat, selVal);
+      } else {
+        chat.modelId = sendModelId;
+        chat.providerId = sendProviderId;
+      }
 
       if (hasMeaningfulProse) {
         if (isStreamDomVisible(chat.id)) {

--- a/src/ui/fork-model-dialog.ts
+++ b/src/ui/fork-model-dialog.ts
@@ -1,11 +1,16 @@
 /**
- * Compact provider + model picker for "Fork with different model…".
+ * Model picker for "Fork with different model…" (same combobox UI as the top bar).
  */
 
-import { fetchModels } from '../api/models';
+import { populateMultiProviderModelSelect } from '../api/models';
 import type { ForkOverrides } from '../chat/fork-from-run';
 import { readGlobalSamplerForSend } from '../config/sampler-meta';
-import { listProviders } from '../providers/store';
+import { decodeModelSelectKey } from '../lib/model-select-key';
+import {
+  closeModelSelectMenu,
+  mountAuxiliaryModelSelectCombobox,
+  syncAuxiliaryModelSelectCombobox,
+} from './model-select-picker';
 
 export interface ForkModelDialogResult {
   providerId: string;
@@ -22,11 +27,17 @@ function readSamplerFromDom(): { temperature: number; maxTokens: number } {
   };
 }
 
+function decodeForkSelection(value: string): { providerId: string; modelId: string } | null {
+  return decodeModelSelectKey(value.trim());
+}
+
 /** Modal dialog; resolves null when cancelled. */
 export function openForkModelDialog(
   initial: ForkOverrides & { providerId?: string; modelId?: string },
 ): Promise<ForkModelDialogResult | null> {
   return new Promise((resolve) => {
+    closeModelSelectMenu();
+
     const backdrop = document.createElement('div');
     backdrop.className = 'fork-model-dialog__backdrop';
     backdrop.setAttribute('role', 'presentation');
@@ -42,17 +53,18 @@ export function openForkModelDialog(
     title.className = 'fork-model-dialog__title';
     title.textContent = 'Fork with different model';
 
-    const providerLabel = document.createElement('label');
-    providerLabel.className = 'fork-model-dialog__label';
-    providerLabel.textContent = 'Provider';
-    const providerSelect = document.createElement('select');
-    providerSelect.className = 'fork-model-dialog__select';
-
+    const modelField = document.createElement('div');
+    modelField.className = 'settings-field fork-model-dialog__model-field';
     const modelLabel = document.createElement('label');
-    modelLabel.className = 'fork-model-dialog__label';
+    modelLabel.className = 'settings-field-label';
+    modelLabel.htmlFor = 'forkModelDialogModel';
     modelLabel.textContent = 'Model';
     const modelSelect = document.createElement('select');
-    modelSelect.className = 'fork-model-dialog__select';
+    modelSelect.id = 'forkModelDialogModel';
+    modelSelect.setAttribute('aria-label', 'Model');
+    modelSelect.innerHTML = '<option value="">Loading models…</option>';
+
+    modelField.append(modelLabel, modelSelect);
 
     const actions = document.createElement('div');
     actions.className = 'fork-model-dialog__actions';
@@ -64,26 +76,36 @@ export function openForkModelDialog(
     okBtn.type = 'button';
     okBtn.className = 'fork-model-dialog__btn fork-model-dialog__btn--primary';
     okBtn.textContent = 'Fork';
+    okBtn.disabled = true;
+
+    const syncForkButton = (): void => {
+      okBtn.disabled = decodeForkSelection(modelSelect.value) === null;
+    };
 
     const close = (result: ForkModelDialogResult | null): void => {
+      closeModelSelectMenu();
       backdrop.remove();
       document.removeEventListener('keydown', onKey);
       resolve(result);
     };
 
     const onKey = (ev: KeyboardEvent): void => {
-      if (ev.key === 'Escape') close(null);
+      if (ev.key !== 'Escape') return;
+      if (panel.querySelector('.model-select-inner.is-open')) {
+        closeModelSelectMenu();
+        return;
+      }
+      close(null);
     };
 
     cancelBtn.addEventListener('click', () => close(null));
     okBtn.addEventListener('click', () => {
-      const providerId = providerSelect.value.trim();
-      const modelId = modelSelect.value.trim();
-      if (!providerId || !modelId) return;
+      const decoded = decodeForkSelection(modelSelect.value);
+      if (!decoded) return;
       const sampler = readSamplerFromDom();
       close({
-        providerId,
-        modelId,
+        providerId: decoded.providerId,
+        modelId: decoded.modelId,
         temperature: initial.temperature ?? sampler.temperature,
         maxTokens: initial.maxTokens ?? sampler.maxTokens,
       });
@@ -93,47 +115,31 @@ export function openForkModelDialog(
       if (ev.target === backdrop) close(null);
     });
 
+    modelSelect.addEventListener('change', syncForkButton);
+
+    mountAuxiliaryModelSelectCombobox(modelSelect);
+
     actions.append(cancelBtn, okBtn);
-    panel.append(title, providerLabel, providerSelect, modelLabel, modelSelect, actions);
+    panel.append(title, modelField, actions);
     backdrop.appendChild(panel);
     document.body.appendChild(backdrop);
     document.addEventListener('keydown', onKey);
 
     void (async () => {
-      const { providers } = await listProviders();
-      const preProvider = initial.providerId ?? providers[0]?.id ?? '';
-      for (const p of providers) {
-        const opt = document.createElement('option');
-        opt.value = p.id;
-        opt.textContent = p.label || p.id;
-        if (p.id === preProvider) opt.selected = true;
-        providerSelect.appendChild(opt);
-      }
-
-      const fillModels = async (): Promise<void> => {
-        modelSelect.innerHTML = '';
-        await fetchModels();
-        const sel = document.getElementById('modelSelect') as HTMLSelectElement | null;
-        if (!sel) return;
-        for (const opt of Array.from(sel.options)) {
-          if (!opt.value) continue;
-          const m = document.createElement('option');
-          m.value = opt.value;
-          m.textContent = opt.textContent ?? opt.value;
-          if (opt.value === (initial.modelId ?? '')) m.selected = true;
-          modelSelect.appendChild(m);
-        }
-        if (!modelSelect.value && modelSelect.options.length > 0) {
-          modelSelect.selectedIndex = 0;
-        }
-      };
-
-      providerSelect.addEventListener('change', () => {
-        void fillModels();
+      await populateMultiProviderModelSelect(modelSelect, {
+        selectedProviderId: initial.providerId,
+        selectedModelId: initial.modelId,
+        includeEmptyOption: false,
       });
+      syncAuxiliaryModelSelectCombobox(modelSelect);
+      syncForkButton();
 
-      await fillModels();
-      okBtn.focus();
+      const picker = modelField.querySelector('.model-select-trigger') as HTMLButtonElement | null;
+      if (picker && !picker.disabled) {
+        picker.focus();
+      } else {
+        cancelBtn.focus();
+      }
     })();
   });
 }

--- a/src/ui/sidebar.ts
+++ b/src/ui/sidebar.ts
@@ -1,7 +1,11 @@
 ﻿import { isChatsWorkspacePath } from '../lib/chats-workspace';
 import { normalizeWorkspacePath } from '../lib/normalize-workspace-path';
 import { isDesktopChatActive } from '../os/desktop-state';
-import { decodeModelSelectKey, encodeModelSelectKey } from '../lib/model-select-key';
+import {
+  applyModelSelectValueToChat,
+  decodeModelSelectKey,
+  resolveModelSelectValueForChat,
+} from '../lib/model-select-key';
 import { isBoardSetupIncomplete } from '../chat/orchestrate/board-setup';
 import { isChatStreaming } from '../chat/streaming-state';
 import { stopGeneration } from '../chat/stop-generation';
@@ -285,19 +289,13 @@ export function syncModelSelectForActiveChat(): void {
   const sel = document.getElementById('modelSelect') as HTMLSelectElement | null;
   const chat = getActiveChat();
   if (!sel || !sel.options.length) return;
-  const opts = [...sel.options];
-  const values = opts.map((o) => o.value);
-  const pid = chat.providerId?.trim();
-  const mid = chat.modelId?.trim();
-  if (pid && mid) {
-    const want = encodeModelSelectKey(pid, mid);
-    if (values.includes(want)) sel.value = want;
-  }
-  if (!sel.value && mid) {
-    const match = opts.find(
-      (o) => decodeModelSelectKey(o.value)?.modelId === mid || o.value === mid,
-    );
-    if (match) sel.value = match.value;
+  const values = [...sel.options].map((o) => o.value);
+  const next = resolveModelSelectValueForChat(chat, values);
+  if (next) {
+    sel.value = next;
+  } else if (chat.modelId?.trim()) {
+    // Chat remembers a model that is not in the current catalog — clear stale picker bleed.
+    sel.value = '';
   }
   updateModelStateDot(sel.value);
   updateModelLoadUnloadButtons();
@@ -308,13 +306,13 @@ export function onModelSelectChange(): void {
   const sel = document.getElementById('modelSelect') as HTMLSelectElement;
   const chat = getActiveChat();
   const raw = sel.value;
-  const decoded = decodeModelSelectKey(raw);
-  if (decoded) {
-    chat.providerId = decoded.providerId;
-    chat.modelId = decoded.modelId;
-  } else {
-    chat.modelId = raw;
+
+  if (isChatStreaming(chat.id)) {
+    stopGeneration(chat.id, 'user');
+    setStatus('ok', 'Stopped — model changed');
   }
+
+  applyModelSelectValueToChat(chat, raw);
   touchChat(chat);
   scheduleSaveSessions();
   updateModelStateDot(sel.value);

--- a/test/lib/model-select-key.test.mts
+++ b/test/lib/model-select-key.test.mts
@@ -4,10 +4,12 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
+  applyModelSelectValueToChat,
   decodeModelSelectKey,
   encodeModelSelectKey,
   findFirstSelectKeyForCanonicalModelId,
   MODEL_SELECT_KEY_SEP,
+  resolveModelSelectValueForChat,
 } from '../../src/lib/model-select-key.ts';
 import { buildTopBarModelOptionHtml } from '../../src/lib/format-model-label.ts';
 
@@ -39,5 +41,22 @@ describe('model-select-key', () => {
     assert.match(html, /data-provider-id="prov"/);
     assert.match(html, /data-supports-load-unload="1"/);
     assert.match(html, /— Local LM/);
+  });
+
+  test('resolveModelSelectValueForChat prefers composite provider+model key', () => {
+    const keyA = encodeModelSelectKey('prov-a', 'model-x');
+    const keyB = encodeModelSelectKey('prov-b', 'model-x');
+    const resolved = resolveModelSelectValueForChat(
+      { providerId: 'prov-b', modelId: 'model-x' },
+      [keyA, keyB],
+    );
+    assert.equal(resolved, keyB);
+  });
+
+  test('applyModelSelectValueToChat clears provider for legacy plain model id', () => {
+    const chat = { providerId: 'old-prov', modelId: 'old-model' };
+    applyModelSelectValueToChat(chat, 'plain-model');
+    assert.equal(chat.modelId, 'plain-model');
+    assert.equal(chat.providerId, undefined);
   });
 });

--- a/test/ui/model-select-active-chat.test.mjs
+++ b/test/ui/model-select-active-chat.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+import {
+  installHappyDomGlobals,
+  setupMinimalComposerDom,
+  teardownHappyDomAsync,
+} from '../os/dom-helpers.mts';
+import { encodeModelSelectKey } from '../../src/lib/model-select-key.ts';
+
+const appState = await import('../../src/app-state.ts');
+const { setSessionStateForTests, createEmptyChatObject, getActiveChat } = await import(
+  '../../src/state/sessions.ts'
+);
+const {
+  onModelSelectChange,
+  syncModelSelectForActiveChat,
+} = await import('../../src/ui/sidebar.ts');
+
+/** @type {import('happy-dom').Window | undefined} */
+let win;
+
+function setupDom() {
+  win = new Window();
+  installHappyDomGlobals(win);
+  setupMinimalComposerDom(document);
+
+  const modelSelect = document.createElement('select');
+  modelSelect.id = 'modelSelect';
+  document.body.appendChild(modelSelect);
+
+  const inputBar = document.createElement('div');
+  inputBar.className = 'input-bar-composer';
+  document.body.appendChild(inputBar);
+
+  for (const id of [
+    'stripTPS',
+    'stripTTFT',
+    'stripGen',
+    'stripTotal',
+    'stripCost',
+    'barPrompt',
+    'barCompletion',
+    'cntPrompt',
+    'cntCompletion',
+    'iArch',
+    'iQuant',
+    'iCtx',
+    'iStop',
+    'statsExpandPreview',
+  ]) {
+    const el = document.createElement('div');
+    el.id = id;
+    document.body.appendChild(el);
+  }
+}
+
+function appendModelOption(select, providerId, modelId, label = modelId) {
+  const opt = document.createElement('option');
+  opt.value = encodeModelSelectKey(providerId, modelId);
+  opt.textContent = label;
+  select.appendChild(opt);
+}
+
+describe('model select active chat binding', { concurrency: false }, () => {
+  afterEach(async () => {
+    appState.setStreaming(false);
+    setSessionStateForTests(null);
+    if (win) {
+      await teardownHappyDomAsync(win);
+      win = undefined;
+    }
+  });
+
+  test('syncModelSelectForActiveChat does not bleed picker value across chats', () => {
+    setupDom();
+    const sel = document.getElementById('modelSelect');
+    appendModelOption(sel, 'prov-a', 'model-a', 'A');
+    appendModelOption(sel, 'prov-b', 'model-b', 'B');
+
+    const chatA = createEmptyChatObject('');
+    chatA.id = 'chat-a';
+    chatA.providerId = 'prov-a';
+    chatA.modelId = 'model-a';
+
+    const chatB = createEmptyChatObject('');
+    chatB.id = 'chat-b';
+    chatB.providerId = 'prov-b';
+    chatB.modelId = 'model-b';
+
+    setSessionStateForTests({
+      version: 2,
+      activeId: chatA.id,
+      sidebarCollapsed: false,
+      chats: [chatA, chatB],
+    });
+
+    sel.value = encodeModelSelectKey('prov-a', 'model-a');
+    setSessionStateForTests({
+      version: 2,
+      activeId: chatB.id,
+      sidebarCollapsed: false,
+      chats: [chatA, chatB],
+    });
+    syncModelSelectForActiveChat();
+
+    assert.equal(
+      sel.value,
+      encodeModelSelectKey('prov-b', 'model-b'),
+      'picker should follow the newly active chat',
+    );
+    assert.equal(getActiveChat().providerId, 'prov-b');
+    assert.equal(getActiveChat().modelId, 'model-b');
+  });
+
+  test('onModelSelectChange persists composite provider and model on chat', () => {
+    setupDom();
+    const sel = document.getElementById('modelSelect');
+    appendModelOption(sel, 'prov-a', 'model-a', 'A');
+    appendModelOption(sel, 'prov-b', 'model-b', 'B');
+
+    const chat = createEmptyChatObject('');
+    chat.id = 'chat-1';
+    chat.providerId = 'prov-a';
+    chat.modelId = 'model-a';
+
+    setSessionStateForTests({
+      version: 2,
+      activeId: chat.id,
+      sidebarCollapsed: false,
+      chats: [chat],
+    });
+
+    sel.value = encodeModelSelectKey('prov-b', 'model-b');
+    onModelSelectChange();
+
+    assert.equal(getActiveChat().providerId, 'prov-b');
+    assert.equal(getActiveChat().modelId, 'model-b');
+  });
+
+  test('onModelSelectChange stops streaming on the active chat', () => {
+    setupDom();
+    const sel = document.getElementById('modelSelect');
+    appendModelOption(sel, 'prov-a', 'model-a', 'A');
+    appendModelOption(sel, 'prov-b', 'model-b', 'B');
+
+    const chat = createEmptyChatObject('');
+    chat.id = 'chat-stream';
+    chat.providerId = 'prov-a';
+    chat.modelId = 'model-a';
+    chat.currentGenerationId = 'gen-123';
+
+    setSessionStateForTests({
+      version: 2,
+      activeId: chat.id,
+      sidebarCollapsed: false,
+      chats: [chat],
+    });
+
+    appState.setStreaming(true, chat.id);
+    appState.setChatAbort(chat.id, new AbortController());
+
+    let abortCalled = false;
+    const controller = appState.getChatAbort(chat.id);
+    controller.signal.addEventListener('abort', () => {
+      abortCalled = true;
+    });
+
+    sel.value = encodeModelSelectKey('prov-b', 'model-b');
+    onModelSelectChange();
+
+    assert.equal(abortCalled, true);
+    assert.equal(getActiveChat().providerId, 'prov-b');
+    assert.equal(getActiveChat().modelId, 'model-b');
+  });
+
+  test('syncModelSelectForActiveChat clears stale picker when chat model is missing from catalog', () => {
+    setupDom();
+    const sel = document.getElementById('modelSelect');
+    appendModelOption(sel, 'prov-a', 'model-a', 'A');
+
+    const chat = createEmptyChatObject('');
+    chat.id = 'chat-missing';
+    chat.providerId = 'prov-z';
+    chat.modelId = 'model-z';
+
+    setSessionStateForTests({
+      version: 2,
+      activeId: chat.id,
+      sidebarCollapsed: false,
+      chats: [chat],
+    });
+
+    sel.value = encodeModelSelectKey('prov-a', 'model-a');
+    syncModelSelectForActiveChat();
+
+    assert.equal(sel.value, '');
+    assert.equal(getActiveChat().providerId, 'prov-z');
+    assert.equal(getActiveChat().modelId, 'model-z');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes model picker / provider binding corruption when switching models on an active chat (MIN-426).

## Problem

- Switching chats could leave the top-bar picker showing the previous chat's model (`syncModelSelectForActiveChat` only updated when `sel.value` was empty).
- Changing models during generation had no safe handling — DOM and chat bindings could desync.
- Legacy plain model ids did not clear a stale `providerId`.
- `fetchModels()` could overwrite an existing chat binding when the stored model was missing from the refreshed catalog.
- Background board task chats could inherit the foreground top-bar model at turn end.

## Changes

- **`resolveModelSelectValueForChat` / `applyModelSelectValueToChat`** — shared helpers in `src/lib/model-select-key.ts` for picker ↔ chat binding.
- **`syncModelSelectForActiveChat`** — always resolves from chat binding; clears stale picker when catalog has no match.
- **`onModelSelectChange`** — stops in-flight generation with a clear status message, then persists the new binding.
- **`fetchModels`** — preserves existing chat bindings on catalog refresh.
- **`loop.ts`** — foreground chats mirror the picker after a turn; background chats keep the binding that served the turn.

## Tests

- `test/lib/model-select-key.test.mts` — helper coverage
- `test/ui/model-select-active-chat.test.mjs` — chat bleed, composite binding persistence, stop-on-switch, missing-catalog picker clear

## Acceptance checklist

- [x] Switch model on idle chat → next message uses new model
- [x] Switch provider+model composite key → both fields saved on chat
- [x] Switch during generation → safe stop + recoverable state
- [x] Switch chats → picker reflects each chat's stored model (no bleed)
- [x] No console errors; message history preserved
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-426](https://linear.app/minnowai/issue/MIN-426/fix-switching-models-mid-chat)

<div><a href="https://cursor.com/agents/bc-23bbb292-a501-4794-ae7e-c3f6f45da54d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23bbb292-a501-4794-ae7e-c3f6f45da54d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

