### PR TITLE
Fix memory synthesis: vector deduplication and cold-start gating

### DIFF
--- a/server/brain/synthesis.js
+++ b/server/brain/synthesis.js
@@ -7,6 +7,13 @@ import { loadAllPagesWithBodies, retrieveMemoryBlockHybrid } from './retrieve.js
 import { createPage, loadBrainConfig, updatePage } from './store.js';
 import { loadSynthesisConfig, resolveSynthesisModel } from './synthesis-config.js';
 import { addMemoryProposal } from './proposals.js';
+import { getEmbedder, embedTexts } from '../engine/embeddings.js';
+import {
+  cosineSimilarity,
+  getEntryVector,
+  isVectorStoreCompatible,
+  loadVectorStore,
+} from './vector-store.js';
 
 /** Recent message pairs included in extraction context. */
 export const CONTEXT_WINDOW = 6;
@@ -144,24 +151,62 @@ export function slugifyFactTitle(title) {
 }
 
 /**
+ * Cosine similarity above which a new fact counts as a duplicate of an existing page.
+ * Must stay high enough that same-topic updates ("prefers dark mode" → "prefers light
+ * mode") are written and left to retireSupersededPages, not silently dropped here.
+ */
+export const VECTOR_DUPLICATE_THRESHOLD = 0.92;
+
+/**
  * @param {string} title
  * @param {string} body
  * @param {Array<{ meta: object, body: string }>} existing
  * @param {object} brainConfig
+ * @param {{ getEmbedder?: typeof getEmbedder, embedTexts?: typeof embedTexts, loadVectorStore?: typeof loadVectorStore, getEntryVector?: typeof getEntryVector }} [deps]
  * @returns {Promise<boolean>}
  */
-export async function isDuplicateMemory(title, body, existing, brainConfig) {
+export async function isDuplicateMemory(title, body, existing, brainConfig, deps = {}) {
   const query = `${title} ${body}`.trim();
   if (!query) return true;
 
   const emb = brainConfig.embeddings ?? {};
-  if (emb.enabled) {
-    const { ids } = await retrieveMemoryBlockHybrid(
-      existing,
-      { query, limit: 3, maxChars: 4000 },
-      brainConfig,
-    );
-    if (ids.length > 0) return true;
+  if (emb.enabled && existing.length > 0) {
+    // Score each existing page directly against a similarity threshold. Top-k
+    // retrieval is the wrong tool here: it always returns ids once any page
+    // exists (no score cutoff, plus a recent/pinned fallback), which made every
+    // new fact a "duplicate" after the first page was written.
+    try {
+      const embedder = await (deps.getEmbedder ?? getEmbedder)(brainConfig);
+      const store = await (deps.loadVectorStore ?? loadVectorStore)();
+      if (
+        isVectorStoreCompatible(store, {
+          modelId: embedder.id,
+          backend: emb.backend,
+          dim: embedder.dim,
+        })
+      ) {
+        const [queryVector] = await (deps.embedTexts ?? embedTexts)(
+          embedder,
+          [query],
+          emb.queryTimeoutMs,
+        );
+        if (queryVector) {
+          for (const row of existing) {
+            const stored =
+              store.vectors[row.meta.id] ??
+              (await (deps.getEntryVector ?? getEntryVector)(row.meta.id));
+            if (
+              stored &&
+              cosineSimilarity(queryVector, stored) >= VECTOR_DUPLICATE_THRESHOLD
+            ) {
+              return true;
+            }
+          }
+        }
+      }
+    } catch {
+      /* embeddings unavailable — fall through to the keyword check */
+    }
   }
 
   const needle = query.toLowerCase();

--- a/src/chat/prompts/compose-context.ts
+++ b/src/chat/prompts/compose-context.ts
@@ -116,6 +116,7 @@ export async function buildComposeContext(
     workAgentId: null,
     skillBody: null,
     memoryBlock,
+    memoryEnabled: injectMemory,
     enabledToolIds,
     infoPresetId,
     planGranularity: meta.planGranularity ?? 'medium',

--- a/src/chat/prompts/prompt-composer.ts
+++ b/src/chat/prompts/prompt-composer.ts
@@ -57,6 +57,24 @@ function contextHasBrowserPreviewTools(ctx: ComposeContext): boolean {
   return ids.some((id) => BROWSER_PREVIEW_TOOL_IDS.has(id));
 }
 
+/** Brain write tools whose presence warrants save guidance even with an empty wiki. */
+const BRAIN_WRITE_TOOL_IDS = new Set(['save_memory', 'brain_write_page']);
+
+function contextHasBrainWriteTools(ctx: ComposeContext): boolean {
+  return (ctx.enabledToolIds ?? []).some((id) => BRAIN_WRITE_TOOL_IDS.has(id));
+}
+
+/**
+ * Memory part gate: retrieved notes always inject; with no notes (fresh/empty
+ * wiki) the part still injects when memory is on and write tools are enabled,
+ * so the agent learns how to save — otherwise nothing is ever written and the
+ * section never appears (cold-start deadlock).
+ */
+function isMemoryPartEnabled(ctx: ComposeContext): boolean {
+  if (ctx.memoryBlock?.trim()) return true;
+  return ctx.memoryEnabled === true && contextHasBrainWriteTools(ctx);
+}
+
 /** Default lite part gating (memory uses shorter retrieve cap when enabled). */
 const LITE_DISABLED_PARTS = new Set<PromptPartId>(['info']);
 
@@ -101,7 +119,7 @@ function isPartEnabled(
     return Boolean(ctx.skillBody?.trim());
   }
   if (partId === 'memory') {
-    return Boolean(ctx.memoryBlock?.trim());
+    return isMemoryPartEnabled(ctx);
   }
   if (partId === 'mode') {
     if (!ctx.modeId) return false;
@@ -161,13 +179,13 @@ function resolvePartBody(
   if (partId === 'skill' && ctx.skillBody?.trim()) {
     return ctx.skillBody.trim();
   }
-  if (partId === 'memory' && ctx.memoryBlock?.trim()) {
+  if (partId === 'memory' && isMemoryPartEnabled(ctx)) {
     const loadProfile = profile === 'lite' ? 'lite' : 'full';
     const loaded = loadPromptById('info', 'memory', loadProfile);
     if (loaded?.body?.trim()) {
       return loaded.body.trim();
     }
-    return ctx.memoryBlock.trim();
+    return ctx.memoryBlock?.trim() ?? '';
   }
 
   const kind = kindForPart(partId);
@@ -332,7 +350,9 @@ function buildInterpolationVars(ctx: ComposeContext): InterpolationVars {
     profile: profileLabel,
     expert: ctx.expertLabel?.trim() || ctx.expertId || '',
     cwd: ctx.cwd,
-    memory: ctx.memoryBlock ?? '',
+    memory:
+      ctx.memoryBlock?.trim() ||
+      '(no wiki notes matched this message — the wiki may still be empty)',
     user_message: ctx.userMessagePreview ?? '',
     work_agent: ctx.workAgentId ?? '',
     work_agent_label: ctx.workAgentLabel?.trim() || ctx.workAgentId || '',

--- a/src/chat/prompts/types.ts
+++ b/src/chat/prompts/types.ts
@@ -90,6 +90,8 @@ export interface ComposeContext {
   workAgentLabel?: string | null;
   skillBody: string | null;
   memoryBlock: string | null;
+  /** True when memory retrieval/saving is enabled for this chat (injects save guidance even with an empty wiki). */
+  memoryEnabled?: boolean;
   enabledToolIds: string[];
   infoPresetId: string | null;
   userMessagePreview?: string;

--- a/src/synthesis/client.ts
+++ b/src/synthesis/client.ts
@@ -250,18 +250,35 @@ export function schedulePostTurnSynthesis(input: SynthesisRunInput): void {
 
       const data = (await res.json()) as {
         memoryProposals?: unknown[];
+        memoryPages?: unknown[];
+        memorySkipped?: string[];
         skillProposal?: unknown | null;
       };
-      const created =
+      if (data.memorySkipped?.includes('no-model')) {
+        console.warn(
+          '[synthesis] Skipped: no utility model resolved. Pick a model in the menubar or Settings → Memory → Synthesis.',
+        );
+      }
+      const savedPages = data.memoryPages?.length ?? 0;
+      const proposals =
         (data.memoryProposals?.length ?? 0) + (data.skillProposal ? 1 : 0);
-      if (created > 0) {
+      if (savedPages > 0 || proposals > 0) {
+        const parts: string[] = [];
+        if (savedPages > 0) {
+          parts.push(`${savedPages} memor${savedPages === 1 ? 'y' : 'ies'} saved`);
+        }
+        if (proposals > 0) {
+          parts.push(
+            `${proposals} proposal${proposals === 1 ? '' : 's'} ready for review`,
+          );
+        }
         const { pushNotification } = await import('../notifications/push');
         pushNotification({
           kind: 'synthesis',
           title: 'Auto-learning',
-          preview: `${created} new memory/skill proposal${created === 1 ? '' : 's'} ready for review`,
-          appId: 'settings',
-          dedupeKey: `synthesis:${input.chatId}:${created}`,
+          preview: parts.join(' · '),
+          appId: savedPages > 0 ? 'brain' : 'settings',
+          dedupeKey: `synthesis:${input.chatId}:${savedPages}:${proposals}`,
         });
       }
     } catch {

--- a/test/brain/synthesis-dedupe.test.mjs
+++ b/test/brain/synthesis-dedupe.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * isDuplicateMemory — vector dedupe must threshold on similarity, not top-k hits.
+ *
+ * Regression: with embeddings enabled, hybrid top-k retrieval returned ids for
+ * ANY query once one page existed (no score cutoff + recent/pinned fallback),
+ * so every new fact was marked duplicate and synthesis never wrote again.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  isDuplicateMemory,
+  VECTOR_DUPLICATE_THRESHOLD,
+} from '../../server/brain/synthesis.js';
+
+const PAGE_ID = '11111111-1111-4111-8111-111111111111';
+
+function makeExisting(title, body) {
+  return [{ meta: { id: PAGE_ID, title, path: 'facts/x.md' }, body }];
+}
+
+const EMB_ON = {
+  embeddings: { enabled: true, backend: 'local', modelId: 'test-model', queryTimeoutMs: 100 },
+};
+const EMB_OFF = { embeddings: { enabled: false } };
+
+function makeDeps({ storedVector, queryVector }) {
+  return {
+    getEmbedder: async () => ({ id: 'test-model', dim: queryVector.length }),
+    embedTexts: async () => [queryVector],
+    loadVectorStore: async () => ({
+      model: 'test-model',
+      backend: 'local',
+      dim: queryVector.length,
+      vectors: storedVector ? { [PAGE_ID]: storedVector } : {},
+    }),
+    getEntryVector: async () => storedVector ?? null,
+  };
+}
+
+describe('isDuplicateMemory', () => {
+  test('threshold is meaningfully high', () => {
+    assert.ok(VECTOR_DUPLICATE_THRESHOLD >= 0.85 && VECTOR_DUPLICATE_THRESHOLD < 1);
+  });
+
+  test('embeddings off: distinct fact is not a duplicate', async () => {
+    const dup = await isDuplicateMemory(
+      'Favorite editor',
+      'The user prefers Neovim',
+      makeExisting('Lives in Berlin', 'The user lives in Berlin'),
+      EMB_OFF,
+    );
+    assert.equal(dup, false);
+  });
+
+  test('embeddings off: contained fact is a duplicate', async () => {
+    const dup = await isDuplicateMemory(
+      'Lives in Berlin',
+      'The user lives in Berlin',
+      makeExisting('Location', 'Note: Lives in Berlin The user lives in Berlin — confirmed twice'),
+      EMB_OFF,
+    );
+    assert.equal(dup, true);
+  });
+
+  test('embeddings on: dissimilar vector is NOT a duplicate (regression)', async () => {
+    const dup = await isDuplicateMemory(
+      'Favorite editor',
+      'The user prefers Neovim',
+      makeExisting('Lives in Berlin', 'The user lives in Berlin'),
+      EMB_ON,
+      makeDeps({ storedVector: [1, 0, 0], queryVector: [0, 1, 0] }),
+    );
+    assert.equal(dup, false);
+  });
+
+  test('embeddings on: near-identical vector is a duplicate', async () => {
+    const dup = await isDuplicateMemory(
+      'Home city',
+      'User is based in Berlin',
+      makeExisting('Lives in Berlin', 'The user lives in Berlin'),
+      EMB_ON,
+      makeDeps({ storedVector: [1, 0.01, 0], queryVector: [1, 0, 0] }),
+    );
+    assert.equal(dup, true);
+  });
+
+  test('embeddings on but embedder unavailable: falls back to keyword check', async () => {
+    const dup = await isDuplicateMemory(
+      'Favorite editor',
+      'The user prefers Neovim',
+      makeExisting('Lives in Berlin', 'The user lives in Berlin'),
+      EMB_ON,
+      {
+        getEmbedder: async () => {
+          throw new Error('no model');
+        },
+      },
+    );
+    assert.equal(dup, false);
+  });
+
+  test('embeddings on with incompatible store: falls back to keyword check', async () => {
+    const deps = makeDeps({ storedVector: [1, 0, 0], queryVector: [1, 0, 0] });
+    deps.loadVectorStore = async () => ({
+      model: 'other-model',
+      backend: 'local',
+      dim: 3,
+      vectors: {},
+    });
+    const dup = await isDuplicateMemory(
+      'Favorite editor',
+      'The user prefers Neovim',
+      makeExisting('Lives in Berlin', 'The user lives in Berlin'),
+      EMB_ON,
+      deps,
+    );
+    assert.equal(dup, false);
+  });
+});

--- a/test/prompts/memory-part-cold-start.test.mjs
+++ b/test/prompts/memory-part-cold-start.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * Memory part cold-start gating — save guidance must inject even when the wiki
+ * is empty, as long as memory is enabled and brain write tools are available.
+ *
+ * Regression: the memory part (the only prompt section teaching save_memory /
+ * brain_write_page usage) was gated on a non-empty retrieval block, so a fresh
+ * install never told the agent how to save → nothing was ever written → the
+ * section never appeared.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, test } from 'node:test';
+import { composeSystemPrompt } from '../../src/chat/prompts/prompt-composer.ts';
+import {
+  registerPromptFilesFromRaw,
+  resetPromptRegistry,
+} from '../../src/chat/prompts/prompt-loader.ts';
+import { fixturePath } from './test-helpers.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const promptsDir = path.join(here, '..', '..', 'src', 'chat', 'prompts');
+
+async function registerFixtures() {
+  const map = {
+    './base/base-default.full.md': await fs.readFile(
+      fixturePath('base-default.full.md'),
+      'utf8',
+    ),
+    './tool-usage/tool-usage-default.full.md': await fs.readFile(
+      fixturePath('tool-usage-default.full.md'),
+      'utf8',
+    ),
+    // Real shipped memory templates (kind: info, id: memory).
+    './memory/memory.full.md': await fs.readFile(
+      path.join(promptsDir, 'memory', 'full.md'),
+      'utf8',
+    ),
+    './memory/memory.lite.md': await fs.readFile(
+      path.join(promptsDir, 'memory', 'lite.md'),
+      'utf8',
+    ),
+  };
+  registerPromptFilesFromRaw(map);
+}
+
+function baseCtx(overrides = {}) {
+  return {
+    profile: 'full',
+    cwd: '/test',
+    modeId: 'build',
+    expertId: null,
+    workAgentId: null,
+    skillBody: null,
+    memoryBlock: null,
+    memoryEnabled: true,
+    enabledToolIds: ['get_datetime', 'save_memory', 'brain_write_page'],
+    infoPresetId: null,
+    ...overrides,
+  };
+}
+
+describe('memory part cold-start gating', () => {
+  beforeEach(() => {
+    resetPromptRegistry();
+  });
+
+  test('empty wiki + memory on + write tools → save guidance injects', async () => {
+    await registerFixtures();
+    const out = composeSystemPrompt(baseCtx());
+    assert.ok(out.includes('save_memory'), 'expected save_memory guidance');
+    assert.ok(out.includes('brain_write_page'), 'expected brain_write_page guidance');
+    assert.ok(
+      out.includes('no wiki notes matched this message'),
+      'expected empty-retrieval placeholder for {{memory}}',
+    );
+  });
+
+  test('retrieved block still injects and interpolates', async () => {
+    await registerFixtures();
+    const out = composeSystemPrompt(
+      baseCtx({ memoryBlock: 'RETRIEVED_NOTE_XYZ' }),
+    );
+    assert.ok(out.includes('RETRIEVED_NOTE_XYZ'));
+    assert.ok(!out.includes('no wiki notes matched this message'));
+  });
+
+  test('memory disabled → no memory section without a block', async () => {
+    await registerFixtures();
+    const out = composeSystemPrompt(baseCtx({ memoryEnabled: false }));
+    assert.ok(!out.includes('save_memory'));
+  });
+
+  test('no brain write tools → no memory section without a block', async () => {
+    await registerFixtures();
+    const out = composeSystemPrompt(
+      baseCtx({ enabledToolIds: ['get_datetime'] }),
+    );
+    assert.ok(!out.includes('save_memory'));
+  });
+
+  test('lite profile also injects save guidance on empty wiki', async () => {
+    await registerFixtures();
+    const map = {
+      './base/base-default.lite.md': await fs.readFile(
+        fixturePath('base-default.lite.md'),
+        'utf8',
+      ),
+      './tool-usage/tool-usage-default.lite.md': await fs.readFile(
+        fixturePath('tool-usage-default.lite.md'),
+        'utf8',
+      ),
+    };
+    registerPromptFilesFromRaw(map);
+    const out = composeSystemPrompt(baseCtx({ profile: 'lite' }));
+    assert.ok(out.includes('save_memory'));
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes two critical regressions in the memory synthesis system:

1. **Vector deduplication threshold bug**: The hybrid retrieval was using top-k hits without a similarity score cutoff, causing every new fact to be marked as a duplicate after the first page was written, preventing any further synthesis.

2. **Memory part cold-start deadlock**: The memory section (which teaches `save_memory` and `brain_write_page` usage) was gated on having retrieved notes, so fresh installs never learned how to save facts, creating a deadlock where nothing was ever written.

## Key Changes

- **`server/brain/synthesis.js`**:
  - Replaced top-k retrieval with direct similarity scoring against a configurable threshold (`VECTOR_DUPLICATE_THRESHOLD = 0.92`)
  - Added vector store compatibility checks before attempting embeddings
  - Gracefully falls back to keyword-based deduplication if embeddings are unavailable
  - Injected dependencies for testability

- **`src/chat/prompts/prompt-composer.ts`**:
  - Added `isMemoryPartEnabled()` gate that injects the memory section when either:
    - Retrieved notes exist, OR
    - Memory is enabled AND brain write tools (`save_memory`, `brain_write_page`) are available
  - Updated interpolation to show a placeholder message when the wiki is empty: "(no wiki notes matched this message — the wiki may still be empty)"

- **`src/chat/prompts/compose-context.ts`**:
  - Added `memoryEnabled` flag to the compose context to track whether memory is active

- **`src/synthesis/client.ts`**:
  - Enhanced synthesis response handling to distinguish between saved pages and proposals
  - Improved notification messaging to show both saved memories and pending proposals
  - Routes notifications to 'brain' app when memories are saved, 'settings' for proposals only

## Testing

Added comprehensive test suites:
- `test/brain/synthesis-dedupe.test.mjs`: Tests vector similarity thresholding, fallback behavior, and store compatibility checks
- `test/prompts/memory-part-cold-start.test.mjs`: Tests memory section injection on empty wiki with write tools enabled

## Implementation Details

The vector deduplication now scores each existing page directly against the query vector using cosine similarity, only marking as duplicate if similarity exceeds 0.92. This threshold is high enough to catch true duplicates while allowing legitimate updates (e.g., preference changes) to be written and handled by the supersession logic.

The memory part gating ensures users see save guidance immediately, enabling the positive feedback loop where facts are saved, retrieved, and refined.

https://claude.ai/code/session_01PHgCufAL8LAvR7wrkUJoB5