### PR TITLE
Add fuzzy chat search across desktop and Code workspaces

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -906,6 +906,18 @@ Assistant chats live in session state with `workspacePath` set to the chats sand
 
 New assistant chats default to `modeId: 'general'`, `workAgentAuto: true`, and the chats workspace path. **Desktop chat** threads use `createDesktopChat()` → `modeId: 'desktop'`, work agent **`desktop`** (General-assistant tone, full tool use), and workspace `~/.minnow/workspace` via [`desktop-chat-sessions.ts`](../src/os/desktop-chat-sessions.ts).
 
+### Chat search (sidebar + desktop rail)
+
+Fuzzy search across **all** chats (desktop assistant threads + Code workspace chats) from magnifier buttons in the Code sidebar header (`#btnChatSearch` in `index.html`, wired in [`src/ui/shell-handlers.ts`](../src/ui/shell-handlers.ts)) and the desktop chat rail header (`#btnDesktopChatSearch` built in [`src/os/desktop.ts`](../src/os/desktop.ts), wired in [`src/ui/desktop-chat-rail.ts`](../src/ui/desktop-chat-rail.ts)).
+
+| Concern | Location |
+|---------|----------|
+| Search core (pure) | [`src/chat/chat-search.ts`](../src/chat/chat-search.ts) — `searchChats()`: token AND-matching over titles + user/assistant message text; substring hits (word-start bonus) outrank bounded-gap subsequence fallbacks; title hits weighted 2× over message hits; recency tiebreak; snippet around the first match |
+| Popover UI | [`src/ui/chat-search-popover.ts`](../src/ui/chat-search-popover.ts) — anchored popover (input + keyboard-navigable results); results badge Chat vs Code (`isChatsWorkspacePath` \|\| `isDesktopWorkspacePath`) and deep-link via `launchChatWithThread` / `launchCodeWithChat` in [`src/os/chat-launch.ts`](../src/os/chat-launch.ts) |
+| Styles | [`src/styles/chat-search.css`](../src/styles/chat-search.css) |
+
+Empty placeholder drafts (no history, `New chat` name) are excluded. **Tests:** `test/chat/chat-search.test.mts`.
+
 ### Chat app UI shell (MinnowOS Chat App — step 3)
 
 Full-page Chat app at `#/app/chat` with session rail, message scroll shell, composer, and collapsible outputs drawer.

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -908,12 +908,15 @@ New assistant chats default to `modeId: 'general'`, `workAgentAuto: true`, and t
 
 ### Chat search (sidebar + desktop rail)
 
-Fuzzy search across **all** chats (desktop assistant threads + Code workspace chats) from magnifier buttons in the Code sidebar header (`#btnChatSearch` in `index.html`, wired in [`src/ui/shell-handlers.ts`](../src/ui/shell-handlers.ts)) and the desktop chat rail header (`#btnDesktopChatSearch` built in [`src/os/desktop.ts`](../src/os/desktop.ts), wired in [`src/ui/desktop-chat-rail.ts`](../src/ui/desktop-chat-rail.ts)).
+Fuzzy search from magnifier buttons in the Code sidebar header (`#btnChatSearch` in `index.html`, wired in [`src/ui/shell-handlers.ts`](../src/ui/shell-handlers.ts)) and the desktop chat rail header (`#btnDesktopChatSearch` built in [`src/os/desktop.ts`](../src/os/desktop.ts), wired in [`src/ui/desktop-chat-rail.ts`](../src/ui/desktop-chat-rail.ts)).
+
+**Default scope:** Code sidebar searches **only the current workspace**; desktop rail searches **desktop surface chats** (chats sandbox + desktop workspace). An **All workspaces** toggle in the popover expands to every chat; preference persists in `localStorage` (`minnow.chatSearch.allWorkspaces`).
 
 | Concern | Location |
 |---------|----------|
-| Search core (pure) | [`src/chat/chat-search.ts`](../src/chat/chat-search.ts) — `searchChats()`: token AND-matching over titles + user/assistant message text; substring hits (word-start bonus) outrank bounded-gap subsequence fallbacks; title hits weighted 2× over message hits; recency tiebreak; snippet around the first match |
-| Popover UI | [`src/ui/chat-search-popover.ts`](../src/ui/chat-search-popover.ts) — anchored popover (input + keyboard-navigable results); results badge Chat vs Code (`isChatsWorkspacePath` \|\| `isDesktopWorkspacePath`) and deep-link via `launchChatWithThread` / `launchCodeWithChat` in [`src/os/chat-launch.ts`](../src/os/chat-launch.ts) |
+| Search core (pure) | [`src/chat/chat-search.ts`](../src/chat/chat-search.ts) — `searchChats()`: token AND-matching over titles + user/assistant message text; substring hits (word-start bonus) outrank bounded-gap subsequence fallbacks; title hits weighted 2× over message hits; recency tiebreak; snippet around the first match; `filterChatsByWorkspacePath()` for workspace-scoped lists |
+| Popover UI | [`src/ui/chat-search-popover.ts`](../src/ui/chat-search-popover.ts) — anchored popover (input + **All workspaces** toggle + keyboard-navigable results); results badge Chat vs Code (`isChatsWorkspacePath` \|\| `isDesktopWorkspacePath`); workspace basename shown only when searching all workspaces; deep-link via `launchChatWithThread` / `launchCodeWithChat` in [`src/os/chat-launch.ts`](../src/os/chat-launch.ts) |
+| Cross-workspace navigation | [`src/os/chat-launch.ts`](../src/os/chat-launch.ts) — `launchCodeWithChat` calls `executeWorkspaceSwitch` when the target chat belongs to a different project folder |
 | Styles | [`src/styles/chat-search.css`](../src/styles/chat-search.css) |
 
 Empty placeholder drafts (no history, `New chat` name) are excluded. **Tests:** `test/chat/chat-search.test.mts`.

--- a/index.html
+++ b/index.html
@@ -2019,6 +2019,16 @@
         <button
           class="icon-btn"
           type="button"
+          id="btnChatSearch"
+          aria-label="Search chats"
+          title="Search chats"
+          aria-expanded="false"
+        >
+          <svg class="icon-svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+        </button>
+        <button
+          class="icon-btn"
+          type="button"
           id="btnSidebarCollapse"
           aria-label="Collapse sidebar"
         >

--- a/src/chat/chat-search.ts
+++ b/src/chat/chat-search.ts
@@ -1,0 +1,183 @@
+/**
+ * Fuzzy chat search across desktop (assistant) and Code (workspace) chats.
+ * Pure matching/scoring — popover UI lives in ui/chat-search-popover.ts.
+ */
+
+import { isPlaceholderChatName } from './titles/placeholder';
+import type { Chat } from '../types';
+
+export interface ChatSearchResult {
+  chat: Chat;
+  score: number;
+  /** Where the best match came from. */
+  matchedIn: 'title' | 'message';
+  /** Matched message role when matchedIn === 'message'. */
+  role?: 'user' | 'assistant';
+  /** Short excerpt around the first matched keyword. */
+  snippet: string;
+}
+
+interface TextMatch {
+  score: number;
+  /** Offset of the earliest matched token (snippet anchor). */
+  firstIndex: number;
+}
+
+const DEFAULT_RESULT_LIMIT = 30;
+const SNIPPET_BEFORE_CHARS = 32;
+const SNIPPET_TOTAL_CHARS = 110;
+/** Title hits outrank message hits of the same raw token score. */
+const TITLE_WEIGHT = 2;
+
+function isWordChar(ch: string): boolean {
+  return /[\p{L}\p{N}_]/u.test(ch);
+}
+
+/**
+ * Score one lowercased query token against lowercased text.
+ * Substring hits score highest (word-start bonus); otherwise an in-order
+ * subsequence within a bounded window still matches, penalized by gap size.
+ */
+function scoreToken(token: string, text: string): TextMatch | null {
+  const idx = text.indexOf(token);
+  if (idx >= 0) {
+    const atWordStart = idx === 0 || !isWordChar(text[idx - 1]);
+    return { score: 100 + (atWordStart ? 40 : 0), firstIndex: idx };
+  }
+  if (token.length < 2) return null;
+
+  // Subsequence fallback: token chars in order, tightest span wins.
+  const maxSpan = token.length * 4;
+  let start = text.indexOf(token[0]);
+  let best: TextMatch | null = null;
+  while (start >= 0) {
+    let ti = 1;
+    let last = start;
+    for (let i = start + 1; i < text.length && ti < token.length; i++) {
+      if (text[i] === token[ti]) {
+        last = i;
+        ti++;
+      }
+      if (i - start > maxSpan) break;
+    }
+    if (ti === token.length) {
+      const gap = last - start + 1 - token.length;
+      const score = Math.max(1, 60 - gap * 4);
+      if (!best || score > best.score) best = { score, firstIndex: start };
+      if (gap === 0) break;
+    }
+    start = text.indexOf(token[0], start + 1);
+  }
+  return best;
+}
+
+/** Split a query into lowercased keyword tokens. */
+export function tokenizeQuery(query: string): string[] {
+  return query.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Match every token against the text (AND semantics). Returns the summed
+ * token scores and the earliest matched offset, or null when any token misses.
+ */
+export function matchText(tokens: string[], text: string): TextMatch | null {
+  if (!tokens.length) return null;
+  const lower = text.toLowerCase();
+  let score = 0;
+  let firstIndex = lower.length;
+  for (const token of tokens) {
+    const hit = scoreToken(token, lower);
+    if (!hit) return null;
+    score += hit.score;
+    if (hit.firstIndex < firstIndex) firstIndex = hit.firstIndex;
+  }
+  return { score, firstIndex };
+}
+
+/** Collapse whitespace and clip a window around the match for display. */
+function buildSnippet(text: string, firstIndex: number): string {
+  let start = Math.max(0, firstIndex - SNIPPET_BEFORE_CHARS);
+  // Snap to a word boundary so snippets don't open mid-word.
+  while (start > 0 && start < text.length && isWordChar(text[start - 1])) start--;
+  const raw = text.slice(start, start + SNIPPET_TOTAL_CHARS);
+  const collapsed = raw.replace(/\s+/g, ' ').trim();
+  const prefix = start > 0 ? '…' : '';
+  const suffix = start + SNIPPET_TOTAL_CHARS < text.length ? '…' : '';
+  return `${prefix}${collapsed}${suffix}`;
+}
+
+/** Message text eligible for search (user/assistant with non-empty string content). */
+function searchableMessageText(message: Chat['history'][number]): string | null {
+  if (message.role !== 'user' && message.role !== 'assistant') return null;
+  const content = typeof message.content === 'string' ? message.content : '';
+  return content.trim() ? content : null;
+}
+
+/** True for unsent draft rows that should never appear in results. */
+function isSearchableChat(chat: Chat): boolean {
+  return chat.history.length > 0 || !isPlaceholderChatName(chat.name);
+}
+
+function firstMessagePreview(chat: Chat): string {
+  for (const message of chat.history) {
+    const text = searchableMessageText(message);
+    if (text) return buildSnippet(text, 0);
+  }
+  return '';
+}
+
+/** Best match for one chat across its title and message history, or null. */
+export function scoreChat(chat: Chat, tokens: string[]): ChatSearchResult | null {
+  if (!isSearchableChat(chat)) return null;
+
+  let best: ChatSearchResult | null = null;
+  const titleHit = matchText(tokens, chat.name);
+  if (titleHit) {
+    best = {
+      chat,
+      score: titleHit.score * TITLE_WEIGHT,
+      matchedIn: 'title',
+      snippet: firstMessagePreview(chat),
+    };
+  }
+
+  for (const message of chat.history) {
+    const text = searchableMessageText(message);
+    if (!text) continue;
+    const hit = matchText(tokens, text);
+    if (!hit || (best && hit.score <= best.score)) continue;
+    best = {
+      chat,
+      score: hit.score,
+      matchedIn: 'message',
+      role: message.role as 'user' | 'assistant',
+      snippet: buildSnippet(text, hit.firstIndex),
+    };
+  }
+  return best;
+}
+
+/**
+ * Fuzzy-search chats by title and message contents.
+ * Ranked by match score, then by most recent activity.
+ */
+export function searchChats(
+  chats: Chat[],
+  query: string,
+  options?: { limit?: number },
+): ChatSearchResult[] {
+  const tokens = tokenizeQuery(query);
+  if (!tokens.length) return [];
+  const limit = options?.limit ?? DEFAULT_RESULT_LIMIT;
+
+  const results: ChatSearchResult[] = [];
+  for (const chat of chats) {
+    const result = scoreChat(chat, tokens);
+    if (result) results.push(result);
+  }
+  results.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    return (b.chat.lastMessageAt ?? 0) - (a.chat.lastMessageAt ?? 0);
+  });
+  return results.slice(0, limit);
+}

--- a/src/chat/chat-search.ts
+++ b/src/chat/chat-search.ts
@@ -3,6 +3,7 @@
  * Pure matching/scoring — popover UI lives in ui/chat-search-popover.ts.
  */
 
+import { normalizeWorkspacePath } from '../lib/normalize-workspace-path';
 import { isPlaceholderChatName } from './titles/placeholder';
 import type { Chat } from '../types';
 
@@ -155,6 +156,13 @@ export function scoreChat(chat: Chat, tokens: string[]): ChatSearchResult | null
     };
   }
   return best;
+}
+
+/** Keep only chats bound to the given workspace root (normalized path equality). */
+export function filterChatsByWorkspacePath(chats: Chat[], workspacePath: string): Chat[] {
+  const key = normalizeWorkspacePath(workspacePath);
+  if (!key) return chats;
+  return chats.filter((chat) => normalizeWorkspacePath(chat.workspacePath ?? '') === key);
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,10 @@ export const ICON_CHEVRON_LEFT =
 export const ICON_CHEVRON_RIGHT =
   '<svg class="icon-svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18l6-6-6-6"/></svg>';
 
+/** SVG magnifier for chat search buttons (sidebar + desktop rail). */
+export const ICON_SEARCH =
+  '<svg class="icon-svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>';
+
 /** Document-with-lines icon for the file sidebar toggle. */
 export const ICON_FILE_TREE =
   '<svg class="icon-svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>';

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import './styles/motion.css';
 import './styles/topbar.css';
 import './styles/model-select.css';
 import './styles/sidebar.css';
+import './styles/chat-search.css';
 import './styles/messages.css';
 import './styles/message-actions.css';
 import './styles/voice.css';

--- a/src/os/chat-launch.ts
+++ b/src/os/chat-launch.ts
@@ -2,7 +2,36 @@
  * Code app launch helper — switch workspace chat from OS deep-links.
  */
 
+import { isChatsWorkspacePath } from '../lib/chats-workspace';
+import { isDesktopWorkspacePath } from '../lib/desktop-workspace';
+import { normalizeWorkspacePath } from '../lib/normalize-workspace-path';
+import { sessionState } from '../state/sessions';
+import { getWorkspacePath } from '../state/workspace';
 import { launchApp } from './router';
+
+/** True when the chat belongs to a user project folder (not a Minnow sandbox). */
+function isProjectWorkspacePath(path: string): boolean {
+  const trimmed = path.trim();
+  if (!trimmed) return false;
+  return !isChatsWorkspacePath(trimmed) && !isDesktopWorkspacePath(trimmed);
+}
+
+/** Switch the Code workspace when a deep-linked chat lives in another project folder. */
+async function ensureWorkspaceForCodeChat(chatId: string): Promise<boolean> {
+  const chat = sessionState?.chats.find((row) => row.id === chatId);
+  const chatWorkspace = chat?.workspacePath?.trim();
+  if (!chat || !chatWorkspace || !isProjectWorkspacePath(chatWorkspace)) {
+    return true;
+  }
+
+  if (normalizeWorkspacePath(chatWorkspace) === normalizeWorkspacePath(getWorkspacePath())) {
+    return true;
+  }
+
+  const { executeWorkspaceSwitch } = await import('../ui/workspace-switch-guard');
+  const info = await executeWorkspaceSwitch(chatWorkspace);
+  return info !== null;
+}
 
 /** Foreground Code and activate the given chat session. */
 export async function launchCodeWithChat(chatId: string): Promise<void> {
@@ -11,6 +40,9 @@ export async function launchCodeWithChat(chatId: string): Promise<void> {
     launchApp('code');
     return;
   }
+
+  const allowed = await ensureWorkspaceForCodeChat(trimmed);
+  if (!allowed) return;
 
   launchApp('code', { chatId: trimmed, codeSection: 'chat' });
   await switchToCodeChat(trimmed);

--- a/src/os/desktop.ts
+++ b/src/os/desktop.ts
@@ -11,7 +11,7 @@ import {
 import { isDesktopExpertsActive, isDesktopResearchActive, subscribeDesktopState } from './desktop-state';
 import { wireDesktopResearchControls } from './research-desktop';
 import { createOsIcon } from './icons';
-import { ICON_CHEVRON_LEFT } from '../constants';
+import { ICON_CHEVRON_LEFT, ICON_SEARCH } from '../constants';
 import type { DesktopPrefs } from './types';
 
 function greetingFor(d: Date): string {
@@ -121,6 +121,15 @@ export function renderDesktop(root: HTMLElement): () => void {
   railTitle.className = 'chat-sidebar-title';
   railTitle.textContent = 'Chats';
 
+  const railSearch = document.createElement('button');
+  railSearch.type = 'button';
+  railSearch.id = 'btnDesktopChatSearch';
+  railSearch.className = 'icon-btn';
+  railSearch.setAttribute('aria-label', 'Search chats');
+  railSearch.title = 'Search chats';
+  railSearch.setAttribute('aria-expanded', 'false');
+  railSearch.innerHTML = ICON_SEARCH;
+
   const railCollapse = document.createElement('button');
   railCollapse.type = 'button';
   railCollapse.id = 'btnDesktopChatRailCollapse';
@@ -128,7 +137,7 @@ export function renderDesktop(root: HTMLElement): () => void {
   railCollapse.setAttribute('aria-label', 'Collapse chat sessions');
   railCollapse.innerHTML = ICON_CHEVRON_LEFT;
 
-  railHeader.append(railTitle, railCollapse);
+  railHeader.append(railTitle, railSearch, railCollapse);
 
   const railNewChat = document.createElement('button');
   railNewChat.type = 'button';

--- a/src/styles/chat-search.css
+++ b/src/styles/chat-search.css
@@ -30,6 +30,17 @@
   border-color: var(--mn-border-strong);
 }
 
+.chat-search-scope-toggle {
+  padding: 4px 2px 2px;
+  border-bottom: none;
+  gap: 10px;
+}
+
+.chat-search-scope-toggle .settings-toggle-row__title {
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
 .chat-search-results {
   display: flex;
   flex-direction: column;

--- a/src/styles/chat-search.css
+++ b/src/styles/chat-search.css
@@ -1,0 +1,106 @@
+/* Chat search popover (sidebar + desktop rail search buttons) */
+
+.chat-search-popover {
+  position: fixed;
+  z-index: 60;
+  width: min(340px, calc(100vw - 1rem));
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+  gap: 8px;
+  background: var(--mn-bg);
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover-tall);
+  color: var(--mn-fg);
+}
+
+.chat-search-input {
+  width: 100%;
+  padding: 7px 10px;
+  background: var(--mn-surface-1);
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-sm);
+  color: var(--mn-fg);
+  font-size: 0.85rem;
+}
+
+.chat-search-input:focus {
+  outline: none;
+  border-color: var(--mn-border-strong);
+}
+
+.chat-search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: min(48vh, 380px);
+  overflow-y: auto;
+}
+
+.chat-search-empty {
+  padding: 10px 8px;
+  color: var(--mn-fg-muted);
+  font-size: 0.8rem;
+}
+
+.chat-search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.chat-search-result.is-active {
+  background: var(--mn-surface-1);
+}
+
+.chat-search-result__head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.chat-search-result__badge {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--mn-border);
+  color: var(--mn-fg-muted);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.chat-search-result__name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.82rem;
+  font-weight: 550;
+}
+
+.chat-search-result__workspace {
+  flex-shrink: 0;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--mn-fg-muted);
+  font-size: 0.7rem;
+}
+
+.chat-search-result__snippet {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: var(--mn-fg-muted);
+  font-size: 0.74rem;
+  line-height: 1.35;
+}

--- a/src/ui/chat-search-popover.ts
+++ b/src/ui/chat-search-popover.ts
@@ -1,0 +1,268 @@
+/**
+ * Chat search popover — fuzzy search across desktop and Code chats from the
+ * sidebar / desktop rail search buttons. Results deep-link into the owning surface.
+ */
+
+import { searchChats, type ChatSearchResult } from '../chat/chat-search';
+import { getChatsWorkspacePath, isChatsWorkspacePath } from '../lib/chats-workspace';
+import { getDesktopWorkspacePath, isDesktopWorkspacePath } from '../lib/desktop-workspace';
+import { sessionState } from '../state/sessions';
+import type { Chat } from '../types';
+
+/** True when the chat opens on the desktop chat surface (assistant or desktop sandbox). */
+function isDesktopSurfaceChat(chat: Chat): boolean {
+  const path = chat.workspacePath ?? '';
+  return isChatsWorkspacePath(path) || isDesktopWorkspacePath(path);
+}
+
+let popoverEl: HTMLDivElement | null = null;
+let anchorEl: HTMLElement | null = null;
+let inputEl: HTMLInputElement | null = null;
+let resultsEl: HTMLDivElement | null = null;
+let open = false;
+let results: ChatSearchResult[] = [];
+let activeIndex = -1;
+let outsidePointerHandler: ((e: PointerEvent) => void) | null = null;
+let escapeHandler: ((e: KeyboardEvent) => void) | null = null;
+
+function detachGlobalListeners(): void {
+  if (outsidePointerHandler) {
+    document.removeEventListener('pointerdown', outsidePointerHandler, true);
+    outsidePointerHandler = null;
+  }
+  if (escapeHandler) {
+    document.removeEventListener('keydown', escapeHandler, true);
+    escapeHandler = null;
+  }
+}
+
+/** Close the chat search popover if open. */
+export function closeChatSearchPopover(): void {
+  if (!open) return;
+  open = false;
+  detachGlobalListeners();
+  anchorEl?.setAttribute('aria-expanded', 'false');
+  anchorEl = null;
+  inputEl = null;
+  resultsEl = null;
+  results = [];
+  activeIndex = -1;
+  popoverEl?.remove();
+  popoverEl = null;
+}
+
+/** Whether the chat search popover is visible. */
+export function isChatSearchPopoverOpen(): boolean {
+  return open;
+}
+
+function positionPopover(anchor: HTMLElement, popover: HTMLElement): void {
+  const rect = anchor.getBoundingClientRect();
+  const margin = 8;
+  const popoverWidth = popover.offsetWidth || 320;
+
+  let left = rect.left;
+  left = Math.max(margin, Math.min(left, window.innerWidth - popoverWidth - margin));
+  const top = Math.min(rect.bottom + 4, window.innerHeight - margin - 80);
+
+  popover.style.top = `${top}px`;
+  popover.style.left = `${left}px`;
+}
+
+function attachGlobalListeners(): void {
+  outsidePointerHandler = (e: PointerEvent) => {
+    const target = e.target as Node | null;
+    if (!popoverEl || !anchorEl) return;
+    if (popoverEl.contains(target) || anchorEl.contains(target)) return;
+    closeChatSearchPopover();
+  };
+  document.addEventListener('pointerdown', outsidePointerHandler, true);
+
+  escapeHandler = (e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    closeChatSearchPopover();
+  };
+  document.addEventListener('keydown', escapeHandler, true);
+}
+
+/** Foreground the surface that owns the chat (desktop assistant vs Code workspace). */
+function openSearchResult(chat: Chat): void {
+  const isDesktop = isDesktopSurfaceChat(chat);
+  closeChatSearchPopover();
+  void import('../os/chat-launch').then((m) => {
+    if (isDesktop) {
+      void m.launchChatWithThread(chat.id);
+    } else {
+      void m.launchCodeWithChat(chat.id);
+    }
+  });
+}
+
+function workspaceBasename(workspacePath: string): string {
+  const normalized = workspacePath.replace(/\\/g, '/').replace(/\/+$/, '');
+  const slash = normalized.lastIndexOf('/');
+  return slash >= 0 ? normalized.slice(slash + 1) : normalized;
+}
+
+function setActiveIndex(next: number): void {
+  if (!resultsEl) return;
+  const rows = resultsEl.querySelectorAll<HTMLElement>('.chat-search-result');
+  if (!rows.length) {
+    activeIndex = -1;
+    return;
+  }
+  activeIndex = Math.max(0, Math.min(next, rows.length - 1));
+  rows.forEach((row, i) => {
+    row.classList.toggle('is-active', i === activeIndex);
+    row.setAttribute('aria-selected', i === activeIndex ? 'true' : 'false');
+  });
+  rows[activeIndex].scrollIntoView({ block: 'nearest' });
+}
+
+function renderResults(query: string): void {
+  if (!resultsEl) return;
+  resultsEl.replaceChildren();
+  activeIndex = -1;
+
+  if (!query.trim()) {
+    results = [];
+    const hint = document.createElement('div');
+    hint.className = 'chat-search-empty';
+    hint.textContent = 'Type to search chat titles and messages';
+    resultsEl.appendChild(hint);
+    return;
+  }
+
+  results = searchChats(sessionState?.chats ?? [], query);
+  if (!results.length) {
+    const empty = document.createElement('div');
+    empty.className = 'chat-search-empty';
+    empty.textContent = 'No matching chats';
+    resultsEl.appendChild(empty);
+    return;
+  }
+
+  results.forEach((result, index) => {
+    const { chat } = result;
+    const isDesktop = isDesktopSurfaceChat(chat);
+
+    const row = document.createElement('div');
+    row.className = 'chat-search-result';
+    row.setAttribute('role', 'option');
+    row.setAttribute('aria-selected', 'false');
+    row.dataset.chatId = chat.id;
+
+    const head = document.createElement('div');
+    head.className = 'chat-search-result__head';
+
+    const badge = document.createElement('span');
+    badge.className =
+      'chat-search-result__badge' +
+      (isDesktop ? ' chat-search-result__badge--chat' : ' chat-search-result__badge--code');
+    badge.textContent = isDesktop ? 'Chat' : 'Code';
+    head.appendChild(badge);
+
+    const name = document.createElement('span');
+    name.className = 'chat-search-result__name';
+    name.textContent = chat.name;
+    head.appendChild(name);
+
+    if (!isDesktop && chat.workspacePath) {
+      const ws = document.createElement('span');
+      ws.className = 'chat-search-result__workspace';
+      ws.textContent = workspaceBasename(chat.workspacePath);
+      ws.title = chat.workspacePath;
+      head.appendChild(ws);
+    }
+
+    row.appendChild(head);
+
+    if (result.snippet) {
+      const snippet = document.createElement('div');
+      snippet.className = 'chat-search-result__snippet';
+      snippet.textContent =
+        result.matchedIn === 'message' && result.role === 'user'
+          ? `You: ${result.snippet}`
+          : result.snippet;
+      row.appendChild(snippet);
+    }
+
+    row.addEventListener('click', () => openSearchResult(chat));
+    row.addEventListener('pointerenter', () => setActiveIndex(index));
+    resultsEl?.appendChild(row);
+  });
+}
+
+function onInputKeydown(e: KeyboardEvent): void {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    setActiveIndex(activeIndex + 1);
+    return;
+  }
+  if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    setActiveIndex(activeIndex - 1);
+    return;
+  }
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    const target = results[activeIndex] ?? results[0];
+    if (target) openSearchResult(target.chat);
+  }
+}
+
+function buildPopover(): HTMLDivElement {
+  const popover = document.createElement('div');
+  popover.className = 'chat-search-popover';
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-modal', 'false');
+  popover.setAttribute('aria-label', 'Search chats');
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'chat-search-input';
+  input.placeholder = 'Search all chats…';
+  input.setAttribute('aria-label', 'Search all chats');
+  input.addEventListener('input', () => renderResults(input.value));
+  input.addEventListener('keydown', onInputKeydown);
+
+  const list = document.createElement('div');
+  list.className = 'chat-search-results';
+  list.setAttribute('role', 'listbox');
+  list.setAttribute('aria-label', 'Matching chats');
+
+  popover.append(input, list);
+  inputEl = input;
+  resultsEl = list;
+  return popover;
+}
+
+/** Open the chat search popover anchored to a sidebar / rail button. */
+export function openChatSearchPopover(anchor: HTMLElement): void {
+  closeChatSearchPopover();
+
+  // Prime the sandbox path caches so results classify desktop vs Code chats.
+  void getChatsWorkspacePath();
+  void getDesktopWorkspacePath();
+
+  popoverEl = buildPopover();
+  document.body.appendChild(popoverEl);
+  anchorEl = anchor;
+  open = true;
+  anchor.setAttribute('aria-expanded', 'true');
+
+  renderResults('');
+  positionPopover(anchor, popoverEl);
+  attachGlobalListeners();
+
+  requestAnimationFrame(() => inputEl?.focus());
+}
+
+/** Toggle the popover from its anchor button. */
+export function toggleChatSearchPopover(anchor: HTMLElement): void {
+  if (open && anchorEl === anchor) {
+    closeChatSearchPopover();
+    return;
+  }
+  openChatSearchPopover(anchor);
+}

--- a/src/ui/chat-search-popover.ts
+++ b/src/ui/chat-search-popover.ts
@@ -3,11 +3,22 @@
  * sidebar / desktop rail search buttons. Results deep-link into the owning surface.
  */
 
-import { searchChats, type ChatSearchResult } from '../chat/chat-search';
+import {
+  filterChatsByWorkspacePath,
+  searchChats,
+  type ChatSearchResult,
+} from '../chat/chat-search';
 import { getChatsWorkspacePath, isChatsWorkspacePath } from '../lib/chats-workspace';
 import { getDesktopWorkspacePath, isDesktopWorkspacePath } from '../lib/desktop-workspace';
 import { sessionState } from '../state/sessions';
+import { getWorkspacePath } from '../state/workspace';
 import type { Chat } from '../types';
+import { createSettingsToggleRow } from './settings-switch';
+
+/** Where the popover was opened from — drives default search scope. */
+type ChatSearchContext = 'code' | 'desktop';
+
+const ALL_WORKSPACES_STORAGE_KEY = 'minnow.chatSearch.allWorkspaces';
 
 /** True when the chat opens on the desktop chat surface (assistant or desktop sandbox). */
 function isDesktopSurfaceChat(chat: Chat): boolean {
@@ -19,11 +30,60 @@ let popoverEl: HTMLDivElement | null = null;
 let anchorEl: HTMLElement | null = null;
 let inputEl: HTMLInputElement | null = null;
 let resultsEl: HTMLDivElement | null = null;
+let searchAllWorkspaces = false;
+let searchContext: ChatSearchContext = 'code';
 let open = false;
 let results: ChatSearchResult[] = [];
 let activeIndex = -1;
 let outsidePointerHandler: ((e: PointerEvent) => void) | null = null;
 let escapeHandler: ((e: KeyboardEvent) => void) | null = null;
+
+function readSearchAllWorkspacesPreference(): boolean {
+  try {
+    return localStorage.getItem(ALL_WORKSPACES_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function persistSearchAllWorkspacesPreference(value: boolean): void {
+  try {
+    localStorage.setItem(ALL_WORKSPACES_STORAGE_KEY, value ? 'true' : 'false');
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+function resolveSearchContext(anchor: HTMLElement): ChatSearchContext {
+  return anchor.id === 'btnDesktopChatSearch' ? 'desktop' : 'code';
+}
+
+function chatsForCurrentScope(): Chat[] {
+  const all = sessionState?.chats ?? [];
+  if (searchAllWorkspaces) return all;
+  if (searchContext === 'desktop') {
+    return all.filter(isDesktopSurfaceChat);
+  }
+  return filterChatsByWorkspacePath(all, getWorkspacePath());
+}
+
+function searchPlaceholder(): string {
+  if (searchAllWorkspaces) return 'Search all chats…';
+  if (searchContext === 'desktop') return 'Search desktop chats…';
+  return 'Search this workspace…';
+}
+
+function emptyQueryHint(): string {
+  if (searchAllWorkspaces) return 'Type to search chat titles and messages';
+  if (searchContext === 'desktop') return 'Type to search desktop chat titles and messages';
+  return 'Type to search chats in this workspace';
+}
+
+function noResultsMessage(): string {
+  if (searchAllWorkspaces) return 'No matching chats';
+  if (searchContext === 'desktop') return 'No matching desktop chats';
+  return 'No matching chats in this workspace';
+}
 
 function detachGlobalListeners(): void {
   if (outsidePointerHandler) {
@@ -45,6 +105,7 @@ export function closeChatSearchPopover(): void {
   anchorEl = null;
   inputEl = null;
   resultsEl = null;
+  searchContext = 'code';
   results = [];
   activeIndex = -1;
   popoverEl?.remove();
@@ -119,6 +180,13 @@ function setActiveIndex(next: number): void {
   rows[activeIndex].scrollIntoView({ block: 'nearest' });
 }
 
+function syncSearchInputPlaceholder(): void {
+  if (!inputEl) return;
+  const placeholder = searchPlaceholder();
+  inputEl.placeholder = placeholder;
+  inputEl.setAttribute('aria-label', placeholder);
+}
+
 function renderResults(query: string): void {
   if (!resultsEl) return;
   resultsEl.replaceChildren();
@@ -128,16 +196,16 @@ function renderResults(query: string): void {
     results = [];
     const hint = document.createElement('div');
     hint.className = 'chat-search-empty';
-    hint.textContent = 'Type to search chat titles and messages';
+    hint.textContent = emptyQueryHint();
     resultsEl.appendChild(hint);
     return;
   }
 
-  results = searchChats(sessionState?.chats ?? [], query);
+  results = searchChats(chatsForCurrentScope(), query);
   if (!results.length) {
     const empty = document.createElement('div');
     empty.className = 'chat-search-empty';
-    empty.textContent = 'No matching chats';
+    empty.textContent = noResultsMessage();
     resultsEl.appendChild(empty);
     return;
   }
@@ -167,7 +235,7 @@ function renderResults(query: string): void {
     name.textContent = chat.name;
     head.appendChild(name);
 
-    if (!isDesktop && chat.workspacePath) {
+    if (!isDesktop && chat.workspacePath && searchAllWorkspaces) {
       const ws = document.createElement('span');
       ws.className = 'chat-search-result__workspace';
       ws.textContent = workspaceBasename(chat.workspacePath);
@@ -221,19 +289,31 @@ function buildPopover(): HTMLDivElement {
   const input = document.createElement('input');
   input.type = 'text';
   input.className = 'chat-search-input';
-  input.placeholder = 'Search all chats…';
-  input.setAttribute('aria-label', 'Search all chats');
   input.addEventListener('input', () => renderResults(input.value));
   input.addEventListener('keydown', onInputKeydown);
+
+  const { row: scopeRow, input: scopeToggle } = createSettingsToggleRow('All workspaces', {
+    id: 'chatSearchAllWorkspaces',
+    checked: searchAllWorkspaces,
+    onChange: (checked) => {
+      searchAllWorkspaces = checked;
+      persistSearchAllWorkspacesPreference(checked);
+      syncSearchInputPlaceholder();
+      renderResults(input.value);
+    },
+  });
+  scopeRow.classList.add('chat-search-scope-toggle');
 
   const list = document.createElement('div');
   list.className = 'chat-search-results';
   list.setAttribute('role', 'listbox');
   list.setAttribute('aria-label', 'Matching chats');
 
-  popover.append(input, list);
+  popover.append(input, scopeRow, list);
   inputEl = input;
   resultsEl = list;
+  syncSearchInputPlaceholder();
+  scopeToggle.checked = searchAllWorkspaces;
   return popover;
 }
 
@@ -244,6 +324,9 @@ export function openChatSearchPopover(anchor: HTMLElement): void {
   // Prime the sandbox path caches so results classify desktop vs Code chats.
   void getChatsWorkspacePath();
   void getDesktopWorkspacePath();
+
+  searchContext = resolveSearchContext(anchor);
+  searchAllWorkspaces = readSearchAllWorkspacesPreference();
 
   popoverEl = buildPopover();
   document.body.appendChild(popoverEl);

--- a/src/ui/desktop-chat-rail.ts
+++ b/src/ui/desktop-chat-rail.ts
@@ -269,6 +269,14 @@ export function wireDesktopChatRail(): void {
     collapse.addEventListener('click', () => collapseDesktopChatRail());
   }
 
+  const search = document.getElementById('btnDesktopChatSearch');
+  if (search && search.dataset.bound !== '1') {
+    search.dataset.bound = '1';
+    search.addEventListener('click', () => {
+      void import('./chat-search-popover').then((m) => m.toggleChatSearchPopover(search));
+    });
+  }
+
   const backdrop = getRailBackdrop();
   if (backdrop && backdrop.dataset.bound !== '1') {
     backdrop.dataset.bound = '1';

--- a/src/ui/shell-handlers.ts
+++ b/src/ui/shell-handlers.ts
@@ -111,6 +111,11 @@ export function initShellHandlers(): void {
   wireClick('fileSidebarBackdrop', closeMobileFileSidebar);
 
   // Chat sidebar
+  wireClick('btnChatSearch', () => {
+    const btn = document.getElementById('btnChatSearch');
+    if (!btn) return;
+    void import('./chat-search-popover').then((m) => m.toggleChatSearchPopover(btn));
+  });
   wireClick('btnSidebarCollapse', toggleSidebarCollapsed);
   wireClickAll('.chat-new-wide, .chat-new-compact', createChat);
   wireClick('btnOrchestrate', () => {

--- a/test/chat/chat-search.test.mts
+++ b/test/chat/chat-search.test.mts
@@ -4,7 +4,7 @@
 
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { matchText, searchChats, tokenizeQuery } from '../../src/chat/chat-search.ts';
+import { filterChatsByWorkspacePath, matchText, searchChats, tokenizeQuery } from '../../src/chat/chat-search.ts';
 import type { Chat, Message } from '../../src/types.ts';
 
 function makeChat(overrides: Partial<Chat> & { id: string }): Chat {
@@ -161,5 +161,28 @@ describe('searchChats', () => {
     );
     assert.equal(searchChats(many, 'deploy').length, 30);
     assert.equal(searchChats(many, 'deploy', { limit: 5 }).length, 5);
+  });
+});
+
+describe('filterChatsByWorkspacePath', () => {
+  test('keeps chats whose workspacePath matches after normalization', () => {
+    const chats = [
+      makeChat({ id: 'a', workspacePath: '/repo/minnow', history: [user('a')] }),
+      makeChat({ id: 'b', workspacePath: '/repo/other', history: [user('b')] }),
+      makeChat({ id: 'c', workspacePath: '', history: [user('c')] }),
+    ];
+    const filtered = filterChatsByWorkspacePath(chats, '/repo/minnow/');
+    assert.deepEqual(
+      filtered.map((chat) => chat.id),
+      ['a'],
+    );
+  });
+
+  test('returns all chats when workspace path is empty', () => {
+    const chats = [
+      makeChat({ id: 'a', workspacePath: '/repo/a', history: [user('a')] }),
+      makeChat({ id: 'b', workspacePath: '/repo/b', history: [user('b')] }),
+    ];
+    assert.equal(filterChatsByWorkspacePath(chats, '').length, 2);
   });
 });

--- a/test/chat/chat-search.test.mts
+++ b/test/chat/chat-search.test.mts
@@ -1,0 +1,165 @@
+/**
+ * Fuzzy chat search core: token matching, ranking, snippets, draft exclusion.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { matchText, searchChats, tokenizeQuery } from '../../src/chat/chat-search.ts';
+import type { Chat, Message } from '../../src/types.ts';
+
+function makeChat(overrides: Partial<Chat> & { id: string }): Chat {
+  return {
+    name: 'Untitled',
+    workspacePath: '/repo/minnow',
+    modelId: 'test-model',
+    modeId: 'general',
+    workAgentId: null,
+    workAgentAuto: true,
+    history: [],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1000,
+    lastMessageAt: 1000,
+    ...overrides,
+  } as Chat;
+}
+
+function user(content: string): Message {
+  return { role: 'user', content };
+}
+
+function assistant(content: string): Message {
+  return { role: 'assistant', content };
+}
+
+describe('tokenizeQuery', () => {
+  test('lowercases and splits on whitespace', () => {
+    assert.deepEqual(tokenizeQuery('  Fix  LOGIN bug '), ['fix', 'login', 'bug']);
+  });
+
+  test('empty query yields no tokens', () => {
+    assert.deepEqual(tokenizeQuery('   '), []);
+  });
+});
+
+describe('matchText', () => {
+  test('substring match scores higher at word starts', () => {
+    const wordStart = matchText(['data'], 'the database schema');
+    const midWord = matchText(['base'], 'the database schema');
+    assert.ok(wordStart && midWord);
+    assert.ok(wordStart.score > midWord.score);
+  });
+
+  test('fuzzy subsequence matches with gaps', () => {
+    const hit = matchText(['dbase'], 'database');
+    assert.ok(hit);
+    const exact = matchText(['database'], 'database');
+    assert.ok(exact && exact.score > hit.score);
+  });
+
+  test('all tokens must match (AND semantics)', () => {
+    assert.equal(matchText(['login', 'zebra'], 'fix the login page'), null);
+    assert.ok(matchText(['login', 'page'], 'fix the login page'));
+  });
+
+  test('subsequence with oversized gaps does not match', () => {
+    assert.equal(matchText(['abc'], 'a' + 'x'.repeat(50) + 'bc'), null);
+  });
+});
+
+describe('searchChats', () => {
+  const chats: Chat[] = [
+    makeChat({
+      id: 'title-hit',
+      name: 'Login page rework',
+      history: [user('start with the header')],
+      lastMessageAt: 3000,
+    }),
+    makeChat({
+      id: 'message-hit',
+      name: 'Tuesday sync',
+      history: [
+        user('can you fix the login form validation?'),
+        assistant('Sure — the login form now validates email input.'),
+      ],
+      lastMessageAt: 2000,
+    }),
+    makeChat({
+      id: 'unrelated',
+      name: 'Recipe ideas',
+      history: [user('pasta with garlic butter')],
+    }),
+    makeChat({ id: 'draft', name: 'New chat', history: [] }),
+  ];
+
+  test('empty query returns no results', () => {
+    assert.deepEqual(searchChats(chats, ''), []);
+  });
+
+  test('finds keywords in titles and messages, ranking titles first', () => {
+    const results = searchChats(chats, 'login');
+    assert.deepEqual(
+      results.map((r) => r.chat.id),
+      ['title-hit', 'message-hit'],
+    );
+    assert.equal(results[0].matchedIn, 'title');
+    assert.equal(results[1].matchedIn, 'message');
+  });
+
+  test('message hits carry a snippet around the match', () => {
+    const results = searchChats(chats, 'validation');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].chat.id, 'message-hit');
+    assert.equal(results[0].role, 'user');
+    assert.match(results[0].snippet, /login form validation/);
+  });
+
+  test('multi-word query needs every keyword in one text', () => {
+    const results = searchChats(chats, 'garlic pasta');
+    assert.deepEqual(
+      results.map((r) => r.chat.id),
+      ['unrelated'],
+    );
+    assert.deepEqual(searchChats(chats, 'garlic login'), []);
+  });
+
+  test('fuzzy query tolerates missing characters', () => {
+    const results = searchChats(chats, 'valdation');
+    assert.deepEqual(
+      results.map((r) => r.chat.id),
+      ['message-hit'],
+    );
+  });
+
+  test('empty placeholder drafts are excluded', () => {
+    assert.deepEqual(searchChats(chats, 'new chat'), []);
+  });
+
+  test('equal scores rank by recent activity', () => {
+    const a = makeChat({
+      id: 'older',
+      name: 'alpha',
+      history: [user('shared keyword here')],
+      lastMessageAt: 100,
+    });
+    const b = makeChat({
+      id: 'newer',
+      name: 'beta',
+      history: [user('shared keyword here')],
+      lastMessageAt: 200,
+    });
+    const results = searchChats([a, b], 'shared keyword');
+    assert.deepEqual(
+      results.map((r) => r.chat.id),
+      ['newer', 'older'],
+    );
+  });
+
+  test('respects the result limit', () => {
+    const many = Array.from({ length: 40 }, (_, i) =>
+      makeChat({ id: `c${i}`, name: `deploy notes ${i}`, history: [user('hello')] }),
+    );
+    assert.equal(searchChats(many, 'deploy').length, 30);
+    assert.equal(searchChats(many, 'deploy', { limit: 5 }).length, 5);
+  });
+});


### PR DESCRIPTION
Implements a unified chat search feature that allows users to fuzzy-search across all chats (desktop assistant threads and Code workspace chats) from magnifier buttons in both the Code sidebar and desktop rail.

## Summary
This PR adds a complete chat search system with two main components:
1. **Core search logic** (`src/chat/chat-search.ts`) — Pure fuzzy matching and ranking algorithm
2. **Search UI** (`src/ui/chat-search-popover.ts`) — Interactive popover with keyboard navigation and result deep-linking

## Key Changes

- **Fuzzy search algorithm** with token-based matching:
  - Substring matches score highest (with word-start bonuses)
  - Fuzzy subsequence matching for typo tolerance
  - AND semantics (all query tokens must match)
  - Configurable result limit (default 30)

- **Search popover UI**:
  - Anchored to sidebar/rail search buttons with smart positioning
  - Keyboard navigation (arrow keys, Enter to select, Escape to close)
  - Click-outside and escape key handlers for dismissal
  - Results show chat name, type badge (Chat/Code), workspace path, and message snippets
  - Active result highlighting with auto-scroll

- **Result ranking**:
  - Title matches outrank message matches (2x weight)
  - Equal scores sorted by most recent activity
  - Excludes unsent draft chats with placeholder names
  - Message snippets show context with ellipsis and word-boundary snapping

- **Integration**:
  - Search button added to Code sidebar header (`#btnChatSearch`)
  - Search button added to desktop rail (`#btnDesktopChatSearch`)
  - Results deep-link to owning surface (desktop assistant or Code workspace)
  - Workspace path caches primed on popover open for accurate chat classification

- **Styling** (`src/styles/chat-search.css`):
  - Fixed popover with responsive width and max-height
  - Accessible ARIA attributes (dialog, listbox, options)
  - Themed with design system variables

- **Testing**:
  - Comprehensive test suite covering tokenization, matching, ranking, and edge cases
  - Tests for title/message precedence, fuzzy matching, multi-word queries, draft exclusion, and result limits

## Implementation Details

- Uses Unicode-aware word character detection (`\p{L}\p{N}_`) for international text
- Snippet building snaps to word boundaries to avoid mid-word truncation
- Popover positioning accounts for viewport edges with 8px margins
- Message role tracking (user/assistant) for snippet context in results
- Lazy imports for chat launch functions to minimize bundle impact

https://claude.ai/code/session_01AYxXnc4f3diQhCnbBs52ge