### PR TITLE
Fix file explorer offline state after page reload (MIN-436)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -1019,7 +1019,7 @@ Project file explorer (right) and editable CodeMirror viewer in a horizontal spl
 
 **Tree row density (E4 / feature-21):** Default rows are compact (`min-height: 0`, tighter padding in `file-panel.css`); `@media (pointer: coarse)` restores `min-height: var(--touch-min)` (44px) and touch padding. Row hover/selection matches chat sidebar (`.chat-item-row`): fine-pointer `--surface-elevated` hover, `--accent` border when selected. Depth indent: `src/ui/file-tree-indent.ts` (`FILE_TREE_DEPTH_INDENT_PX` = 12, dir/file base 6 / 24), re-exported from `file-tree.ts`.
 
-**Server:** Tree and viewer call `executeTool()` directly (`POST /api/tools`); tool catalog toggles in Settings are **not** required. Offline (`npm run dev`): empty state “Start with `npm start`…”. On boot, after `detectLocalServer()`, `initFilePanel()` and `onFilePanelServerAvailabilityChanged()` load the tree when the server is up (no need to open the Files panel or click refresh).
+**Server:** Tree and viewer call `executeTool()` directly (`POST /api/tools`); tool catalog toggles in Settings are **not** required. Offline (`npm run dev`): empty state “Start with `npm start`…”. On boot, `detectLocalServer()` runs in `startApp()` **before** `initOsRouter()` so Code reload does not initialize the tree while the ping flag is still false (**MIN-436**); `initFilePanel()` + `onFilePanelServerAvailabilityChanged()` load the tree when the server is up (desktop Files drawer calls `ensureCodeWorkspaceModules()` first).
 
 **Persistence (`filePanel`):** `fileSidebarCollapsed`, `fileSidebarWidth` (220–560px), `viewerOpen` (legacy; kept in sync with `rightPaneMode`), `rightPaneMode` (`viewer` | `preview` | null), `previewSource` (legacy; synced from active preview tab), `previewTabs` + `activePreviewTab` (MIN-224), `previewAutoReload`, `splitRatio` (0.35–0.75), `expandedDirs`, `selectedPath`, `openViewerTabs`, `activeViewerTab` (workspace paths only; `selectedPath` stays in sync with the active tab for tree highlight), `treeRoot`. **Workspace switch** clears viewer tabs (`applyWorkspaceSwitch` in `workspace-button.ts`). Legacy configs with only `selectedPath` migrate into `openViewerTabs` on load. No dedicated `localStorage` key when config API is up.
 
@@ -2014,7 +2014,8 @@ Use the port printed by `server.js` (default **9473**; another port if `PORT` is
 Order in `startApp()` (before `initApp()`):
 
 1. `await detectConfigServer()` → `await loadSessionsFromStorage()` — **must complete before `initOsRouter()`** so Code app foregrounding never calls `getActiveChat()` on an empty blob.
-2. `initOsRouter()` (MinnowOS shell only) — hash routing after sessions are ready.
+2. `await detectLocalServer()` — **must complete before `initOsRouter()`** so Code boot (`ensureCodeWorkspaceModules` → `initFilePanel`) sees the tool-server ping result (**MIN-436**).
+3. `initOsRouter()` (MinnowOS shell only) — hash routing after sessions and server ping are ready.
 
 Order in `initApp()`:
 
@@ -2024,7 +2025,7 @@ Order in `initApp()`:
 4. `await initWorkAgentSystem()` — work agents from glob + `/api/work-agents` overrides.
 5. `await loadSessionsFromStorage({ force: true })` when server mode (re-hydrates from `~/.minnow` after a localStorage boot race — **MIN-408**); otherwise no-op when already loaded from `startApp()`. `registerSessionPersistenceShutdownHandler()` flushes debounced saves on `pagehide` via `fetch` `keepalive`. Server PUT is blocked until a successful GET hydrates `sessionState` so an empty boot blob cannot clobber `sessions/state.json`.
 6. `fillToolsSection()` + `registerToolHandlers()`; `initAttachments()`; `initModeSelector()`; `initWorkAgentDevUi()`.
-7. `await detectLocalServer()` → `loadToolConfigIntoDrawer()` (server-required rows depend on ping).
+7. `await detectLocalServer()` (re-probe) → `notifyCodeWorkspaceServerAvailability()` when Code modules already initialized → `loadToolConfigIntoDrawer()` (server-required rows depend on ping).
 8. `applySidebarVisuals()` + `renderSidebar()`.
 9. `await fetchModels()` → `syncModelSelectForActiveChat()`, `renderChatFromHistory()`, `renderStatsForChat()`, `renderSidebar()` again.
 

--- a/src/boot/code-workspace-modules.ts
+++ b/src/boot/code-workspace-modules.ts
@@ -64,3 +64,12 @@ export async function ensureCodeWorkspaceModulesForBoot(): Promise<void> {
     await ensureCodeWorkspaceModules();
   }
 }
+
+/** Re-sync file tree / terminal offline state after a later detectLocalServer() probe. */
+export async function notifyCodeWorkspaceServerAvailability(): Promise<void> {
+  if (!initialized) return;
+  const filePanel = await import('../ui/init-file-panel');
+  filePanel.onFilePanelServerAvailabilityChanged();
+  const terminal = await import('../ui/terminal-panel');
+  terminal.onTerminalServerAvailabilityChanged();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -247,6 +247,10 @@ export async function initApp(): Promise<void> {
   startSchedulerNotificationPoll();
   initNotificationProducers();
   onWelcomeServerAvailabilityChanged();
+  const { notifyCodeWorkspaceServerAvailability } = await import(
+    './boot/code-workspace-modules'
+  );
+  await notifyCodeWorkspaceServerAvailability();
   bindWorkspacePathForToolCache(getWorkspacePath);
   initWorkspaceButton();
   await refreshWorkspaceUi();
@@ -359,6 +363,9 @@ async function startApp(): Promise<void> {
   // Sessions must load before OS routing — Code app mount calls getActiveChat().
   await detectConfigServer();
   await loadSessionsFromStorage();
+  // Probe the tool server before routing — Code boot initializes the file tree during
+  // initOsRouter() and reads this flag (MIN-436).
+  await detectLocalServer();
   if (isOsShellEnabled()) {
     initOsRouter();
   }

--- a/src/os/desktop-workspace-mounts.ts
+++ b/src/os/desktop-workspace-mounts.ts
@@ -154,8 +154,10 @@ async function refreshFileTreeForSurface(): Promise<void> {
   if (!document.getElementById('fileTreeHost')) {
     return;
   }
+  const { ensureCodeWorkspaceModules } = await import('../boot/code-workspace-modules');
+  await ensureCodeWorkspaceModules();
   const { initFileTreeIfNeeded, refreshFileTree } = await import('../ui/file-tree');
-  initFileTreeIfNeeded();
+  await initFileTreeIfNeeded();
   await refreshFileTree();
 }
 

--- a/src/os/desktop-workspace-rail.ts
+++ b/src/os/desktop-workspace-rail.ts
@@ -134,6 +134,8 @@ async function onTabActivated(tab: DesktopWorkspaceTab): Promise<void> {
     const { showViewerSplit } = await import('../ui/file-layout');
     showViewerSplit();
   } else if (tab === 'files') {
+    const { ensureCodeWorkspaceModules } = await import('../boot/code-workspace-modules');
+    await ensureCodeWorkspaceModules();
     const { initFileTreeIfNeeded, refreshFileTree } = await import('../ui/file-tree');
     await initFileTreeIfNeeded();
     await refreshFileTree();

--- a/src/ui/init-file-panel.ts
+++ b/src/ui/init-file-panel.ts
@@ -84,12 +84,14 @@ function bindFilePanelControls(): void {
 
 /** React to local server ping success/failure (after detectLocalServer). */
 export function onFilePanelServerAvailabilityChanged(): void {
-  if (!sessionState) return;
   setFileTreeServerAvailable(getLocalServerAvailable());
   onFileTreeSearchServerChanged();
   if (getLocalServerAvailable()) {
+    if (typeof document !== 'undefined' && document.getElementById('fileTreeHost')) {
+      void refreshFileTree();
+    }
+    if (!sessionState) return;
     void refreshWorkspaceUi();
-    void refreshFileTree();
     void syncOrchestratePlanStripFromActiveChat();
     syncViewModeToggleFromActiveChat();
     syncGitPanelFromOrchestrator();

--- a/test/file/file-tree-server-availability.test.mts
+++ b/test/file/file-tree-server-availability.test.mts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+
+register('../test-loader.mjs', import.meta.url);
+
+import { setLocalServerAvailableForTests } from '../../src/tools/config.ts';
+import { setFileTreeServerAvailable, isFileTreeServerAvailable } from '../../src/ui/file-tree-server.ts';
+import { onFilePanelServerAvailabilityChanged } from '../../src/ui/init-file-panel.ts';
+import { renderFileTree } from '../../src/ui/file-tree.ts';
+
+function setupFileTreeDom(): void {
+  const window = new Window();
+  globalThis.document = window.document;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.Node = window.Node;
+  document.body.innerHTML = '<div id="fileTreeHost"></div>';
+}
+
+describe('file tree server availability', { concurrency: false }, () => {
+  afterEach(() => {
+    setLocalServerAvailableForTests(false);
+    setFileTreeServerAvailable(false);
+  });
+
+  test('onFilePanelServerAvailabilityChanged syncs flag when server comes online', () => {
+    setFileTreeServerAvailable(false);
+    setLocalServerAvailableForTests(true);
+
+    onFilePanelServerAvailabilityChanged();
+
+    assert.equal(isFileTreeServerAvailable(), true);
+  });
+
+  test('onFilePanelServerAvailabilityChanged renders offline when server is down', () => {
+    setupFileTreeDom();
+    setFileTreeServerAvailable(true);
+    setLocalServerAvailableForTests(false);
+
+    onFilePanelServerAvailabilityChanged();
+
+    assert.equal(isFileTreeServerAvailable(), false);
+    const host = document.getElementById('fileTreeHost');
+    assert.match(host?.textContent ?? '', /npm start/i);
+  });
+
+  test('renderFileTree reflects latest server flag', () => {
+    setupFileTreeDom();
+    setFileTreeServerAvailable(true);
+    renderFileTree();
+    assert.equal(
+      document.getElementById('fileTreeHost')?.querySelector('.file-tree-loading')?.textContent,
+      'Loading project…',
+    );
+
+    setFileTreeServerAvailable(false);
+    renderFileTree();
+    assert.match(document.getElementById('fileTreeHost')?.textContent ?? '', /npm start/i);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes MIN-436: after reloading the app, the File Explorer incorrectly showed "Start with npm start to browse project files" even when the tool server was running.

## Root cause

On MinnowOS boot, `initOsRouter()` ran before `detectLocalServer()`. Reloading on a Code route (`#/app/code/...`) initialized the file panel during routing while the server ping flag was still `false`, so the tree rendered in offline mode and never recovered.

## Changes

- Probe `/api/tools/ping` in `startApp()` **before** `initOsRouter()` so Code boot sees the correct server state
- Re-sync file panel + terminal via `notifyCodeWorkspaceServerAvailability()` after `initApp()`'s `detectLocalServer()` re-probe
- Make `onFilePanelServerAvailabilityChanged()` always update the tree server flag (not gated on `sessionState`)
- Ensure desktop Files drawer calls `ensureCodeWorkspaceModules()` before loading the tree
- Add regression tests for server availability sync

## Testing

- `npx tsx --import ./test/test-loader.mjs --test test/file/file-tree-server-availability.test.mts`
- `npx tsx --import ./test/test-loader.mjs --test test/file/file-tree-boot.test.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-436](https://linear.app/minnowai/issue/MIN-436/file-explore-breaks-after-reload)

<div><a href="https://cursor.com/agents/bc-9a47f627-8bba-4d53-81be-79ec451190d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a47f627-8bba-4d53-81be-79ec451190d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

