### PR TITLE
Nudge board chats that end without board_report instead of failing the task

### DIFF
--- a/documentation/plans/unified-board-report.md
+++ b/documentation/plans/unified-board-report.md
@@ -60,6 +60,41 @@ All board-linked chats (builder, tester, merge fixer, env fixer, final integrati
 - **`fixerEarlyFinalizeInFlight`** (git-poll early-finalize race guard)
 - Env-fixer **stop-only** stall branch (env fixers now get the same nudge/self-heal path as other chats)
 
+### 4b. Missing-report nudge before failure (added 2026-07-18)
+
+A chat that finished its turn **cleanly** but never called `board_report` is usually an
+agent that forgot the tool, not a failed task. Before routing a missing report into
+self-heal, the finalizer re-prompts the same chat:
+
+| Constant | Value | Role |
+|----------|-------|------|
+| `MISSING_REPORT_NUDGE_CAP` | 2 | Max `board_report` reminders per board chat |
+
+`tryNudgeForMissingBoardReport` in [`orchestrate-board-actions.ts`](../../src/state/orchestrate-board-actions.ts)
+dispatches `runTaskChatNudge(…, { missingReport: true })` on the ended chat and returns
+early, leaving the task's status, chat linkage, worktree, and phase attempt budget
+untouched. Once the cap is hit the finalizer falls through to its existing
+self-heal → quarantine routing.
+
+| Finalizer | Behaviour on missing report |
+|-----------|-----------------------------|
+| `finalizeBoardTaskOnStreamEnd` | Nudge (task stays `in_progress`), then self-heal `build` |
+| `finalizeTaskTestingOnStreamEnd` | Nudge after the `VERDICT:` fallback fails (task stays `testing`), then self-heal `test` |
+| `finalizeEnvFixerOnStreamEnd` | Nudge before the linkage is cleared, then self-heal `infra` |
+| `finalizeMergeFixerOnStreamEnd` | **Unchanged** — the git fallback + bounded re-merge retry is already recovery, not a hard fail |
+
+Gates (all must hold to nudge):
+
+- `isBoardRunning(group)` — a paused/stopped board records the failure and lets the resume sweep re-drive it.
+- `resolveTaskChatStreamOutcome(chat) === 'completed'` — **`stopped`** (user Stop, stall kill) and
+  **`failed`** (provider error, `Maximum tool turns reached`) keep their existing park / retry /
+  quarantine owners. Max-turn and cancel paths are therefore unaffected.
+
+The per-chat counter is deliberately **not** cleared by `stopTaskChatSupervision`: every nudge
+produces another stream-end and the subscriber stops supervision before the finalizer runs, so
+clearing there would reset the budget each pass and nudge forever. It resets only in
+`getOrCreateBoardChat`, i.e. when a genuinely new phase run is launched.
+
 ### 5. Report-driven `reconcileMergingTasks` for dead fixers
 
 [`reconcileMergingTasks`](../../src/state/orchestrate-board-actions.ts) remains the live safety net for `merging` tasks:
@@ -103,7 +138,8 @@ Fixer seed still assumes merge in progress; agents finish with `git commit --no-
 
 ## Tests
 
-- `test/orchestrate/task-stream-end.test.mts` — build/test report routing
+- `test/orchestrate/task-stream-end.test.mts` — build/test report routing, missing-report nudge → quarantine
+- `test/orchestrate/task-testing.test.mts` — Tester nudge before a verdict-less fail
 - `test/orchestrate/merge-fixer-finalize.test.mts` — report-driven merge finalize
 - `test/orchestrate/merge-fixer-stall.test.mts` — unified stall + MERGE_HEAD preflight
 - `test/orchestrate/board-task-chat-stall.test.mts` — 3× stall nudge/self-heal across chat roles

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -61,7 +61,7 @@ import {
   getPlannerChatForGroup,
 } from './chat-groups.ts';
 import { emitBoardChange } from './orchestrate-board-events.ts';
-import { isTaskReadyForAuto, isTaskStalledForRestart, isBoardAutoMode, isBoardRunning, getBoardExecutionMode, syncOrchestrateBoardTimer, updateTask, logTaskStatus, logBuildVerdict, logTestVerdict, logMergeResult, logWorktreeAllocated, logTaskRetry, logModeChange, logAutoStart, logAutoStop, logFinalTestStarted, logFinalTestVerdict, quarantineTaskAndDependents } from './orchestrate-board-store.ts';
+import { isTaskReadyForAuto, isTaskStalledForRestart, isBoardAutoMode, isBoardRunning, getBoardExecutionMode, syncOrchestrateBoardTimer, updateTask, logTaskStatus, logBoardReportNudge, logBuildVerdict, logTestVerdict, logMergeResult, logWorktreeAllocated, logTaskRetry, logModeChange, logAutoStart, logAutoStop, logFinalTestStarted, logFinalTestVerdict, quarantineTaskAndDependents } from './orchestrate-board-store.ts';
 import {
   isIsolationActive,
   resolveIsolationMode,
@@ -376,6 +376,18 @@ const taskChatStallRestarts = new Map<string, number>();
  */
 const stallStoppedChatIds = new Set<string>();
 
+/** Max `board_report` reminders per board chat before falling through to self-heal. */
+export const MISSING_REPORT_NUDGE_CAP = 2;
+
+/**
+ * Per-chatId count of missing-report nudges. Deliberately NOT cleared by
+ * `stopTaskChatSupervision`: every nudge produces another stream-end, and the
+ * subscriber stops supervision before the finalizer runs — clearing there would
+ * reset the budget on each pass and nudge forever. Reset only when a genuinely
+ * new phase run is launched (see `getOrCreateBoardChat`).
+ */
+const missingReportNudges = new Map<string, number>();
+
 /** Test-only: capture stall-path nudge/self-heal calls from heartbeat supervision. */
 let taskChatNudgeCallsForTests: string[] | null = null;
 let taskChatNudgeChatIdsForTests: string[] | null = null;
@@ -672,6 +684,46 @@ function handleTaskChatLaunchFailure(
 }
 
 /**
+ * A board chat that finished its turn cleanly but never called `board_report`
+ * has usually just forgotten the tool — the work itself is intact. Re-prompt the
+ * same chat (context and worktree preserved) instead of treating the missing
+ * report as a phase failure, which would burn an attempt and, on the test path,
+ * restart the Builder from scratch.
+ *
+ * Bounded by {@link MISSING_REPORT_NUDGE_CAP} per chat; once exhausted the
+ * caller falls through to its normal self-heal → quarantine routing.
+ *
+ * Returns true when a nudge was dispatched and the caller must not finalize.
+ */
+function tryNudgeForMissingBoardReport(
+  group: ChatGroup,
+  task: BoardTask,
+  plannerChat: Chat,
+  chat: Chat,
+): boolean {
+  // A paused/stopped board must not launch turns; the resume sweep re-drives it.
+  if (!isBoardRunning(group)) return false;
+
+  // Only a clean end is recoverable by re-prompting. `stopped` (user Stop, stall
+  // kill) and `failed` (provider error, max tool turns) have their own owners and
+  // keep their existing park / retry / quarantine routing.
+  if (resolveTaskChatStreamOutcome(chat) !== 'completed') return false;
+
+  const chatId = chat.id;
+  const sent = missingReportNudges.get(chatId) ?? 0;
+  if (sent >= MISSING_REPORT_NUDGE_CAP) return false;
+
+  const attempt = sent + 1;
+  missingReportNudges.set(chatId, attempt);
+  logBoardReportNudge(group, task.id, attempt, MISSING_REPORT_NUDGE_CAP);
+  void runTaskChatNudge(group, task.id, plannerChat, undefined, {
+    chatId,
+    missingReport: true,
+  }).catch((err) => reportBackgroundError('missing-board-report-nudge', err));
+  return true;
+}
+
+/**
  * Advance board task status when its linked **Builder** chat finishes streaming.
  * Successful builds move to testing; auto-pilot launches the Tester.
  */
@@ -830,6 +882,12 @@ export function finalizeBoardTaskOnStreamEnd(
       moveTaskStatus(group, task.id, 'blocked', plannerChat);
       updateTask(group, task.id, { error: summary }, plannerChat);
     }
+    return;
+  }
+
+  // No report at all: re-prompt the Builder before spending a build attempt.
+  // The task stays `in_progress` with its chat and worktree intact.
+  if (!report && tryNudgeForMissingBoardReport(group, freshTask, plannerChat, chat)) {
     return;
   }
 
@@ -1018,6 +1076,10 @@ function getOrCreateBoardChat(input: {
   if (existingId) {
     const existing = findChatById(existingId);
     if (existing) {
+      // A fresh phase launch (build / test / fixer) is a new attempt, so it gets
+      // a full missing-report nudge budget. Nudge continuations go through
+      // runTaskChatNudge instead and deliberately keep the running count.
+      missingReportNudges.delete(existing.id);
       if (input.taskId) existing.boardTaskId = input.taskId;
       if (input.role === 'tester') existing.workAgentId = 'tester';
       if (input.role === 'fixer') existing.workAgentId = null;
@@ -1573,12 +1635,18 @@ function boardReportNudgeLine(
 export function buildContinueNudgeMessage(
   task: BoardTask,
   priorError?: string,
-  options?: { stalledChatId?: string },
+  options?: { stalledChatId?: string; missingReport?: boolean },
 ): string {
   const lines = [
     `Continue the orchestrate task ${task.id} — ${task.title} where you left off.`,
     "Pick up from your last step; don't restart from scratch.",
   ];
+  if (options?.missingReport) {
+    lines.push(
+      'Your last turn ended without calling board_report, so the board cannot advance.',
+      'If the work is already done, call board_report now with the outcome; otherwise finish it first.',
+    );
+  }
   const err = priorError?.trim();
   if (err) {
     lines.push(`The prior attempt errored mid-way: ${err}`);
@@ -1751,7 +1819,7 @@ export async function runTaskChatNudge(
   taskId: string,
   plannerChat: Chat,
   priorError?: string,
-  options?: { chatId?: string },
+  options?: { chatId?: string; missingReport?: boolean },
 ): Promise<void> {
   const board = group.orchestrateBoard;
   if (!board) return;
@@ -1806,7 +1874,10 @@ export async function runTaskChatNudge(
       }
     }
 
-    const nudge = buildContinueNudgeMessage(task, priorError, { stalledChatId: targetChatId });
+    const nudge = buildContinueNudgeMessage(task, priorError, {
+      stalledChatId: targetChatId,
+      missingReport: options?.missingReport,
+    });
     refreshHeartbeatThresholds();
     startTaskChatSupervision(taskChat.id);
 
@@ -2876,6 +2947,12 @@ async function finalizeEnvFixerOnStreamEnd(
       return;
     }
 
+    // No report: re-prompt this fixer before burning an env-fix attempt. Nudge
+    // first — clearing the linkage below is what makes the failure terminal.
+    if (!report && endedChat && tryNudgeForMissingBoardReport(group, fresh, plannerChat, endedChat)) {
+      return;
+    }
+
     updateTask(
       group,
       fresh.id,
@@ -3306,15 +3383,15 @@ export async function finalizeTaskTestingOnStreamEnd(
   // and leave the task in `testing` — the resume sweep (isTaskStalledForRestart)
   // restarts the tester when the board runs again.
   const testChatId = fresh.testChatId?.trim();
-  const stoppedTestChat = testChatId ? findChatById(testChatId) : undefined;
-  if (stoppedTestChat && resolveTaskChatStreamOutcome(stoppedTestChat) === 'stopped') {
+  const endedTestChat = testChatId ? findChatById(testChatId) : undefined;
+  if (endedTestChat && resolveTaskChatStreamOutcome(endedTestChat) === 'stopped') {
     const board = group.orchestrateBoard;
-    const stopReason = resolveTaskChatStopReason(stoppedTestChat, board);
+    const stopReason = resolveTaskChatStopReason(endedTestChat, board);
     const neutralStop =
       stopReason === 'user' || board?.userStopped === true || !isBoardRunning(group);
     if (neutralStop) {
       updateTask(group, fresh.id, { testChatId: undefined }, plannerChat);
-      teardownBoardTaskChatResources(stoppedTestChat, sessionState?.groups);
+      teardownBoardTaskChatResources(endedTestChat, sessionState?.groups);
       return;
     }
   }
@@ -3332,6 +3409,13 @@ export async function finalizeTaskTestingOnStreamEnd(
         plannerChat,
       );
     }
+  }
+
+  // No report and no VERDICT marker: re-prompt the Tester before recording a
+  // fail. Without this the missing tool call is routed as a test failure, which
+  // burns a test attempt and reseeds the Builder for work that may well be sound.
+  if (!report && endedTestChat && tryNudgeForMissingBoardReport(group, fresh, plannerChat, endedTestChat)) {
+    return;
   }
 
   const outcome = report?.outcome;
@@ -4323,6 +4407,14 @@ export function clearTaskChatStallRestartsForTests(): void {
 
 export function getTaskChatStallRestartCountForTests(chatId: string): number {
   return taskChatStallRestarts.get(chatId) ?? 0;
+}
+
+export function clearMissingReportNudgesForTests(): void {
+  missingReportNudges.clear();
+}
+
+export function getMissingReportNudgeCountForTests(chatId: string): number {
+  return missingReportNudges.get(chatId) ?? 0;
 }
 
 /** Enable/disable capture of stall-path nudge and self-heal calls from heartbeat ticks. */

--- a/src/state/orchestrate-board-store.ts
+++ b/src/state/orchestrate-board-store.ts
@@ -262,6 +262,26 @@ export function logTaskRetry(
   });
 }
 
+/**
+ * A board chat ended without calling `board_report` and was re-prompted.
+ * Distinct from {@link logTaskRetry}: no phase attempt is burned and the chat
+ * keeps its context — the task stays recoverable.
+ */
+export function logBoardReportNudge(
+  group: ChatGroup,
+  taskId: string,
+  attempt: number,
+  max: number,
+): void {
+  appendBoardLog(group, {
+    type: 'task_retry',
+    level: 'warn',
+    taskId,
+    message: `${taskId}: ended without board_report — nudge ${attempt}/${max}`,
+    detail: { attempt },
+  });
+}
+
 export function logFinalTestStarted(group: ChatGroup, chatId: string): void {
   appendBoardLog(group, {
     type: 'final_test_started',

--- a/test/orchestrate/fixer-recovery.test.mts
+++ b/test/orchestrate/fixer-recovery.test.mts
@@ -18,9 +18,11 @@ import {
 } from '../../src/agents/controller/report.ts';
 import {
   autoDelegateNext,
+  clearMissingReportNudgesForTests,
   clearStallStoppedChatIdsForTests,
   clearTaskChatStallRestartsForTests,
   continueBoardTask,
+  getMissingReportNudgeCountForTests,
   isStallStoppedChatForTests,
   enqueueMergeCompletedTaskWorktreeForTests,
   finalizeBoardTaskOnStreamEnd,
@@ -633,6 +635,27 @@ describe('Env-fixer pass board_report routing', () => {
       process.env.MINNOW_TEST = prevMinnowTest;
     }
     setSessionStateForTests(null);
+  });
+
+  test('clean env-fixer end without board_report nudges instead of burning an attempt', async () => {
+    clearMissingReportNudgesForTests();
+    const group = makeGroup();
+    const { planner, fixerChat } = seedEnvFixerTask(group);
+    // A clean turn end (trailing assistant message) with no board_report.
+    fixerChat.history = [
+      { role: 'user', content: 'Fix missing deps' },
+      { role: 'assistant', content: 'Installed the missing packages.' },
+    ];
+
+    await triggerFixerStallReconcileForTests(group, planner, TASK_ID);
+
+    const task = group.orchestrateBoard!.tasks.find((t) => t.id === TASK_ID)!;
+    // Linkage intact and no env-fix attempt spent — the fixer can still report.
+    assert.equal(task.fixerChatId, FIXER_CHAT_ID);
+    assert.equal(task.fixerKind, 'env');
+    assert.equal(task.envFixPhase, 'build');
+    assert.equal(task.envFixAttempts, undefined);
+    assert.equal(getMissingReportNudgeCountForTests(FIXER_CHAT_ID), 1);
   });
 
   test('test-phase pass moves task to testing and clears fixer linkage', async () => {

--- a/test/orchestrate/task-stream-end.test.mts
+++ b/test/orchestrate/task-stream-end.test.mts
@@ -9,8 +9,11 @@ import {
   setAutopilotMetaForTests,
 } from '../../src/config/autopilot-meta.ts';
 import {
+  clearMissingReportNudgesForTests,
   clearTaskQueuesForTests,
   countRunningTaskChats,
+  getMissingReportNudgeCountForTests,
+  MISSING_REPORT_NUDGE_CAP,
   drainTaskQueueForTests,
   enqueueTaskForTests,
   finalizeBoardTaskOnStreamEnd,
@@ -140,6 +143,7 @@ describe('task stream end finalization', () => {
     releaseLaunchSlotForTests(TASK_CHAT_ID);
     releaseLaunchSlotForTests(TASK_B_CHAT_ID);
     resetAutopilotMetaCache();
+    clearMissingReportNudgesForTests();
     setAutopilotMetaForTests({ maxBuildAttempts: 1 });
   });
 
@@ -351,6 +355,100 @@ describe('task stream end finalization', () => {
     // Phase 2: exhausted build attempts are quarantined via self-heal (not left as failed).
     assert.equal(updated.status, 'quarantined');
     assert.match(updated.quarantine?.summary ?? updated.error ?? '', /board_report/i);
+  });
+
+  test('clean build end without board_report nudges instead of burning an attempt', () => {
+    const prevMinnowTest = process.env.MINNOW_TEST;
+    process.env.MINNOW_TEST = '1';
+    try {
+      const group = makeGroup('auto');
+      const planner = makePlanner();
+      const task = group.orchestrateBoard!.tasks[0]!;
+      finalizeBoardTaskOnStreamEnd(group, task, planner);
+
+      const updated = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      // Recoverable: the task keeps its chat and its build budget.
+      assert.equal(updated.status, 'in_progress');
+      assert.equal(updated.chatId, TASK_CHAT_ID);
+      assert.equal(updated.buildAttempts, undefined);
+      assert.equal(updated.quarantine, undefined);
+      assert.equal(updated.endedAt, undefined);
+      assert.equal(getMissingReportNudgeCountForTests(TASK_CHAT_ID), 1);
+    } finally {
+      if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+      else process.env.MINNOW_TEST = prevMinnowTest;
+    }
+  });
+
+  test('board_report after a nudge advances the board normally', () => {
+    const prevMinnowTest = process.env.MINNOW_TEST;
+    process.env.MINNOW_TEST = '1';
+    try {
+      const group = makeGroup('auto');
+      const planner = makePlanner();
+      finalizeBoardTaskOnStreamEnd(group, group.orchestrateBoard!.tasks[0]!, planner);
+      assert.equal(getMissingReportNudgeCountForTests(TASK_CHAT_ID), 1);
+
+      // The nudged turn calls board_report, then ends.
+      updateTask(
+        group,
+        'W1-A',
+        { boardReport: { outcome: 'pass', summary: 'Build verified' } },
+        planner,
+      );
+      finalizeBoardTaskOnStreamEnd(group, group.orchestrateBoard!.tasks[0]!, planner);
+
+      const updated = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      assert.equal(updated.status, 'testing');
+      assert.ok(updated.endedAt);
+    } finally {
+      if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+      else process.env.MINNOW_TEST = prevMinnowTest;
+    }
+  });
+
+  test('missing board_report quarantines once the nudge budget is exhausted', () => {
+    const prevMinnowTest = process.env.MINNOW_TEST;
+    process.env.MINNOW_TEST = '1';
+    try {
+      setAutopilotMetaForTests({ maxBuildAttempts: 1 });
+      const group = makeGroup('auto');
+      const planner = makePlanner();
+      updateTask(group, 'W1-A', { buildAttempts: 1 }, planner);
+
+      for (let i = 0; i < MISSING_REPORT_NUDGE_CAP; i++) {
+        finalizeBoardTaskOnStreamEnd(group, group.orchestrateBoard!.tasks[0]!, planner);
+        assert.equal(
+          group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!.status,
+          'in_progress',
+        );
+      }
+      finalizeBoardTaskOnStreamEnd(group, group.orchestrateBoard!.tasks[0]!, planner);
+
+      const updated = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      assert.equal(updated.status, 'quarantined');
+      assert.match(updated.quarantine?.summary ?? updated.error ?? '', /board_report/i);
+    } finally {
+      if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+      else process.env.MINNOW_TEST = prevMinnowTest;
+    }
+  });
+
+  test('a paused board records the missing report instead of nudging', () => {
+    const prevMinnowTest = process.env.MINNOW_TEST;
+    process.env.MINNOW_TEST = '1';
+    try {
+      const group = makeGroup('manual');
+      const planner = makePlanner();
+      finalizeBoardTaskOnStreamEnd(group, group.orchestrateBoard!.tasks[0]!, planner);
+
+      const updated = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      assert.equal(getMissingReportNudgeCountForTests(TASK_CHAT_ID), 0);
+      assert.equal(updated.status, 'failed');
+    } finally {
+      if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+      else process.env.MINNOW_TEST = prevMinnowTest;
+    }
   });
 
   test('markBoardTaskInProgressFromChat sets in_progress when stream starts', () => {

--- a/test/orchestrate/task-testing.test.mts
+++ b/test/orchestrate/task-testing.test.mts
@@ -7,8 +7,11 @@ import { beforeEach, describe, test } from 'node:test';
 import {
   applyFinalTestFailureReopens,
   applyTaskTestFailureState,
+  clearMissingReportNudgesForTests,
   finalizeFinalTestOnStreamEnd,
   finalizeTaskTestingOnStreamEnd,
+  getMissingReportNudgeCountForTests,
+  MISSING_REPORT_NUDGE_CAP,
   tryTriggerFinalIntegrationTest,
 } from '../../src/state/orchestrate-board-actions.ts';
 import { isOrchestratePlanComplete } from '../../src/chat/orchestrate/plan-complete.ts';
@@ -70,6 +73,24 @@ function makeGroup(taskStatuses: Record<string, 'complete' | 'testing' | 'in_pro
     activeChatId: PLANNER_ID,
   });
   return group;
+}
+
+/** Tester chat that finished its turn cleanly but never reported a verdict. */
+function makeNoVerdictTesterChat(): Chat {
+  return {
+    id: TEST_CHAT_ID,
+    name: 'Test',
+    workspacePath: '/tmp/ws',
+    modeId: 'build',
+    modelId: 'm1',
+    workAgentId: 'tester',
+    history: [{ role: 'assistant', content: 'Looks fine to me, everything works.' }],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1,
+    boardGroupId: GROUP_ID,
+    boardTaskId: 'W1-A',
+  };
 }
 
 describe('board_report validation', () => {
@@ -180,7 +201,10 @@ describe('board_report tolerant inputs', () => {
 });
 
 describe('finalizeTaskTestingOnStreamEnd', () => {
-  beforeEach(() => setSessionStateForTests(null));
+  beforeEach(() => {
+    setSessionStateForTests(null);
+    clearMissingReportNudgesForTests();
+  });
 
   test('pass moves task to complete', async () => {
     const group = makeGroup({ 'W1-A': 'testing' });
@@ -260,33 +284,63 @@ describe('finalizeTaskTestingOnStreamEnd', () => {
     assert.equal(group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!.status, 'complete');
   });
 
-  test('no marker and no verdict still fails', async () => {
-    const group = makeGroup({ 'W1-A': 'testing' });
-    const planner = makePlanner();
-    // Fail-routing goes through runSelfHeal, which requires a running board.
-    group.orchestrateBoard!.executionMode = 'afk';
-    group.orchestrateBoard!.autoRunning = true;
-    const testChat: Chat = {
-      id: TEST_CHAT_ID,
-      name: 'Test',
-      workspacePath: '/tmp/ws',
-      modeId: 'build',
-      modelId: 'm1',
-      workAgentId: 'tester',
-      history: [{ role: 'assistant', content: 'Looks fine to me, everything works.' }],
-      lastStats: null,
-      modelInfo: {},
-      updatedAt: 1,
-      boardGroupId: GROUP_ID,
-      boardTaskId: 'W1-A',
-    };
-    updateTask(group, 'W1-A', { testChatId: TEST_CHAT_ID }, planner);
-    setSessionStateForTests({ chats: [planner, testChat], groups: [group], activeChatId: PLANNER_ID });
-    const task = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
-    await finalizeTaskTestingOnStreamEnd(group, task, planner);
-    const updated = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
-    assert.equal(updated.status, 'in_progress');
-    assert.equal(updated.testAttempts, 1);
+  test('no marker and no verdict nudges the Tester instead of failing the task', async () => {
+    const prevMinnowTest = process.env.MINNOW_TEST;
+    process.env.MINNOW_TEST = '1';
+    try {
+      const group = makeGroup({ 'W1-A': 'testing' });
+      const planner = makePlanner();
+      // Nudging (like fail-routing) only happens on a running board.
+      group.orchestrateBoard!.executionMode = 'afk';
+      group.orchestrateBoard!.autoRunning = true;
+      const testChat = makeNoVerdictTesterChat();
+      updateTask(group, 'W1-A', { testChatId: TEST_CHAT_ID }, planner);
+      setSessionStateForTests({ chats: [planner, testChat], groups: [group], activeChatId: PLANNER_ID });
+      const task = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      await finalizeTaskTestingOnStreamEnd(group, task, planner);
+
+      const updated = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      // Task stays in testing and keeps its chat — no attempt burned, no reseed.
+      assert.equal(updated.status, 'testing');
+      assert.equal(updated.testAttempts, undefined);
+      assert.equal(updated.testChatId, TEST_CHAT_ID);
+      assert.equal(updated.pendingBuildSeed, undefined);
+      assert.equal(getMissingReportNudgeCountForTests(TEST_CHAT_ID), 1);
+    } finally {
+      if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+      else process.env.MINNOW_TEST = prevMinnowTest;
+    }
+  });
+
+  test('no verdict fails the task once the nudge budget is exhausted', async () => {
+    const prevMinnowTest = process.env.MINNOW_TEST;
+    process.env.MINNOW_TEST = '1';
+    try {
+      const group = makeGroup({ 'W1-A': 'testing' });
+      const planner = makePlanner();
+      group.orchestrateBoard!.executionMode = 'afk';
+      group.orchestrateBoard!.autoRunning = true;
+      const testChat = makeNoVerdictTesterChat();
+      updateTask(group, 'W1-A', { testChatId: TEST_CHAT_ID }, planner);
+      setSessionStateForTests({ chats: [planner, testChat], groups: [group], activeChatId: PLANNER_ID });
+
+      // Every nudge ends in another report-less stream end; the last one falls
+      // through to the existing self-heal fail routing.
+      for (let i = 0; i < MISSING_REPORT_NUDGE_CAP; i++) {
+        const task = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+        await finalizeTaskTestingOnStreamEnd(group, task, planner);
+        assert.equal(group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!.status, 'testing');
+      }
+      const task = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      await finalizeTaskTestingOnStreamEnd(group, task, planner);
+
+      const updated = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+      assert.equal(updated.status, 'in_progress');
+      assert.equal(updated.testAttempts, 1);
+    } finally {
+      if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+      else process.env.MINNOW_TEST = prevMinnowTest;
+    }
   });
 
   test('retry persists the failure-aware builder seed on the task', async () => {


### PR DESCRIPTION
## What changed

A board chat that finished its turn **cleanly but never called `board_report`** now gets a bounded re-prompt before the board treats the task as failed.

Three finalizers routed a missing report straight into `runSelfHeal`, which burns a phase attempt and can quarantine:

| Finalizer | Old behaviour on missing report |
|-----------|--------------------------------|
| `finalizeBoardTaskOnStreamEnd` | Burned a build attempt, reseeded or quarantined |
| `finalizeTaskTestingOnStreamEnd` | Burned a test attempt and **restarted the Builder from scratch** — because the *Tester* forgot a tool call |
| `finalizeEnvFixerOnStreamEnd` | Burned an env-fix attempt, spawned another fixer |

`tryNudgeForMissingBoardReport` now re-prompts the same chat — context, chat linkage, worktree and attempt budget all untouched — up to `MISSING_REPORT_NUDGE_CAP` (2) times, then falls through to the existing self-heal → quarantine routing. The nudge message names the missing call explicitly and reuses the existing role-specific `boardReportNudgeLine`.

## Why

The common failure was an agent that did the work and simply forgot the tool call. Treating that as a phase failure destroyed sound work and spent a budget meant for real failures. The tester path was the worst case: one forgotten call by the Tester threw away the Builder's entire result.

Aligns with the [unified board report contract](documentation/plans/unified-board-report.md), which is updated with the new section and gates.

## Reviewer notes

**Two gates keep the other recovery owners intact:**

- `isBoardRunning` — a paused/stopped board records the failure and lets the resume sweep re-drive it, rather than launching a turn.
- `resolveTaskChatStreamOutcome(chat) === 'completed'` — **`stopped`** (user Stop, stall kill) and **`failed`** (provider error, `Maximum tool turns reached`) keep their existing park / retry / quarantine paths. **Max-turn and cancel still quarantine as before.**

**The merge fixer is deliberately unchanged.** Unlike the other three it doesn't hard-fail on a missing report — it already runs a git fallback (`check_merged` + `verify_integration`) and then a bounded re-merge retry, so it satisfies "only fail after retries are exhausted" today. Adding a nudge there would have meant rewriting well-tested recovery behavior for no gain in the failure mode being fixed.

**The nudge counter is not cleared by `stopTaskChatSupervision`.** This is the subtle bit and it's called out in a comment at the declaration: every nudge produces another stream-end, and the subscriber stops supervision *before* the finalizer runs — clearing there would reset the budget on each pass and nudge forever. It resets only in `getOrCreateBoardChat`, i.e. when a genuinely new phase run launches.

## Verification

- All **316** orchestrate tests pass, including 7 new ones: nudge-instead-of-fail (build + test + env-fixer), report-after-nudge advancing normally, quarantine once the budget is exhausted, and the paused-board case.
- One existing test changed expectations by design: `no marker and no verdict still fails` is now split into nudge-first and fail-after-budget-exhausted.
- Two pre-existing failures on this branch are **untouched by this change** (confirmed by stashing and re-running): one test in `test/tools/board-member-tool-filter.test.mts`, and a `tsc` error in `src/ui/context-usage-surface.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
