### PR TITLE
✨ Add one-click provider presets (MIN-418)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -324,7 +324,7 @@ Design reference: [`DESIGN.md`](../DESIGN.md), [`documentation/design-system/`](
 
 Multi-provider registry: `~/.minnow/providers/`. UI: Models app → Providers. Chat uses composite model keys (`providerId` + model id) in [`src/lib/model-select-key.ts`](../src/lib/model-select-key.ts).
 
-**One-click presets:** shared catalog in [`src/providers/presets.ts`](../src/providers/presets.ts) — OpenCode Go/Zen, Anthropic, DeepSeek, GitHub Copilot, plus OpenRouter/OpenAI/Groq/Mistral. Used by onboarding cloud setup and Settings → Providers quick-add chips (base URL, auth style, and model-discovery paths pre-wired).
+**One-click presets:** shared catalog in [`src/providers/presets.ts`](../src/providers/presets.ts) — OpenCode Go/Zen, Anthropic, DeepSeek, GitHub Copilot, plus OpenRouter/OpenAI/Groq/Mistral. Used by onboarding cloud setup (chips) and **Settings → Providers → Add provider** (preset grid first, then form; **Add custom provider** opens the full field set for local or arbitrary endpoints).
 
 `fetchModels()` loads all enabled providers. Main chat streams via generations API; `postChatCompletions` shim for headless/sub-agents.
 

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -324,6 +324,8 @@ Design reference: [`DESIGN.md`](../DESIGN.md), [`documentation/design-system/`](
 
 Multi-provider registry: `~/.minnow/providers/`. UI: Models app → Providers. Chat uses composite model keys (`providerId` + model id) in [`src/lib/model-select-key.ts`](../src/lib/model-select-key.ts).
 
+**One-click presets:** shared catalog in [`src/providers/presets.ts`](../src/providers/presets.ts) — OpenCode Go/Zen, Anthropic, DeepSeek, GitHub Copilot, plus OpenRouter/OpenAI/Groq/Mistral. Used by onboarding cloud setup and Settings → Providers quick-add chips (base URL, auth style, and model-discovery paths pre-wired).
+
 `fetchModels()` loads all enabled providers. Main chat streams via generations API; `postChatCompletions` shim for headless/sub-agents.
 
 **Fallback chains:** `config.json` → `fallbackChains` — sequential retry before first upstream byte ([`server/generations/fallback.js`](../server/generations/fallback.js)).

--- a/documentation/guides/settings-reference.md
+++ b/documentation/guides/settings-reference.md
@@ -112,7 +112,7 @@ Also: `config.activeProviderId`.
 
 #### One-click provider presets
 
-Catalog: [`src/providers/presets.ts`](../../src/providers/presets.ts). Presets appear as chips in **onboarding → Cloud API** and in **Settings → Models → Providers → Add provider**.
+Catalog: [`src/providers/presets.ts`](../../src/providers/presets.ts). Presets appear as chips in **onboarding → Cloud API** and as a preset grid in **Settings → Models → Providers → Add provider** (choose a preset or **Add custom provider** for the full form).
 
 | Preset | Base URL | API kind | Auth | Notes |
 |--------|----------|----------|------|-------|

--- a/documentation/guides/settings-reference.md
+++ b/documentation/guides/settings-reference.md
@@ -110,6 +110,24 @@ Stored primarily in browser `localStorage` (custom token overrides may sync via 
 
 Also: `config.activeProviderId`.
 
+#### One-click provider presets
+
+Catalog: [`src/providers/presets.ts`](../../src/providers/presets.ts). Presets appear as chips in **onboarding → Cloud API** and in **Settings → Models → Providers → Add provider**.
+
+| Preset | Base URL | API kind | Auth | Notes |
+|--------|----------|----------|------|-------|
+| OpenCode Go | `https://opencode.ai/zen/go` | OpenAI v1 | Bearer | Gateway auto-API for mixed catalogs |
+| OpenCode Zen | `https://opencode.ai/zen` | OpenAI v1 | Bearer | Gateway auto-API |
+| Anthropic | `https://api.anthropic.com` | Anthropic Messages | X-Api-Key | |
+| DeepSeek | `https://api.deepseek.com` | OpenAI v1 | Bearer | |
+| GitHub Copilot | `https://api.githubcopilot.com` | OpenAI v1 | Bearer | Gateway auto-API; OAuth Bearer token |
+
+Also available: OpenRouter, OpenAI, Groq, Mistral (same catalog).
+
+**GitHub Copilot account variants:** edit the base URL after applying the preset — Business: `https://api.business.githubcopilot.com`, Enterprise: `https://api.enterprise.githubcopilot.com`.
+
+**Env overrides:** there are no dedicated environment variables for preset base URLs. Provider profiles are stored under `~/.minnow/providers/<id>/` (override data dir with `MINNOW_HOME`). Network bind mode uses `MINNOW_NETWORK` (`local` / `lan`).
+
 ### Routing
 
 Per routing row: **provider**, **model**, **sampler override**, **thinking mode**, **fallback chain**.

--- a/index.html
+++ b/index.html
@@ -644,7 +644,13 @@
         <div id="settingsProvidersList" class="settings-providers-list" role="list" aria-label="Configured LLM providers"></div>
         <details id="settingsProvidersAddPanel" class="settings-providers-add-panel hidden">
           <summary class="settings-providers-add-summary">Add provider</summary>
-          <form id="settingsProvidersAddForm" class="settings-providers-form" novalidate>
+          <div id="settingsProvidersAddPicker" class="settings-providers-add-picker" role="group" aria-label="Provider presets"></div>
+          <form id="settingsProvidersAddForm" class="settings-providers-form hidden" novalidate>
+            <div class="settings-providers-add-form-head">
+              <button type="button" id="settingsProvidersAddBack" class="settings-inline-btn settings-providers-add-back">Back to presets</button>
+              <p id="settingsProvidersAddModeLabel" class="settings-providers-add-mode-label field-hint" aria-live="polite"></p>
+              <p id="settingsProvidersAddPresetAuthHint" class="field-hint hidden" data-provider-preset-auth-hint></p>
+            </div>
             <div class="field-row">
               <div class="field">
                 <label for="settingsProvidersAddId">Provider id</label>

--- a/src/onboarding/steps/provider.ts
+++ b/src/onboarding/steps/provider.ts
@@ -17,7 +17,7 @@ import {
   probeLocalProviders,
   type ProviderProbeResult,
 } from '../provider-probe';
-import type { ApiKind, AuthStyle } from '../../providers/types';
+import { ONBOARDING_CLOUD_PRESETS } from '../../providers/presets';
 import type { OnboardingContext, OnboardingStep, OnboardingStepActions } from '../types';
 import { recordStepProgress } from '../state-core';
 
@@ -30,44 +30,6 @@ let cloudBaseUrl = 'https://openrouter.ai/api';
 let cloudApiKey = '';
 let connectionStatus: 'idle' | 'ok' | 'err' = 'idle';
 let connectionError = '';
-
-interface CloudPreset {
-  id: string;
-  label: string;
-  baseUrl: string;
-  apiKind?: ApiKind;
-  authStyle?: AuthStyle;
-  /** Route Claude models to the messages path on mixed OpenAI gateways. */
-  autoApi?: boolean;
-}
-
-/** Gateway origin only; `/v1/models` etc. come from getDefaultPaths(apiKind). */
-const CLOUD_PRESETS: CloudPreset[] = [
-  { id: 'openrouter', label: 'OpenRouter', baseUrl: 'https://openrouter.ai/api' },
-  { id: 'openai', label: 'OpenAI', baseUrl: 'https://api.openai.com' },
-  { id: 'groq', label: 'Groq', baseUrl: 'https://api.groq.com/openai' },
-  { id: 'mistral', label: 'Mistral', baseUrl: 'https://api.mistral.ai' },
-  {
-    id: 'opencode-zen',
-    label: 'OpenCode Zen',
-    baseUrl: 'https://opencode.ai/zen',
-    autoApi: true,
-  },
-  {
-    id: 'opencode-go',
-    label: 'OpenCode Go',
-    baseUrl: 'https://opencode.ai/zen/go',
-    autoApi: true,
-  },
-  {
-    id: 'anthropic',
-    label: 'Anthropic',
-    baseUrl: 'https://api.anthropic.com',
-    apiKind: 'anthropic-v1',
-    authStyle: 'x-api-key',
-  },
-  { id: 'custom', label: 'Custom', baseUrl: '' },
-];
 
 export const providerChoiceStep: OnboardingStep = {
   id: 'provider-choice',
@@ -248,10 +210,11 @@ export const providerCloudStep: OnboardingStep = {
     );
 
     const presetRow = el('div', 'mn-onboarding-chip-row');
-    CLOUD_PRESETS.forEach((preset) => {
+    ONBOARDING_CLOUD_PRESETS.forEach((preset) => {
       const chip = el('button', 'mn-onboarding-wallpaper-chip', preset.label);
       chip.type = 'button';
       if (preset.id === cloudPreset) chip.classList.add('is-selected');
+      if (preset.authHint) chip.title = preset.authHint;
       chip.addEventListener('click', () => {
         cloudPreset = preset.id;
         if (preset.baseUrl) cloudBaseUrl = preset.baseUrl;
@@ -262,6 +225,11 @@ export const providerCloudStep: OnboardingStep = {
       presetRow.appendChild(chip);
     });
     container.appendChild(presetRow);
+
+    const selectedPreset = ONBOARDING_CLOUD_PRESETS.find((preset) => preset.id === cloudPreset);
+    if (selectedPreset?.authHint) {
+      container.appendChild(el('p', 'mn-onboarding-muted', selectedPreset.authHint));
+    }
 
     const urlInput = el('input', 'mn-onboarding-field') as HTMLInputElement;
     urlInput.type = 'url';
@@ -417,7 +385,7 @@ async function testCloudConnection(
     return;
   }
 
-  const preset = CLOUD_PRESETS.find((p) => p.id === cloudPreset);
+  const preset = ONBOARDING_CLOUD_PRESETS.find((p) => p.id === cloudPreset);
   const apiKind = preset?.apiKind ?? 'openai-v1';
   const paths = getDefaultPaths(apiKind);
   const id = `onboarding-cloud-${cloudPreset}`;

--- a/src/providers/presets.ts
+++ b/src/providers/presets.ts
@@ -1,0 +1,91 @@
+/**
+ * One-click cloud provider presets for onboarding and Settings → Providers.
+ * Base URLs are gateway origins only — `/v1/models` etc. come from getDefaultPaths(apiKind).
+ */
+
+import type { ApiKind, AuthStyle } from './types';
+
+export interface ProviderPreset {
+  id: string;
+  label: string;
+  baseUrl: string;
+  apiKind?: ApiKind;
+  authStyle?: AuthStyle;
+  /** Route Claude models to the messages path on mixed OpenAI gateways. */
+  autoApi?: boolean;
+  /** Short credential hint shown in onboarding and Settings. */
+  authHint?: string;
+}
+
+/** Shared catalog — keep in sync with tests under test/providers/presets.test.mjs */
+export const PROVIDER_PRESETS: ProviderPreset[] = [
+  { id: 'openrouter', label: 'OpenRouter', baseUrl: 'https://openrouter.ai/api' },
+  { id: 'openai', label: 'OpenAI', baseUrl: 'https://api.openai.com' },
+  { id: 'groq', label: 'Groq', baseUrl: 'https://api.groq.com/openai' },
+  { id: 'mistral', label: 'Mistral', baseUrl: 'https://api.mistral.ai' },
+  {
+    id: 'opencode-zen',
+    label: 'OpenCode Zen',
+    baseUrl: 'https://opencode.ai/zen',
+    autoApi: true,
+    authHint: 'OpenCode Zen API key (Bearer).',
+  },
+  {
+    id: 'opencode-go',
+    label: 'OpenCode Go',
+    baseUrl: 'https://opencode.ai/zen/go',
+    autoApi: true,
+    authHint: 'OpenCode Go API key (Bearer).',
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    baseUrl: 'https://api.anthropic.com',
+    apiKind: 'anthropic-v1',
+    authStyle: 'x-api-key',
+    authHint: 'Anthropic API key (console.anthropic.com).',
+  },
+  {
+    id: 'deepseek',
+    label: 'DeepSeek',
+    baseUrl: 'https://api.deepseek.com',
+    authHint: 'DeepSeek API key (platform.deepseek.com).',
+  },
+  {
+    id: 'github-copilot',
+    label: 'GitHub Copilot',
+    baseUrl: 'https://api.githubcopilot.com',
+    autoApi: true,
+    authHint:
+      'GitHub Copilot OAuth Bearer token. Business: https://api.business.githubcopilot.com · Enterprise: https://api.enterprise.githubcopilot.com',
+  },
+];
+
+/** Onboarding cloud step adds a manual "Custom" chip with no preset base URL. */
+export const ONBOARDING_CLOUD_PRESETS: ProviderPreset[] = [
+  ...PROVIDER_PRESETS,
+  { id: 'custom', label: 'Custom', baseUrl: '' },
+];
+
+/** MIN-418 featured presets — browsable first in Settings → Providers. */
+export const SETTINGS_FEATURED_PRESET_IDS: string[] = [
+  'opencode-go',
+  'opencode-zen',
+  'anthropic',
+  'deepseek',
+  'github-copilot',
+];
+
+export function getProviderPreset(id: string): ProviderPreset | undefined {
+  return PROVIDER_PRESETS.find((preset) => preset.id === id);
+}
+
+/** Presets for Settings quick-add, featured entries first then the rest. */
+export function listSettingsProviderPresets(): ProviderPreset[] {
+  const featured = SETTINGS_FEATURED_PRESET_IDS.map((id) => getProviderPreset(id)).filter(
+    (preset): preset is ProviderPreset => preset !== undefined,
+  );
+  const featuredIds = new Set(featured.map((preset) => preset.id));
+  const rest = PROVIDER_PRESETS.filter((preset) => !featuredIds.has(preset.id));
+  return [...featured, ...rest];
+}

--- a/src/styles/settings-page.css
+++ b/src/styles/settings-page.css
@@ -2026,6 +2026,22 @@ label.settings-action-btn {
   align-items: center;
 }
 
+.settings-providers-preset-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-providers-preset-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-providers-preset-chip {
+  font-size: 12px;
+}
+
 .settings-providers-form-error {
   margin: 0;
   font-size: 13px;

--- a/src/styles/settings-page.css
+++ b/src/styles/settings-page.css
@@ -2012,6 +2012,109 @@ label.settings-action-btn {
   user-select: none;
 }
 
+.settings-providers-add-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.settings-providers-add-picker-hint {
+  margin: 0;
+}
+
+.settings-providers-preset-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-providers-preset-btn {
+  min-height: 44px;
+  padding: 10px 14px;
+  border: 1px solid var(--mn-border);
+  border-radius: var(--mn-radius-sm);
+  background: transparent;
+  color: var(--mn-fg);
+  font-size: 13px;
+  line-height: 1.3;
+  cursor: pointer;
+  appearance: none;
+  transition:
+    border-color 0.15s var(--mn-ease-out, ease-out),
+    background-color 0.15s var(--mn-ease-out, ease-out);
+}
+
+.settings-providers-preset-btn:focus-visible {
+  outline: 2px solid var(--mn-accent);
+  outline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .settings-providers-preset-btn:hover {
+    border-color: var(--mn-border-strong);
+    background: color-mix(in srgb, var(--mn-fg) 6%, transparent);
+  }
+}
+
+.settings-providers-add-custom {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  min-height: 44px;
+  padding: 12px 14px;
+  border: 1px dashed var(--mn-border-strong);
+  border-radius: var(--mn-radius-sm);
+  background: transparent;
+  color: var(--mn-fg);
+  text-align: left;
+  cursor: pointer;
+  appearance: none;
+  transition:
+    border-color 0.15s var(--mn-ease-out, ease-out),
+    background-color 0.15s var(--mn-ease-out, ease-out);
+}
+
+.settings-providers-add-custom-label {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.settings-providers-add-custom-desc {
+  font-size: 12px;
+  color: var(--mn-fg-muted);
+  line-height: 1.4;
+}
+
+.settings-providers-add-custom:focus-visible {
+  outline: 2px solid var(--mn-accent);
+  outline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .settings-providers-add-custom:hover {
+    border-color: var(--mn-accent);
+    background: color-mix(in srgb, var(--mn-accent) 8%, transparent);
+  }
+}
+
+.settings-providers-add-form-head {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.settings-providers-add-back {
+  padding-left: 0;
+}
+
+.settings-providers-add-mode-label {
+  margin: 0;
+}
+
 .settings-providers-form {
   display: flex;
   flex-direction: column;
@@ -2024,22 +2127,6 @@ label.settings-action-btn {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
-}
-
-.settings-providers-preset-block {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.settings-providers-preset-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.settings-providers-preset-chip {
-  font-size: 12px;
 }
 
 .settings-providers-form-error {

--- a/src/ui/settings-providers.ts
+++ b/src/ui/settings-providers.ts
@@ -244,7 +244,7 @@ function applyProviderPreset(form: ParentNode, preset: ProviderPreset): void {
   const apiKindSel = form.querySelector<HTMLSelectElement>('select[name="apiKind"]');
   const authSel = form.querySelector<HTMLSelectElement>('select[name="authStyle"]');
   const autoApiInput = form.querySelector<HTMLInputElement>('input[name="autoApi"]');
-  if (idInput && !idInput.value.trim()) idInput.value = preset.id;
+  if (idInput) idInput.value = preset.id;
   if (labelInput) labelInput.value = preset.label;
   if (baseUrlInput) baseUrlInput.value = preset.baseUrl;
   if (apiKindSel) apiKindSel.value = apiKind;
@@ -272,23 +272,75 @@ function applyProviderPreset(form: ParentNode, preset: ProviderPreset): void {
   }
 }
 
-/** Quick-add preset chips for common cloud providers. */
-function appendProviderPresetButtons(parent: HTMLElement, form: ParentNode): void {
-  const block = el('div', 'settings-providers-preset-block');
-  block.append(el('p', 'field-hint', 'One-click presets — fill the form below, then add your API key.'));
-  const chipRow = el('div', 'settings-providers-preset-chips');
+/** Show preset picker and hide the add form. */
+function showProvidersAddPicker(): void {
+  const picker = document.getElementById('settingsProvidersAddPicker');
+  const form = document.getElementById('settingsProvidersAddForm');
+  picker?.classList.remove('hidden');
+  form?.classList.add('hidden');
+}
+
+/** Open the add form for a preset or a blank custom provider. */
+function showProvidersAddForm(form: ParentNode, mode: ProviderPreset | 'custom'): void {
+  const picker = document.getElementById('settingsProvidersAddPicker');
+  const addForm = document.getElementById('settingsProvidersAddForm');
+  const modeLabel = document.getElementById('settingsProvidersAddModeLabel');
+  picker?.classList.add('hidden');
+  addForm?.classList.remove('hidden');
+
+  if (mode === 'custom') {
+    clearProvidersAddForm();
+    if (modeLabel) modeLabel.textContent = 'Custom provider — enter connection details below.';
+    const hintEl = form.querySelector<HTMLElement>('[data-provider-preset-auth-hint]');
+    if (hintEl) {
+      hintEl.textContent = '';
+      hintEl.classList.add('hidden');
+    }
+  } else {
+    applyProviderPreset(form, mode);
+    if (modeLabel) modeLabel.textContent = `Adding ${mode.label}. Review fields, add your API key if needed, then save.`;
+  }
+
+  const apiKeyInput = document.getElementById('settingsProvidersAddApiKey') as HTMLInputElement | null;
+  apiKeyInput?.focus();
+}
+
+/** Build preset grid and custom entry for the first step of add-provider. */
+function renderProvidersAddPicker(form: ParentNode): void {
+  const picker = document.getElementById('settingsProvidersAddPicker');
+  if (!picker || picker.dataset.rendered === '1') return;
+  picker.dataset.rendered = '1';
+
+  picker.append(
+    el(
+      'p',
+      'settings-providers-add-picker-hint field-hint',
+      'Pick a hosted API preset or configure a local or custom endpoint.',
+    ),
+  );
+
+  const grid = el('div', 'settings-providers-preset-grid');
   for (const preset of listSettingsProviderPresets()) {
-    const btn = el('button', 'settings-inline-btn settings-providers-preset-chip', preset.label);
+    const btn = el('button', 'settings-providers-preset-btn', preset.label);
     btn.type = 'button';
     if (preset.authHint) btn.title = preset.authHint;
-    btn.addEventListener('click', () => applyProviderPreset(form, preset));
-    chipRow.append(btn);
+    btn.addEventListener('click', () => showProvidersAddForm(form, preset));
+    grid.append(btn);
   }
-  block.append(chipRow);
-  const authHint = el('p', 'field-hint hidden');
-  authHint.dataset.providerPresetAuthHint = '';
-  block.append(authHint);
-  parent.insertBefore(block, parent.querySelector('.settings-providers-form-actions'));
+  picker.append(grid);
+
+  const customBtn = el('button', 'settings-providers-add-custom');
+  customBtn.type = 'button';
+  customBtn.append(el('span', 'settings-providers-add-custom-label', 'Add custom provider'));
+  customBtn.append(el('span', 'settings-providers-add-custom-desc', 'Local server or any OpenAI-compatible base URL'));
+  customBtn.addEventListener('click', () => showProvidersAddForm(form, 'custom'));
+  picker.append(customBtn);
+}
+
+/** Reset add-provider UI to the preset picker after save or panel close. */
+function resetProvidersAddFlow(): void {
+  clearProvidersAddForm();
+  showProvidersAddPicker();
 }
 function appendGatewayFields(parent: HTMLElement, provider?: ProviderPublic): void {
   const block = el('div', 'settings-providers-gateway-fields');
@@ -344,11 +396,6 @@ function appendGatewayFields(parent: HTMLElement, provider?: ProviderPublic): vo
   parent.append(block);
   autoInput.addEventListener('change', () => syncGatewayFieldVisibility(parent));
   syncGatewayFieldVisibility(parent);
-}
-
-/** Quick-add preset buttons for common mixed gateways. */
-function appendGatewayPresetButtons(parent: HTMLElement, form: ParentNode): void {
-  appendProviderPresetButtons(parent, form);
 }
 
 /** When API style changes, refresh paths if they still match the previous kind's defaults. */
@@ -862,11 +909,16 @@ function bindProvidersAddForm(): void {
     fillPathInputs(form, parseApiKind(apiKindInput));
     appendGatewayFields(form);
     wirePathSyncOnApiKindChange(form, apiKindInput);
-    const actions = form.querySelector('.settings-providers-form-actions');
-    if (actions?.parentElement) {
-      appendGatewayPresetButtons(actions.parentElement, form);
-    }
+    renderProvidersAddPicker(form);
+    showProvidersAddPicker();
   }
+
+  const backBtn = document.getElementById('settingsProvidersAddBack');
+  const addPanel = document.getElementById('settingsProvidersAddPanel');
+  backBtn?.addEventListener('click', () => resetProvidersAddFlow());
+  addPanel?.addEventListener('toggle', () => {
+    if (!addPanel.open) resetProvidersAddFlow();
+  });
 
   resetBtn?.addEventListener('click', () => clearProvidersAddForm());
 
@@ -936,7 +988,7 @@ function bindProvidersAddForm(): void {
       }
 
       if (errEl) errEl.classList.add('hidden');
-      clearProvidersAddForm();
+      resetProvidersAddFlow();
       setStatus('ok', `Added provider ${result.provider.label}`);
       await fetchModels();
       await renderProvidersSettingsSection();

--- a/src/ui/settings-providers.ts
+++ b/src/ui/settings-providers.ts
@@ -11,6 +11,10 @@ import {
 import { getDefaultPaths, pathsForProvider } from '../providers/paths';
 import type { ApiKind, AuthStyle, ProviderPublic } from '../providers/types';
 import {
+  listSettingsProviderPresets,
+  type ProviderPreset,
+} from '../providers/presets';
+import {
   probeProviderCapabilities,
   readProviderCapabilities,
   structuredOutputBadge,
@@ -230,39 +234,10 @@ function syncGatewayFieldVisibility(form: ParentNode): void {
   if (messagesField) messagesField.classList.toggle('hidden', !showMessages);
 }
 
-interface GatewayPreset {
-  id: string;
-  label: string;
-  baseUrl: string;
-  modelsPath: string;
-  chatCompletionsPath: string;
-  messagesPath: string;
-  authStyle: AuthStyle;
-}
-
-const GATEWAY_PRESETS: GatewayPreset[] = [
-  {
-    id: 'opencode-zen',
-    label: 'OpenCode Zen',
-    baseUrl: 'https://opencode.ai/zen',
-    modelsPath: '/v1/models',
-    chatCompletionsPath: '/v1/chat/completions',
-    messagesPath: '/v1/messages',
-    authStyle: 'bearer',
-  },
-  {
-    id: 'openrouter',
-    label: 'OpenRouter',
-    baseUrl: 'https://openrouter.ai/api',
-    modelsPath: '/v1/models',
-    chatCompletionsPath: '/v1/chat/completions',
-    messagesPath: '/v1/messages',
-    authStyle: 'bearer',
-  },
-];
-
-/** Apply a quick-add gateway preset to the add-provider form. */
-function applyGatewayPreset(form: ParentNode, preset: GatewayPreset): void {
+/** Apply a one-click provider preset to the add-provider form. */
+function applyProviderPreset(form: ParentNode, preset: ProviderPreset): void {
+  const apiKind = preset.apiKind ?? 'openai-v1';
+  const paths = getDefaultPaths(apiKind);
   const idInput = form.querySelector<HTMLInputElement>('input[name="id"]');
   const labelInput = form.querySelector<HTMLInputElement>('input[name="label"]');
   const baseUrlInput = form.querySelector<HTMLInputElement>('input[name="baseUrl"]');
@@ -272,20 +247,49 @@ function applyGatewayPreset(form: ParentNode, preset: GatewayPreset): void {
   if (idInput && !idInput.value.trim()) idInput.value = preset.id;
   if (labelInput) labelInput.value = preset.label;
   if (baseUrlInput) baseUrlInput.value = preset.baseUrl;
-  if (apiKindSel) apiKindSel.value = 'openai-v1';
-  if (authSel) authSel.value = preset.authStyle;
-  if (autoApiInput) autoApiInput.checked = true;
+  if (apiKindSel) apiKindSel.value = apiKind;
+  if (authSel) authSel.value = preset.authStyle ?? 'bearer';
+  if (autoApiInput) autoApiInput.checked = preset.autoApi === true;
   const modelsInput = form.querySelector<HTMLInputElement>('input[name="modelsPath"]');
   const chatInput = form.querySelector<HTMLInputElement>('input[name="chatCompletionsPath"]');
   const messagesInput = form.querySelector<HTMLInputElement>('input[name="messagesPath"]');
-  if (modelsInput) modelsInput.value = preset.modelsPath;
-  if (chatInput) chatInput.value = preset.chatCompletionsPath;
-  if (messagesInput) messagesInput.value = preset.messagesPath;
+  if (modelsInput) modelsInput.value = paths.modelsPath;
+  if (chatInput) chatInput.value = paths.chatCompletionsPath;
+  if (messagesInput && paths.messagesPath) messagesInput.value = paths.messagesPath;
+  applyAuthStyleDefaultForApiKind(form, apiKind);
   syncGatewayFieldVisibility(form);
-  updatePathFieldLabels(form, 'openai-v1');
+  updatePathFieldLabels(form, apiKind);
+
+  const hintEl = form.querySelector<HTMLElement>('[data-provider-preset-auth-hint]');
+  if (hintEl) {
+    if (preset.authHint) {
+      hintEl.textContent = preset.authHint;
+      hintEl.classList.remove('hidden');
+    } else {
+      hintEl.textContent = '';
+      hintEl.classList.add('hidden');
+    }
+  }
 }
 
-/** Gateway auto-routing controls for mixed OpenAI + Anthropic catalogs. */
+/** Quick-add preset chips for common cloud providers. */
+function appendProviderPresetButtons(parent: HTMLElement, form: ParentNode): void {
+  const block = el('div', 'settings-providers-preset-block');
+  block.append(el('p', 'field-hint', 'One-click presets — fill the form below, then add your API key.'));
+  const chipRow = el('div', 'settings-providers-preset-chips');
+  for (const preset of listSettingsProviderPresets()) {
+    const btn = el('button', 'settings-inline-btn settings-providers-preset-chip', preset.label);
+    btn.type = 'button';
+    if (preset.authHint) btn.title = preset.authHint;
+    btn.addEventListener('click', () => applyProviderPreset(form, preset));
+    chipRow.append(btn);
+  }
+  block.append(chipRow);
+  const authHint = el('p', 'field-hint hidden');
+  authHint.dataset.providerPresetAuthHint = '';
+  block.append(authHint);
+  parent.insertBefore(block, parent.querySelector('.settings-providers-form-actions'));
+}
 function appendGatewayFields(parent: HTMLElement, provider?: ProviderPublic): void {
   const block = el('div', 'settings-providers-gateway-fields');
   block.dataset.providerGatewayFields = '';
@@ -344,14 +348,7 @@ function appendGatewayFields(parent: HTMLElement, provider?: ProviderPublic): vo
 
 /** Quick-add preset buttons for common mixed gateways. */
 function appendGatewayPresetButtons(parent: HTMLElement, form: ParentNode): void {
-  const row = el('div', 'settings-providers-form-actions');
-  for (const preset of GATEWAY_PRESETS) {
-    const btn = el('button', 'settings-inline-btn', `Preset: ${preset.label}`);
-    btn.type = 'button';
-    btn.addEventListener('click', () => applyGatewayPreset(form, preset));
-    row.append(btn);
-  }
-  parent.insertBefore(row, parent.querySelector('.settings-providers-form-actions'));
+  appendProviderPresetButtons(parent, form);
 }
 
 /** When API style changes, refresh paths if they still match the previous kind's defaults. */

--- a/test/onboarding/cloud-provider-urls.test.mjs
+++ b/test/onboarding/cloud-provider-urls.test.mjs
@@ -5,24 +5,18 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { getDefaultPaths } from '../../src/providers/paths.ts';
-
-/** Keep in sync with CLOUD_PRESETS in src/onboarding/steps/provider.ts */
-const ONBOARDING_CLOUD_BASE_URLS = [
-  'https://openrouter.ai/api',
-  'https://api.openai.com',
-  'https://api.groq.com/openai',
-  'https://api.mistral.ai',
-  'https://opencode.ai/zen',
-  'https://opencode.ai/zen/go',
-  'https://api.anthropic.com',
-];
+import { ONBOARDING_CLOUD_PRESETS } from '../../src/providers/presets.ts';
 
 describe('onboarding cloud provider URLs', () => {
   test('preset baseUrls do not double /v1 when joined with default models path', () => {
     const { modelsPath } = getDefaultPaths('openai-v1');
     assert.equal(modelsPath, '/v1/models');
 
-    for (const baseUrl of ONBOARDING_CLOUD_BASE_URLS) {
+    const baseUrls = ONBOARDING_CLOUD_PRESETS.filter((preset) => preset.baseUrl).map(
+      (preset) => preset.baseUrl,
+    );
+
+    for (const baseUrl of baseUrls) {
       const url = `${baseUrl}${modelsPath}`;
       assert.equal(url.includes('/v1/v1/'), false, `unexpected double /v1 in ${url}`);
       assert.match(url, /\/v1\/models$/);

--- a/test/providers/presets.test.mjs
+++ b/test/providers/presets.test.mjs
@@ -1,0 +1,52 @@
+/**
+ * Shared provider preset catalog (onboarding + Settings).
+ */
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { getDefaultPaths } from '../../src/providers/paths.ts';
+import {
+  ONBOARDING_CLOUD_PRESETS,
+  PROVIDER_PRESETS,
+  SETTINGS_FEATURED_PRESET_IDS,
+  getProviderPreset,
+  listSettingsProviderPresets,
+} from '../../src/providers/presets.ts';
+
+describe('provider presets catalog', () => {
+  test('MIN-418 featured presets exist with base URLs and auth hints', () => {
+    for (const id of SETTINGS_FEATURED_PRESET_IDS) {
+      const preset = getProviderPreset(id);
+      assert.ok(preset, `missing featured preset: ${id}`);
+      assert.ok(preset.baseUrl.startsWith('https://'), `${id} baseUrl must be https`);
+      assert.ok(preset.authHint, `${id} should include an auth hint`);
+    }
+  });
+
+  test('onboarding cloud presets include custom chip and all catalog entries', () => {
+    assert.equal(ONBOARDING_CLOUD_PRESETS.length, PROVIDER_PRESETS.length + 1);
+    assert.ok(ONBOARDING_CLOUD_PRESETS.some((preset) => preset.id === 'custom'));
+    assert.ok(ONBOARDING_CLOUD_PRESETS.some((preset) => preset.id === 'deepseek'));
+    assert.ok(ONBOARDING_CLOUD_PRESETS.some((preset) => preset.id === 'github-copilot'));
+  });
+
+  test('settings preset list leads with featured presets', () => {
+    const listed = listSettingsProviderPresets();
+    assert.deepEqual(
+      listed.slice(0, SETTINGS_FEATURED_PRESET_IDS.length).map((preset) => preset.id),
+      SETTINGS_FEATURED_PRESET_IDS,
+    );
+    assert.equal(listed.length, PROVIDER_PRESETS.length);
+  });
+
+  test('openai-v1 preset baseUrls do not double /v1 when joined with default models path', () => {
+    const { modelsPath } = getDefaultPaths('openai-v1');
+    assert.equal(modelsPath, '/v1/models');
+
+    for (const preset of PROVIDER_PRESETS) {
+      if (preset.apiKind === 'anthropic-v1') continue;
+      const url = `${preset.baseUrl}${modelsPath}`;
+      assert.equal(url.includes('/v1/v1/'), false, `unexpected double /v1 in ${url}`);
+      assert.match(url, /\/v1\/models$/);
+    }
+  });
+});

--- a/test/ui/settings-page-html.test.mjs
+++ b/test/ui/settings-page-html.test.mjs
@@ -67,6 +67,7 @@ describe('settings page HTML', () => {
   }
 
   test('providers add form exists in index.html', () => {
+    assert.match(html, /id="settingsProvidersAddPicker"/);
     assert.match(html, /id="settingsProvidersAddForm"/);
     assert.match(html, /id="settingsProvidersAddId"/);
     assert.match(html, /id="settingsProvidersAddBaseUrl"/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves MIN-418 by adding one-click provider presets for OpenCode Go, OpenCode Zen, Anthropic, DeepSeek, and GitHub Copilot.

- Introduces a shared catalog in `src/providers/presets.ts` used by onboarding and Settings → Providers
- Adds **DeepSeek** (`https://api.deepseek.com`) and **GitHub Copilot** (`https://api.githubcopilot.com`) presets with auth hints
- Expands Settings quick-add from two gateway buttons to a browsable preset chip row (featured presets first)
- Shows auth hints in onboarding cloud step when a preset is selected
- Documents preset URLs, Copilot account variants, and env override notes in `documentation/guides/settings-reference.md`

## Test plan

- [x] `node --import tsx test/providers/presets.test.mjs`
- [x] `node --import tsx test/onboarding/cloud-provider-urls.test.mjs`
- [ ] Manual: onboarding → Cloud API → select each new preset, verify base URL + hint
- [ ] Manual: Settings → Models → Providers → Add provider → click preset chips, verify form prefill

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-418](https://linear.app/minnowai/issue/MIN-418/provider-presets)

<div><a href="https://cursor.com/agents/bc-642bdaa7-759b-4941-bc37-7e4228b23624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-642bdaa7-759b-4941-bc37-7e4228b23624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

