### PR TITLE
Fix onboarding step count stuck at 11 (MIN-438)

### DIFF
--- a/src/onboarding/controller.ts
+++ b/src/onboarding/controller.ts
@@ -174,6 +174,12 @@ function onKeyDown(ev: KeyboardEvent): void {
   }
 }
 
+function refreshApplicableSteps(): void {
+  if (!ctx) return;
+  applicableSteps = getApplicableSteps(ctx);
+  sidebarHandle?.setSteps(applicableSteps);
+}
+
 function makeActions(): OnboardingStepActions {
   return {
     next: () => void goNext(),
@@ -182,7 +188,7 @@ function makeActions(): OnboardingStepActions {
     patchContext: (patch) => {
       if (!ctx) return;
       ctx = { ...ctx, ...patch };
-      applicableSteps = getApplicableSteps(ctx);
+      refreshApplicableSteps();
     },
     setPrimaryEnabled: (enabled) => {
       if (primaryBtn) primaryBtn.disabled = !enabled;
@@ -249,7 +255,7 @@ async function goNext(): Promise<void> {
   }
 
   if (step.id === 'provider-choice' || step.id === 'extras') {
-    applicableSteps = getApplicableSteps(ctx);
+    refreshApplicableSteps();
   }
 
   if (step.id === 'done') {
@@ -259,7 +265,7 @@ async function goNext(): Promise<void> {
 
   if (stepIndex < applicableSteps.length - 1) {
     stepIndex += 1;
-    applicableSteps = getApplicableSteps(ctx);
+    refreshApplicableSteps();
     renderCurrentStep();
   } else {
     await unmountOnboarding(true);
@@ -294,7 +300,7 @@ async function skipCurrent(): Promise<void> {
 
   if (stepIndex < applicableSteps.length - 1) {
     stepIndex += 1;
-    applicableSteps = getApplicableSteps(ctx);
+    refreshApplicableSteps();
     renderCurrentStep();
   } else {
     await unmountOnboarding(true);

--- a/src/onboarding/step-sidebar.ts
+++ b/src/onboarding/step-sidebar.ts
@@ -10,6 +10,8 @@ const FAVICON_URL = '/logos/favicon.ico';
 
 export interface StepSidebarHandle {
   setActiveStep: (stepId: OnboardingStepId, stepIndex: number) => void;
+  /** Replace the filtered step list when path-dependent steps become applicable. */
+  setSteps: (steps: OnboardingStep[]) => void;
   destroy: () => void;
 }
 
@@ -27,7 +29,8 @@ export function mountStepSidebar(
   steps: OnboardingStep[],
   activeId: OnboardingStepId,
 ): StepSidebarHandle {
-  const phases = getApplicablePhases(steps);
+  let activeSteps = steps;
+  let phases = getApplicablePhases(activeSteps);
   const reduced = prefersReducedMotion();
 
   asideMount.innerHTML = '';
@@ -74,7 +77,7 @@ export function mountStepSidebar(
 
     const hint = document.createElement('span');
     hint.className = 'mn-onboarding__phase-hint';
-    hint.textContent = formatPhaseHint(phase, steps);
+    hint.textContent = formatPhaseHint(phase, activeSteps);
 
     copy.append(label, hint);
     item.append(marker, copy);
@@ -135,12 +138,20 @@ export function mountStepSidebar(
   mobileLabel.className = 'mn-onboarding__mobile-progress-label';
   mobileMount.append(mobileTrack, mobileLabel);
 
-  let activeStepIndex = Math.max(0, steps.findIndex((s) => s.id === activeId));
+  let activeStepIndex = Math.max(0, activeSteps.findIndex((s) => s.id === activeId));
+
+  function refreshPhaseHints(): void {
+    phases.forEach((phase, phaseIndex) => {
+      const hint = phaseItems[phaseIndex]?.querySelector('.mn-onboarding__phase-hint');
+      if (hint) hint.textContent = formatPhaseHint(phase, activeSteps);
+    });
+  }
 
   function paint(stepId: OnboardingStepId, stepIndex: number): void {
     activeStepIndex = stepIndex;
     const phaseIndex = resolvePhaseIndex(phases, stepId);
-    const pct = steps.length <= 1 ? 0 : Math.round((stepIndex / (steps.length - 1)) * 100);
+    const pct =
+      activeSteps.length <= 1 ? 0 : Math.round((stepIndex / (activeSteps.length - 1)) * 100);
 
     phaseItems.forEach((item, i) => {
       item.classList.toggle('is-active', i === phaseIndex);
@@ -152,7 +163,7 @@ export function mountStepSidebar(
     progressTrack.setAttribute('aria-valuenow', String(pct));
     mobileTrack.setAttribute('aria-valuenow', String(pct));
 
-    const position = formatStepPosition(stepIndex, steps.length);
+    const position = formatStepPosition(stepIndex, activeSteps.length);
     progressLabel.textContent = position;
     mobileLabel.textContent = position;
 
@@ -165,12 +176,20 @@ export function mountStepSidebar(
 
   paint(activeId, activeStepIndex);
 
-  const onResize = () => paint(steps[activeStepIndex]?.id ?? activeId, activeStepIndex);
+  const onResize = () =>
+    paint(activeSteps[activeStepIndex]?.id ?? activeId, activeStepIndex);
   window.addEventListener('resize', onResize);
 
   return {
     setActiveStep(stepId, stepIndex) {
       paint(stepId, stepIndex);
+    },
+    setSteps(nextSteps) {
+      activeSteps = nextSteps;
+      phases = getApplicablePhases(activeSteps);
+      refreshPhaseHints();
+      const stepId = activeSteps[activeStepIndex]?.id ?? activeId;
+      paint(stepId, activeStepIndex);
     },
     destroy() {
       window.removeEventListener('resize', onResize);

--- a/test/onboarding/step-count.test.mjs
+++ b/test/onboarding/step-count.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * MIN-438 — onboarding step totals must reflect path-dependent steps.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+
+const { getApplicableSteps } = await import('../../src/onboarding/steps/registry.ts');
+const {
+  buildOnboardingContext,
+  createDefaultOnboardingState,
+} = await import('../../src/onboarding/state-core.ts');
+const { mountStepSidebar } = await import('../../src/onboarding/step-sidebar.ts');
+
+/** happy-dom windows keep the event loop alive unless closed. */
+let testWindow = null;
+
+function setupDom() {
+  testWindow = new Window();
+  globalThis.window = testWindow;
+  globalThis.document = testWindow.document;
+  globalThis.HTMLElement = testWindow.HTMLElement;
+  globalThis.matchMedia = testWindow.matchMedia.bind(testWindow);
+}
+
+function ctxWith(overrides = {}) {
+  const base = buildOnboardingContext(createDefaultOnboardingState(), {
+    serverAvailable: true,
+    configServerAvailable: true,
+  });
+  return { ...base, ...overrides };
+}
+
+describe('onboarding step count (MIN-438)', () => {
+  afterEach(() => {
+    testWindow?.close();
+    testWindow = null;
+  });
+
+  test('before provider path is chosen, branch steps are excluded (11 with server)', () => {
+    const steps = getApplicableSteps(ctxWith());
+    assert.equal(steps.length, 11);
+    assert.equal(steps.some((step) => step.id === 'provider-local'), false);
+    assert.equal(steps.some((step) => step.id === 'model-pick'), false);
+  });
+
+  test('local provider path includes branch + model pick (13 with server, no api-keys)', () => {
+    const steps = getApplicableSteps(ctxWith({ providerPath: 'local' }));
+    assert.equal(steps.length, 13);
+    assert.equal(steps.some((step) => step.id === 'provider-local'), true);
+    assert.equal(steps.some((step) => step.id === 'model-pick'), true);
+    assert.equal(steps.some((step) => step.id === 'context7'), true);
+  });
+
+  test('sidebar progress label updates when filtered steps grow', () => {
+    setupDom();
+    const aside = document.createElement('aside');
+    const mobile = document.createElement('div');
+    document.body.append(aside, mobile);
+
+    const initial = getApplicableSteps(ctxWith());
+    const handle = mountStepSidebar(aside, mobile, initial, 'welcome');
+
+    assert.equal(
+      aside.querySelector('.mn-onboarding__progress-label')?.textContent,
+      'Step 1 of 11',
+    );
+
+    const expanded = getApplicableSteps(ctxWith({ providerPath: 'local' }));
+    handle.setSteps(expanded);
+    handle.setActiveStep('provider-local', 3);
+
+    assert.equal(
+      aside.querySelector('.mn-onboarding__progress-label')?.textContent,
+      'Step 4 of 13',
+    );
+
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes MIN-438: onboarding progress showed **"Step X of 11"** even though the full local-provider flow has **13** steps.

## Root cause

The setup sidebar captured the initial filtered step list at mount time. Before a provider path is chosen, branch-specific steps (`provider-local` / `provider-managed` / `provider-cloud`) and `model-pick` are excluded, yielding 11 applicable steps. After the user picks a path, the controller recalculated `applicableSteps` (now 13 for the typical local + server flow), but the sidebar progress label and bar still used the original list length.

## Fix

- Add `StepSidebarHandle.setSteps()` to refresh progress labels, phase hints, and the progress bar when the filtered step list changes.
- Call it from a shared `refreshApplicableSteps()` helper whenever onboarding context updates (provider path selection, extras/api-keys branching, navigation).

## Test plan

- [x] `test/onboarding/step-count.test.mjs` — asserts 11 steps pre-path, 13 after local path, and sidebar label updates via `setSteps()`.
- [x] Existing onboarding tests still pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-438](https://linear.app/minnowai/issue/MIN-438/onboarding-steps-incorrect)

<div><a href="https://cursor.com/agents/bc-49f99e4a-c1c6-4656-97ef-090a1c8c5402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49f99e4a-c1c6-4656-97ef-090a1c8c5402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

