### PR TITLE
Email Phase 1: SQLite mail store + IMAP connection pool + incremental sync (MIN-351)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -93,7 +93,7 @@ Full directory map: [`guides/configuration.md`](guides/configuration.md). Notabl
 | `work-agents.json`, `sub-agents.json` | Agent overrides and sub-agent types |
 | `brain/` | Wiki pages, vectors, code index DBs, proposals |
 | `skills/`, `skills.json` | User skills and enable flags |
-| `scheduler.json`, `calendar/`, `email/` | Scheduler, calendar DB, email accounts |
+| `scheduler.json`, `calendar/`, `email/` | Scheduler, calendar DB, email accounts + `mail-<accountId>.db` |
 | `compare/`, `benchmarks/`, `evals/` | Compare history, bench runs, eval harness |
 | `reef/widgets/`, `reef/modules/`, `reef/artifacts/` | Reef templates and user widgets |
 
@@ -302,11 +302,19 @@ Design reference: [`DESIGN.md`](../DESIGN.md), [`documentation/design-system/`](
 | **Research** | Desktop / `#/research` | `server/research/`, `~/.minnow/research/` |
 | **Scheduler** | `#/app/scheduler` | `server/scheduler/`, `scheduler.json` (jobs only run while app open) |
 | **Calendar** | `#/app/calendar` | `server/calendar/`, SQLite `calendar.db`, CalDAV |
-| **Email** | `#/app/email` | `server/email/`, IMAP/SMTP, encrypted accounts |
+| **Email** | `#/app/email` | `server/email/`, IMAP/SMTP, encrypted accounts, SQLite `mail-<accountId>.db` |
 | **Voice** | Models → Voice | `server/voice/`, local Whisper + Qwen TTS option |
 | **Settings** | `#/app/settings` | Full config via `/api/config/*` |
 
 **Deep Research** is a dedicated panel (not a composer mode). **Compare** runs 2–6 blind model slots. **Bench** runs integration + academic packs; distinct from eval harness task packs.
+
+### Email sync engine
+
+- **Store:** one SQLite DB per account (`~/.minnow/email/mail-<accountId>.db`, WAL) — `server/email/store.js` owns the schema, `cache.js` the async API. `message_row_id` is the stable PK, so a move rewrites `folder`/`uid` while triage, reply variants, and bodies survive. `messages_fts` (FTS5) backs search over subject/sender/body. Legacy `cache/<id>/messages.json` is imported once on first sync and renamed `.migrated`.
+- **Connections:** `imap-session.js` holds one long-lived ImapFlow client per account. All reads and mutations borrow it via `withMailbox(accountId, folder, fn)`, which serializes per account and closes after 5 minutes idle. The folder list is cached in `meta`, so archive/move no longer pay a `LIST` each.
+- **Sync:** incremental — `UID lastSeen+1:*` for new mail (headers + first text part only), then a FLAGS-only reconcile over the newest 200 UIDs that applies external reads/stars and drops messages deleted or moved elsewhere. `UIDVALIDITY` changes clear the folder and refill it. Full bodies, HTML, and attachment metadata load lazily on first open (`ensureMessageBody`).
+- **Push:** an IMAP IDLE watcher per polling-enabled account (own connection — IDLE parks the socket) triggers a debounced sync; the interval poller stays as the fallback for servers with broken IDLE.
+- **Routes:** `GET /accounts/:id/threads` (conversation rollups), `GET /search?q=` (FTS, all accounts when `accountId` is omitted), `GET /messages/:id/body` (lazy body fetch).
 
 ---
 

--- a/documentation/plans/email-world-class-spec.md
+++ b/documentation/plans/email-world-class-spec.md
@@ -7,7 +7,7 @@ todos:
     status: completed
   - id: phase1-engine
     content: "Phase 1 — Storage + sync engine: SQLite message store, IMAP connection reuse, incremental flag sync, IDLE push"
-    status: pending
+    status: completed
   - id: phase2-security
     content: "Phase 2 — Security hardening: API auth for /api/email, remote-image blocking, iframe body isolation, send guardrails"
     status: pending

--- a/server/email/accounts.js
+++ b/server/email/accounts.js
@@ -275,6 +275,23 @@ export async function deleteEmailAccount(accountId) {
   }
 
   try {
+    // Drop the live IMAP session first — an open socket (or, on Windows, an
+    // open SQLite handle) would otherwise outlive the account.
+    const { closeImapSession, stopIdleWatcher } = await import('./imap-session.js');
+    await stopIdleWatcher(accountId);
+    await closeImapSession(accountId);
+  } catch {
+    /* ignore session teardown failures */
+  }
+
+  try {
+    const { deleteMailDb } = await import('./store.js');
+    deleteMailDb(accountId);
+  } catch {
+    /* ignore missing mail store */
+  }
+
+  try {
     const { deleteAutomationsForAccount } = await import('./automations.js');
     await deleteAutomationsForAccount(accountId);
   } catch {

--- a/server/email/agent.js
+++ b/server/email/agent.js
@@ -13,9 +13,10 @@ import {
 import { getEmailAccount } from './accounts.js';
 import {
   getCachedMessage,
+  getInboxSummary,
+  getSyncState,
   listCachedMessages,
   listCachedThread,
-  readMessageCache,
   updateInboxSummary,
   updateMessageTriage,
   updateReplyVariants,
@@ -108,8 +109,12 @@ export function parseReplyVariantsJson(raw) {
  * @param {string} accountId
  */
 export async function buildInboxSummary(accountId) {
-  const cache = await readMessageCache(accountId);
-  const inboxRows = cache.messages.filter((row) => String(row.folder) === 'INBOX');
+  // The digest covers the most recent inbox page rather than the whole store —
+  // older mail contributes nothing to a "what needs me today" summary.
+  const { messages: inboxRows } = await listCachedMessages(accountId, {
+    folder: 'INBOX',
+    limit: 200,
+  });
 
   /** @type {{ high: number, normal: number, low: number }} */
   const stats = { high: 0, normal: 0, low: 0 };
@@ -478,9 +483,8 @@ export async function onNewMessages(accountId, newMessages, account, options = {
  * @param {Array<Record<string, unknown>>} incoming
  */
 export async function diffNewMessages(accountId, folder, incoming) {
-  const cache = await readMessageCache(accountId);
-  const prevHighest = cache.folderCursors?.[folder]?.highestUid ?? 0;
-  return incoming.filter((row) => Number(row.uid) > prevHighest);
+  const { highestUid } = await getSyncState(accountId, folder);
+  return incoming.filter((row) => Number(row.uid) > highestUid);
 }
 
 /**
@@ -488,7 +492,7 @@ export async function diffNewMessages(accountId, folder, incoming) {
  * @param {string} accountId
  */
 export async function getOrBuildInboxSummary(accountId) {
-  const existing = (await readMessageCache(accountId)).inboxSummary;
+  const existing = await getInboxSummary(accountId);
   if (existing?.generatedAt) {
     const ageMs = Date.now() - new Date(String(existing.generatedAt)).getTime();
     if (ageMs < 5 * 60_000) {

--- a/server/email/cache.js
+++ b/server/email/cache.js
@@ -1,9 +1,20 @@
 /**
- * Local message metadata cache (~/.minnow/email/cache/<accountId>/).
+ * Local mail store access (~/.minnow/email/mail-<accountId>.db).
+ *
+ * Keeps the async API the rest of server/email was written against; the backing
+ * store is now SQLite (see store.js) instead of one big rewritten JSON file.
  */
 
 import fs from 'node:fs/promises';
-import { emailCacheDir, emailCacheMessagesPath } from './paths.js';
+import { emailCacheMessagesPath } from './paths.js';
+import {
+  getMailDb,
+  hydrateAttachments,
+  readMeta,
+  recomputeThread,
+  reindexMessageFts,
+  writeMeta,
+} from './store.js';
 
 /**
  * @typedef {object} EmailMessageFlags
@@ -12,155 +23,510 @@ import { emailCacheDir, emailCacheMessagesPath } from './paths.js';
  * @property {boolean} [answered]
  */
 
-/**
- * @typedef {object} EmailCacheFile
- * @property {number} version
- * @property {Record<string, { highestUid?: number }>} folderCursors
- * @property {Array<Record<string, unknown>>} messages
- * @property {object} [inboxSummary]
- */
+/** Columns needed for the metadata (no-body) message shape. */
+const MESSAGE_COLUMNS = `message_row_id, id, folder, uid, message_id, thread_id, from_addr,
+  to_json, reply_to, subject, date, date_ms, body_preview, body_hash, has_attachments,
+  in_reply_to, references_json, seen, flagged, answered, triage_json, reply_variants_json`;
+
+/** Same, joined with bodies for reader/agent paths that need the text. */
+const MESSAGE_COLUMNS_WITH_BODY = `m.message_row_id, m.id, m.folder, m.uid, m.message_id,
+  m.thread_id, m.from_addr, m.to_json, m.reply_to, m.subject, m.date, m.date_ms,
+  m.body_preview, m.body_hash, m.has_attachments, m.in_reply_to, m.references_json,
+  m.seen, m.flagged, m.answered, m.triage_json, m.reply_variants_json,
+  b.body_text, b.body_html`;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function toMs(date) {
+  const ms = new Date(String(date ?? '')).getTime();
+  return Number.isFinite(ms) ? ms : 0;
+}
 
 /**
- * @param {string} accountId
- * @returns {Promise<EmailCacheFile>}
+ * Locate one message row by stable id, `folder:uid`, or (when unambiguous) bare uid.
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} messageKey
+ * @param {boolean} [withBody]
  */
-export async function readMessageCache(accountId) {
+function findRow(db, messageKey, withBody = false) {
+  const needle = String(messageKey ?? '');
+  if (!needle) return null;
+
+  const select = withBody
+    ? `SELECT ${MESSAGE_COLUMNS_WITH_BODY} FROM messages m LEFT JOIN bodies b USING (message_row_id)`
+    : `SELECT ${MESSAGE_COLUMNS} FROM messages`;
+  const alias = withBody ? 'm.' : '';
+
+  const byId = db.prepare(`${select} WHERE ${alias}id = ?`).get(needle);
+  if (byId) return byId;
+
+  const colonAt = needle.lastIndexOf(':');
+  if (colonAt > 0) {
+    const folder = needle.slice(0, colonAt);
+    const uid = needle.slice(colonAt + 1);
+    const byFolderUid = db
+      .prepare(`${select} WHERE ${alias}folder = ? AND ${alias}uid = ?`)
+      .get(folder, uid);
+    if (byFolderUid) return byFolderUid;
+  }
+
+  // Legacy bare-uid callers: only honored when it resolves to exactly one row,
+  // so UID 5 in INBOX can no longer shadow UID 5 in Sent (MIN-350 D4).
+  const byUid = db.prepare(`${select} WHERE ${alias}uid = ? LIMIT 2`).all(needle);
+  return byUid.length === 1 ? byUid[0] : null;
+}
+
+/** Row id lookup without materializing the whole row. */
+function findRowId(db, messageKey) {
+  const row = findRow(db, messageKey);
+  return row ? row.message_row_id : null;
+}
+
+/**
+ * Pick a stable, never-rewritten public id for a new message.
+ * Base form matches the historical `${folder}:${uid}`; a moved-away row keeps
+ * its id, so a later message reusing that folder/uid gets a suffixed one.
+ */
+function allocateMessageId(db, folder, uid) {
+  const base = `${folder}:${uid}`;
+  const exists = db.prepare('SELECT 1 FROM messages WHERE id = ?');
+  if (!exists.get(base)) return base;
+  for (let n = 2; n < 1000; n += 1) {
+    const candidate = `${base}#${n}`;
+    if (!exists.get(candidate)) return candidate;
+  }
+  return `${base}#${Date.now()}`;
+}
+
+/**
+ * Insert or update one parsed message. Runs inside the caller's transaction.
+ * @returns {number} message_row_id
+ */
+function upsertMessageRow(db, message) {
+  const folder = String(message.folder ?? 'INBOX');
+  const uid = String(message.uid ?? '');
+  const existing =
+    (message.id ? db.prepare('SELECT message_row_id FROM messages WHERE id = ?').get(String(message.id)) : null) ??
+    db.prepare('SELECT message_row_id FROM messages WHERE folder = ? AND uid = ?').get(folder, uid);
+
+  const flags = message.flags ?? {};
+  const values = {
+    folder,
+    uid,
+    message_id: String(message.messageId ?? ''),
+    thread_id: String(message.threadId ?? ''),
+    from_addr: String(message.from ?? ''),
+    to_json: JSON.stringify(Array.isArray(message.to) ? message.to : []),
+    reply_to: String(message.replyTo ?? ''),
+    subject: String(message.subject ?? ''),
+    date: String(message.date ?? ''),
+    date_ms: toMs(message.date),
+    body_preview: String(message.bodyPreview ?? ''),
+    body_hash: String(message.bodyHash ?? ''),
+    has_attachments: message.hasAttachments ? 1 : 0,
+    in_reply_to: String(message.inReplyTo ?? ''),
+    references_json: JSON.stringify(Array.isArray(message.references) ? message.references : []),
+    seen: flags.seen ? 1 : 0,
+    flagged: flags.flagged ? 1 : 0,
+    answered: flags.answered ? 1 : 0,
+  };
+
+  let rowId;
+  if (existing) {
+    rowId = existing.message_row_id;
+    db.prepare(
+      `UPDATE messages SET
+         folder = @folder, uid = @uid, message_id = @message_id, thread_id = @thread_id,
+         from_addr = @from_addr, to_json = @to_json, reply_to = @reply_to, subject = @subject,
+         date = @date, date_ms = @date_ms, body_preview = @body_preview, body_hash = @body_hash,
+         has_attachments = @has_attachments, in_reply_to = @in_reply_to,
+         references_json = @references_json, seen = @seen, flagged = @flagged, answered = @answered
+       WHERE message_row_id = @message_row_id`,
+    ).run({ ...values, message_row_id: rowId });
+  } else {
+    const id = String(message.id ?? '') || allocateMessageId(db, folder, uid);
+    const info = db
+      .prepare(
+        `INSERT INTO messages (
+           id, folder, uid, message_id, thread_id, from_addr, to_json, reply_to, subject,
+           date, date_ms, body_preview, body_hash, has_attachments, in_reply_to,
+           references_json, seen, flagged, answered
+         ) VALUES (
+           @id, @folder, @uid, @message_id, @thread_id, @from_addr, @to_json, @reply_to, @subject,
+           @date, @date_ms, @body_preview, @body_hash, @has_attachments, @in_reply_to,
+           @references_json, @seen, @flagged, @answered
+         )`,
+      )
+      .run({ ...values, id });
+    rowId = Number(info.lastInsertRowid);
+  }
+
+  if (message.triage !== undefined) {
+    db.prepare('UPDATE messages SET triage_json = ? WHERE message_row_id = ?').run(
+      message.triage ? JSON.stringify(message.triage) : null,
+      rowId,
+    );
+  }
+  if (message.replyVariants !== undefined) {
+    db.prepare('UPDATE messages SET reply_variants_json = ? WHERE message_row_id = ?').run(
+      message.replyVariants ? JSON.stringify(message.replyVariants) : null,
+      rowId,
+    );
+  }
+
+  if (Array.isArray(message.attachments)) {
+    db.prepare('DELETE FROM attachments WHERE message_row_id = ?').run(rowId);
+    const insert = db.prepare(
+      'INSERT INTO attachments (message_row_id, idx, filename, content_type, size) VALUES (?, ?, ?, ?, ?)',
+    );
+    message.attachments.forEach((att, idx) => {
+      insert.run(
+        rowId,
+        idx,
+        String(att?.filename ?? 'attachment'),
+        String(att?.contentType ?? 'application/octet-stream'),
+        Number(att?.size) || 0,
+      );
+    });
+  }
+
+  if (typeof message.bodyText === 'string' || typeof message.bodyHtml === 'string') {
+    saveBodyRow(db, rowId, {
+      bodyText: message.bodyText,
+      bodyHtml: message.bodyHtml,
+      complete: message.bodyComplete,
+    });
+  }
+
+  reindexMessageFts(db, rowId);
+  recomputeThread(db, values.thread_id);
+  return rowId;
+}
+
+/** Upsert the lazily-fetched body for a message row. */
+function saveBodyRow(db, rowId, { bodyText, bodyHtml, complete }) {
+  const existing = db.prepare('SELECT * FROM bodies WHERE message_row_id = ?').get(rowId);
+  // A re-sync carries only the preview text; it must not overwrite a body that
+  // was already fully downloaded (which would drop the HTML part).
+  if (existing?.complete && !complete) {
+    return;
+  }
+  db.prepare(
+    `INSERT INTO bodies (message_row_id, body_text, body_html, complete, fetched_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(message_row_id) DO UPDATE SET
+       body_text = excluded.body_text,
+       body_html = excluded.body_html,
+       complete = excluded.complete,
+       fetched_at = excluded.fetched_at`,
+  ).run(
+    rowId,
+    typeof bodyText === 'string' ? bodyText : (existing?.body_text ?? ''),
+    typeof bodyHtml === 'string' ? bodyHtml : (existing?.body_html ?? null),
+    complete === undefined ? (existing?.complete ?? 0) : complete ? 1 : 0,
+    nowIso(),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// JSON → SQLite migration (one-time, idempotent)
+// ---------------------------------------------------------------------------
+
+/**
+ * Import a pre-Phase-1 `messages.json` cache once. The JSON file is kept (and
+ * renamed to `.migrated`) so a bad import can be replayed by hand.
+ * @param {string} accountId
+ */
+export async function migrateJsonCacheIfNeeded(accountId) {
+  const db = getMailDb(accountId);
+  if (readMeta(db, 'jsonMigratedAt')) {
+    return { migrated: false, reason: 'already_migrated' };
+  }
+
   const filePath = emailCacheMessagesPath(accountId);
+  let parsed;
   try {
-    const raw = await fs.readFile(filePath, 'utf8');
-    const parsed = JSON.parse(raw);
-    return {
-      version: parsed?.version ?? 1,
-      folderCursors:
-        parsed?.folderCursors && typeof parsed.folderCursors === 'object'
-          ? parsed.folderCursors
-          : {},
-      messages: Array.isArray(parsed?.messages) ? parsed.messages : [],
-      inboxSummary:
-        parsed?.inboxSummary && typeof parsed.inboxSummary === 'object'
-          ? parsed.inboxSummary
-          : undefined,
-    };
+    parsed = JSON.parse(await fs.readFile(filePath, 'utf8'));
   } catch (err) {
     if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') {
-      return { version: 1, folderCursors: {}, messages: [] };
+      writeMeta(db, 'jsonMigratedAt', nowIso());
+      return { migrated: false, reason: 'no_json_cache' };
     }
     throw err;
   }
+
+  const messages = Array.isArray(parsed?.messages) ? parsed.messages : [];
+  const cursors = parsed?.folderCursors && typeof parsed.folderCursors === 'object' ? parsed.folderCursors : {};
+
+  const tx = db.transaction(() => {
+    for (const message of messages) {
+      upsertMessageRow(db, message);
+    }
+    for (const [folder, cursor] of Object.entries(cursors)) {
+      setSyncStateRow(db, folder, { highestUid: Number(cursor?.highestUid) || 0 });
+    }
+    if (parsed?.inboxSummary && typeof parsed.inboxSummary === 'object') {
+      writeMeta(db, 'inboxSummary', parsed.inboxSummary);
+    }
+    writeMeta(db, 'jsonMigratedAt', nowIso());
+  });
+  tx();
+
+  // Integrity check before retiring the JSON file (Part 7 constraint).
+  const count = db.prepare('SELECT COUNT(*) AS n FROM messages').get()?.n ?? 0;
+  if (count >= messages.length) {
+    await fs.rename(filePath, `${filePath}.migrated`).catch(() => {});
+  }
+
+  return { migrated: true, messages: messages.length };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy JSON-shaped API (metadata only — bodies are loaded on demand)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the whole account store in the historical cache-file shape.
+ * @param {string} accountId
+ */
+export async function readMessageCache(accountId) {
+  const db = getMailDb(accountId);
+  const rows = db.prepare(`SELECT ${MESSAGE_COLUMNS} FROM messages ORDER BY date_ms DESC`).all();
+  /** @type {Record<string, { highestUid?: number }>} */
+  const folderCursors = {};
+  for (const row of db.prepare('SELECT folder, highest_uid FROM sync_state').all()) {
+    folderCursors[row.folder] = { highestUid: row.highest_uid };
+  }
+  return {
+    version: 2,
+    folderCursors,
+    messages: hydrateAttachments(db, rows),
+    inboxSummary: readMeta(db, 'inboxSummary', undefined) ?? undefined,
+  };
 }
 
 /**
+ * Replace the whole store with the given cache object (tests, recovery).
  * @param {string} accountId
- * @param {EmailCacheFile} cache
+ * @param {{ messages?: Array<Record<string, unknown>>, folderCursors?: Record<string, { highestUid?: number }>, inboxSummary?: object }} cache
  */
 export async function writeMessageCache(accountId, cache) {
-  const filePath = emailCacheMessagesPath(accountId);
-  await fs.mkdir(emailCacheDir(accountId), { recursive: true });
-  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
-  const payload = {
-    version: 1,
-    folderCursors: cache.folderCursors ?? {},
-    messages: cache.messages ?? [],
-    inboxSummary: cache.inboxSummary ?? undefined,
-    updatedAt: new Date().toISOString(),
-  };
-  await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  await fs.rename(tmp, filePath);
+  const db = getMailDb(accountId);
+  const tx = db.transaction(() => {
+    // A whole-store replace must drop the sync cursors too, or the next sync
+    // asks for `UID cursor+1:*` against an empty store and skips everything.
+    db.exec('DELETE FROM messages; DELETE FROM messages_fts; DELETE FROM threads; DELETE FROM sync_state;');
+    for (const message of cache.messages ?? []) {
+      upsertMessageRow(db, message);
+    }
+    for (const [folder, cursor] of Object.entries(cache.folderCursors ?? {})) {
+      setSyncStateRow(db, folder, { highestUid: Number(cursor?.highestUid) || 0 });
+    }
+    writeMeta(db, 'inboxSummary', cache.inboxSummary ?? null);
+  });
+  tx();
 }
 
 /**
- * Merge fetched messages into cache (by uid + folder).
+ * Merge fetched messages into the store and advance the folder cursor.
  * @param {string} accountId
  * @param {Array<Record<string, unknown>>} incoming
  * @param {string} folder
  * @param {number | undefined} highestUid
  */
 export async function mergeMessagesIntoCache(accountId, incoming, folder, highestUid) {
-  const cache = await readMessageCache(accountId);
-  const key = (row) => `${row.folder}:${row.uid}`;
-  const map = new Map(cache.messages.map((row) => [key(row), row]));
-
-  for (const message of incoming) {
-    map.set(key(message), { ...map.get(key(message)), ...message });
-  }
-
-  cache.messages = Array.from(map.values()).sort((a, b) => {
-    const da = new Date(String(a.date ?? 0)).getTime();
-    const db = new Date(String(b.date ?? 0)).getTime();
-    return db - da;
+  const db = getMailDb(accountId);
+  const tx = db.transaction(() => {
+    for (const message of incoming) {
+      upsertMessageRow(db, message);
+    }
+    if (highestUid && Number.isFinite(highestUid)) {
+      const prev = db.prepare('SELECT highest_uid FROM sync_state WHERE folder = ?').get(folder);
+      setSyncStateRow(db, folder, {
+        highestUid: Math.max(prev?.highest_uid ?? 0, highestUid),
+      });
+    } else {
+      setSyncStateRow(db, folder, {});
+    }
   });
-
-  if (!cache.folderCursors[folder]) {
-    cache.folderCursors[folder] = {};
-  }
-  if (highestUid && Number.isFinite(highestUid)) {
-    const prev = cache.folderCursors[folder].highestUid ?? 0;
-    cache.folderCursors[folder].highestUid = Math.max(prev, highestUid);
-  }
-
-  await writeMessageCache(accountId, cache);
-  return cache;
+  tx();
+  return readMessageCache(accountId);
 }
 
 /**
- * List cached messages with optional folder filter and pagination.
+ * List cached messages with folder filter, flag filter, FTS query, pagination.
  * @param {string} accountId
  * @param {{ folder?: string, offset?: number, limit?: number, query?: string, filter?: string }} options
  */
 export async function listCachedMessages(accountId, options = {}) {
-  const cache = await readMessageCache(accountId);
-  let rows = cache.messages.slice();
+  const db = getMailDb(accountId);
+  const where = [];
+  const params = [];
 
   const folder = options.folder ? String(options.folder) : '';
   if (folder) {
-    rows = rows.filter((row) => String(row.folder) === folder);
+    where.push('folder = ?');
+    params.push(folder);
   }
 
   const filter = String(options.filter ?? '').trim().toLowerCase();
   if (filter === 'unread') {
-    rows = rows.filter((row) => !row.flags?.seen);
+    where.push('seen = 0');
   } else if (filter === 'flagged') {
-    rows = rows.filter((row) => Boolean(row.flags?.flagged));
+    where.push('flagged = 1');
   }
 
-  const query = String(options.query ?? '').trim().toLowerCase();
+  const query = String(options.query ?? '').trim();
   if (query) {
-    rows = rows.filter((row) => {
-      const hay = [
-        row.subject,
-        row.from,
-        row.bodyPreview,
-        ...(Array.isArray(row.to) ? row.to : []),
-      ]
-        .map((part) => String(part ?? '').toLowerCase())
-        .join(' ');
-      return hay.includes(query);
-    });
+    where.push(
+      `message_row_id IN (SELECT message_row_id FROM messages_fts WHERE messages_fts MATCH ?)`,
+    );
+    params.push(toFtsQuery(query));
   }
 
+  const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
   const offset = Math.max(0, Number(options.offset) || 0);
   const limit = Math.min(200, Math.max(1, Number(options.limit) || 50));
-  const total = rows.length;
-  const page = rows.slice(offset, offset + limit);
 
-  return { messages: page, total, offset, limit };
+  const total = db.prepare(`SELECT COUNT(*) AS n FROM messages ${clause}`).get(...params)?.n ?? 0;
+  const rows = db
+    .prepare(`SELECT ${MESSAGE_COLUMNS} FROM messages ${clause} ORDER BY date_ms DESC LIMIT ? OFFSET ?`)
+    .all(...params, limit, offset);
+
+  return { messages: hydrateAttachments(db, rows), total, offset, limit };
+}
+
+/**
+ * Turn a user query into a safe FTS5 MATCH expression (prefix-matched terms).
+ * @param {string} raw
+ */
+export function toFtsQuery(raw) {
+  const terms = String(raw ?? '')
+    .split(/\s+/)
+    .map((term) => term.replace(/["*]/g, '').trim())
+    .filter(Boolean);
+  if (!terms.length) {
+    return '""';
+  }
+  return terms.map((term) => `"${term}"*`).join(' AND ');
+}
+
+/**
+ * Full-text search across folders (D10 — bodies are indexed too).
+ * @param {string} accountId
+ * @param {{ query: string, folder?: string, offset?: number, limit?: number }} options
+ */
+export async function searchCachedMessages(accountId, options) {
+  const query = String(options?.query ?? '').trim();
+  if (!query) {
+    return { messages: [], total: 0, offset: 0, limit: 0, query };
+  }
+  const db = getMailDb(accountId);
+  const offset = Math.max(0, Number(options.offset) || 0);
+  const limit = Math.min(200, Math.max(1, Number(options.limit) || 50));
+  const folder = options.folder ? String(options.folder) : '';
+
+  const params = [toFtsQuery(query)];
+  let folderClause = '';
+  if (folder) {
+    folderClause = 'AND m.folder = ?';
+    params.push(folder);
+  }
+
+  const total =
+    db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM messages_fts f
+         JOIN messages m ON m.message_row_id = f.message_row_id
+         WHERE messages_fts MATCH ? ${folderClause}`,
+      )
+      .get(...params)?.n ?? 0;
+
+  const rows = db
+    .prepare(
+      `SELECT ${MESSAGE_COLUMNS.split(', ').map((col) => `m.${col.trim()}`).join(', ')}
+       FROM messages_fts f
+       JOIN messages m ON m.message_row_id = f.message_row_id
+       WHERE messages_fts MATCH ? ${folderClause}
+       ORDER BY bm25(messages_fts), m.date_ms DESC
+       LIMIT ? OFFSET ?`,
+    )
+    .all(...params, limit, offset);
+
+  return { messages: hydrateAttachments(db, rows), total, offset, limit, query };
+}
+
+/**
+ * Conversation rollups for the thread list.
+ * @param {string} accountId
+ * @param {{ folder?: string, offset?: number, limit?: number, filter?: string, query?: string }} options
+ */
+export async function listCachedThreads(accountId, options = {}) {
+  const db = getMailDb(accountId);
+  const where = [];
+  const params = [];
+
+  const folder = options.folder ? String(options.folder) : '';
+  if (folder) {
+    where.push('t.thread_id IN (SELECT thread_id FROM messages WHERE folder = ?)');
+    params.push(folder);
+  }
+
+  const filter = String(options.filter ?? '').trim().toLowerCase();
+  if (filter === 'unread') {
+    where.push('t.unread_count > 0');
+  } else if (filter === 'flagged') {
+    where.push('t.flagged = 1');
+  }
+
+  const query = String(options.query ?? '').trim();
+  if (query) {
+    where.push(
+      `t.thread_id IN (
+         SELECT m.thread_id FROM messages_fts f
+         JOIN messages m ON m.message_row_id = f.message_row_id
+         WHERE messages_fts MATCH ?)`,
+    );
+    params.push(toFtsQuery(query));
+  }
+
+  const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const offset = Math.max(0, Number(options.offset) || 0);
+  const limit = Math.min(200, Math.max(1, Number(options.limit) || 50));
+
+  const total = db.prepare(`SELECT COUNT(*) AS n FROM threads t ${clause}`).get(...params)?.n ?? 0;
+  const rows = db
+    .prepare(`SELECT t.* FROM threads t ${clause} ORDER BY t.last_date_ms DESC LIMIT ? OFFSET ?`)
+    .all(...params, limit, offset);
+
+  const threads = rows.map((row) => ({
+    threadId: row.thread_id,
+    subject: row.subject,
+    participants: JSON.parse(row.participants_json || '[]'),
+    messageCount: row.message_count,
+    unreadCount: row.unread_count,
+    flagged: Boolean(row.flagged),
+    hasAttachments: Boolean(row.has_attachments),
+    lastDate: row.last_date,
+    folders: JSON.parse(row.folders_json || '[]'),
+    snippet: row.snippet,
+    summary: row.summary ?? null,
+  }));
+
+  return { threads, total, offset, limit };
 }
 
 /**
  * @param {string} accountId
- * @param {string} compositeId — `${folder}:${uid}` or message cache id
+ * @param {string} compositeId — stable message id or `${folder}:${uid}`
  */
 export async function getCachedMessage(accountId, compositeId) {
-  const cache = await readMessageCache(accountId);
-  const needle = String(compositeId);
-  return (
-    cache.messages.find(
-      (row) =>
-        row.id === needle ||
-        `${row.folder}:${row.uid}` === needle ||
-        String(row.uid) === needle,
-    ) ?? null
-  );
+  const db = getMailDb(accountId);
+  const row = findRow(db, compositeId, true);
+  if (!row) return null;
+  return hydrateAttachments(db, [row])[0];
 }
 
 /**
@@ -168,11 +534,15 @@ export async function getCachedMessage(accountId, compositeId) {
  * @param {string} threadId
  */
 export async function listCachedThread(accountId, threadId) {
-  const cache = await readMessageCache(accountId);
-  const rows = cache.messages
-    .filter((row) => String(row.threadId) === String(threadId))
-    .sort((a, b) => new Date(String(a.date)).getTime() - new Date(String(b.date)).getTime());
-  return rows;
+  const db = getMailDb(accountId);
+  const rows = db
+    .prepare(
+      `SELECT ${MESSAGE_COLUMNS_WITH_BODY} FROM messages m
+       LEFT JOIN bodies b USING (message_row_id)
+       WHERE m.thread_id = ? ORDER BY m.date_ms ASC`,
+    )
+    .all(String(threadId));
+  return hydrateAttachments(db, rows);
 }
 
 /**
@@ -182,25 +552,16 @@ export async function listCachedThread(accountId, threadId) {
  * @param {object} triage
  */
 export async function updateMessageTriage(accountId, messageKey, triage) {
-  const cache = await readMessageCache(accountId);
-  const index = cache.messages.findIndex(
-    (row) =>
-      row.id === messageKey ||
-      `${row.folder}:${row.uid}` === messageKey ||
-      String(row.uid) === messageKey,
-  );
-  if (index < 0) {
+  const db = getMailDb(accountId);
+  const rowId = findRowId(db, messageKey);
+  if (rowId === null) {
     throw new Error('Cached message not found');
   }
-  cache.messages[index] = {
-    ...cache.messages[index],
-    triage: {
-      ...triage,
-      cachedAt: new Date().toISOString(),
-    },
-  };
-  await writeMessageCache(accountId, cache);
-  return cache.messages[index];
+  db.prepare('UPDATE messages SET triage_json = ? WHERE message_row_id = ?').run(
+    JSON.stringify({ ...triage, cachedAt: nowIso() }),
+    rowId,
+  );
+  return getCachedMessage(accountId, messageKey);
 }
 
 /**
@@ -210,75 +571,73 @@ export async function updateMessageTriage(accountId, messageKey, triage) {
  * @param {EmailMessageFlags} flags
  */
 export async function updateMessageFlags(accountId, messageKey, flags) {
-  const cache = await readMessageCache(accountId);
-  const index = cache.messages.findIndex(
-    (row) =>
-      row.id === messageKey ||
-      `${row.folder}:${row.uid}` === messageKey ||
-      String(row.uid) === messageKey,
-  );
-  if (index < 0) {
+  const db = getMailDb(accountId);
+  const row = findRow(db, messageKey);
+  if (!row) {
     throw new Error('Cached message not found');
   }
-  cache.messages[index] = {
-    ...cache.messages[index],
-    flags: {
-      seen: Boolean(flags.seen),
-      flagged: Boolean(flags.flagged),
-      answered: Boolean(flags.answered),
-    },
-  };
-  await writeMessageCache(accountId, cache);
-  return cache.messages[index];
+  const tx = db.transaction(() => {
+    db.prepare('UPDATE messages SET seen = ?, flagged = ?, answered = ? WHERE message_row_id = ?').run(
+      flags.seen ? 1 : 0,
+      flags.flagged ? 1 : 0,
+      flags.answered ? 1 : 0,
+      row.message_row_id,
+    );
+    recomputeThread(db, row.thread_id);
+  });
+  tx();
+  return getCachedMessage(accountId, messageKey);
 }
 
 /**
- * Move a cached message to another folder (updates id + uid).
+ * Move a cached message to another folder. The stable `id` is deliberately
+ * left alone so triage/variants/dashboard references survive the move (D4).
  * @param {string} accountId
  * @param {string} messageKey
  * @param {string} destFolder
  * @param {string} newUid
  */
 export async function updateMessageFolder(accountId, messageKey, destFolder, newUid) {
-  const cache = await readMessageCache(accountId);
-  const index = cache.messages.findIndex(
-    (row) =>
-      row.id === messageKey ||
-      `${row.folder}:${row.uid}` === messageKey ||
-      String(row.uid) === messageKey,
-  );
-  if (index < 0) {
+  const db = getMailDb(accountId);
+  const row = findRow(db, messageKey);
+  if (!row) {
     throw new Error('Cached message not found');
   }
-  const row = cache.messages[index];
-  cache.messages[index] = {
-    ...row,
-    folder: destFolder,
-    uid: newUid,
-    id: `${destFolder}:${newUid}`,
-  };
-  await writeMessageCache(accountId, cache);
-  return cache.messages[index];
+  const tx = db.transaction(() => {
+    // A stale row already sitting at the destination uid would break UNIQUE.
+    db.prepare('DELETE FROM messages WHERE folder = ? AND uid = ? AND message_row_id != ?').run(
+      destFolder,
+      String(newUid),
+      row.message_row_id,
+    );
+    db.prepare('UPDATE messages SET folder = ?, uid = ? WHERE message_row_id = ?').run(
+      destFolder,
+      String(newUid),
+      row.message_row_id,
+    );
+    recomputeThread(db, row.thread_id);
+  });
+  tx();
+  return getCachedMessage(accountId, messageKey);
 }
 
 /**
- * Remove a message from the local cache after permanent delete.
+ * Remove a message from the store after a permanent delete.
  * @param {string} accountId
  * @param {string} messageKey
  */
 export async function removeMessageFromCache(accountId, messageKey) {
-  const cache = await readMessageCache(accountId);
-  const before = cache.messages.length;
-  cache.messages = cache.messages.filter(
-    (row) =>
-      row.id !== messageKey &&
-      `${row.folder}:${row.uid}` !== messageKey &&
-      String(row.uid) !== messageKey,
-  );
-  if (cache.messages.length === before) {
+  const db = getMailDb(accountId);
+  const row = findRow(db, messageKey);
+  if (!row) {
     throw new Error('Cached message not found');
   }
-  await writeMessageCache(accountId, cache);
+  const tx = db.transaction(() => {
+    db.prepare('DELETE FROM messages_fts WHERE message_row_id = ?').run(row.message_row_id);
+    db.prepare('DELETE FROM messages WHERE message_row_id = ?').run(row.message_row_id);
+    recomputeThread(db, row.thread_id);
+  });
+  tx();
   return { removed: true };
 }
 
@@ -289,22 +648,16 @@ export async function removeMessageFromCache(accountId, messageKey) {
  * @param {Array<{ id: string, label: string, body: string, createdAt: string }>} variants
  */
 export async function updateReplyVariants(accountId, messageKey, variants) {
-  const cache = await readMessageCache(accountId);
-  const index = cache.messages.findIndex(
-    (row) =>
-      row.id === messageKey ||
-      `${row.folder}:${row.uid}` === messageKey ||
-      String(row.uid) === messageKey,
-  );
-  if (index < 0) {
+  const db = getMailDb(accountId);
+  const rowId = findRowId(db, messageKey);
+  if (rowId === null) {
     throw new Error('Cached message not found');
   }
-  cache.messages[index] = {
-    ...cache.messages[index],
-    replyVariants: variants,
-  };
-  await writeMessageCache(accountId, cache);
-  return cache.messages[index];
+  db.prepare('UPDATE messages SET reply_variants_json = ? WHERE message_row_id = ?').run(
+    JSON.stringify(variants ?? []),
+    rowId,
+  );
+  return getCachedMessage(accountId, messageKey);
 }
 
 /**
@@ -313,9 +666,7 @@ export async function updateReplyVariants(accountId, messageKey, variants) {
  * @param {Record<string, unknown>} summary
  */
 export async function updateInboxSummary(accountId, summary) {
-  const cache = await readMessageCache(accountId);
-  cache.inboxSummary = summary;
-  await writeMessageCache(accountId, cache);
+  writeMeta(getMailDb(accountId), 'inboxSummary', summary);
   return summary;
 }
 
@@ -324,23 +675,255 @@ export async function updateInboxSummary(accountId, summary) {
  * @param {string} accountId
  */
 export async function getInboxSummary(accountId) {
-  const cache = await readMessageCache(accountId);
-  return cache.inboxSummary ?? null;
+  return readMeta(getMailDb(accountId), 'inboxSummary', null);
 }
 
 /**
- * Count unread messages per folder from cache flags.
+ * Count unread messages per folder.
  * @param {string} accountId
  */
 export async function getFolderUnreadCounts(accountId) {
-  const cache = await readMessageCache(accountId);
+  const db = getMailDb(accountId);
   /** @type {Record<string, number>} */
   const counts = {};
-  for (const row of cache.messages) {
-    const folder = String(row.folder ?? 'INBOX');
-    if (!row.flags?.seen) {
-      counts[folder] = (counts[folder] ?? 0) + 1;
-    }
+  for (const row of db
+    .prepare('SELECT folder, COUNT(*) AS n FROM messages WHERE seen = 0 GROUP BY folder')
+    .all()) {
+    counts[row.folder] = row.n;
   }
   return counts;
+}
+
+// ---------------------------------------------------------------------------
+// Bodies (lazy fetch support)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the cached body for a message, if one has been downloaded.
+ * @param {string} accountId
+ * @param {string} messageKey
+ */
+export async function getCachedBody(accountId, messageKey) {
+  const db = getMailDb(accountId);
+  const rowId = findRowId(db, messageKey);
+  if (rowId === null) return null;
+  const body = db.prepare('SELECT * FROM bodies WHERE message_row_id = ?').get(rowId);
+  if (!body) return null;
+  return {
+    bodyText: body.body_text ?? '',
+    bodyHtml: body.body_html ?? undefined,
+    complete: Boolean(body.complete),
+    fetchedAt: body.fetched_at,
+  };
+}
+
+/**
+ * Persist a downloaded body (and refresh the FTS entry so search sees it).
+ * @param {string} accountId
+ * @param {string} messageKey
+ * @param {{ bodyText?: string, bodyHtml?: string, complete?: boolean, attachments?: Array<Record<string, unknown>>, bodyHash?: string }} body
+ */
+export async function saveCachedBody(accountId, messageKey, body) {
+  const db = getMailDb(accountId);
+  const row = findRow(db, messageKey);
+  if (!row) {
+    throw new Error('Cached message not found');
+  }
+  const tx = db.transaction(() => {
+    saveBodyRow(db, row.message_row_id, body);
+    if (typeof body.bodyHash === 'string' && body.bodyHash) {
+      db.prepare('UPDATE messages SET body_hash = ? WHERE message_row_id = ?').run(
+        body.bodyHash,
+        row.message_row_id,
+      );
+    }
+    if (Array.isArray(body.attachments)) {
+      db.prepare('DELETE FROM attachments WHERE message_row_id = ?').run(row.message_row_id);
+      const insert = db.prepare(
+        'INSERT INTO attachments (message_row_id, idx, filename, content_type, size) VALUES (?, ?, ?, ?, ?)',
+      );
+      body.attachments.forEach((att, idx) => {
+        insert.run(
+          row.message_row_id,
+          idx,
+          String(att?.filename ?? 'attachment'),
+          String(att?.contentType ?? 'application/octet-stream'),
+          Number(att?.size) || 0,
+        );
+      });
+      db.prepare('UPDATE messages SET has_attachments = ? WHERE message_row_id = ?').run(
+        body.attachments.length ? 1 : 0,
+        row.message_row_id,
+      );
+    }
+    reindexMessageFts(db, row.message_row_id);
+  });
+  tx();
+  return getCachedMessage(accountId, messageKey);
+}
+
+// ---------------------------------------------------------------------------
+// Sync state / folder cache
+// ---------------------------------------------------------------------------
+
+function setSyncStateRow(db, folder, patch) {
+  const existing = db.prepare('SELECT * FROM sync_state WHERE folder = ?').get(folder);
+  db.prepare(
+    `INSERT INTO sync_state (folder, uid_validity, highest_uid, highest_modseq, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(folder) DO UPDATE SET
+       uid_validity = excluded.uid_validity,
+       highest_uid = excluded.highest_uid,
+       highest_modseq = excluded.highest_modseq,
+       updated_at = excluded.updated_at`,
+  ).run(
+    folder,
+    patch.uidValidity !== undefined ? String(patch.uidValidity) : (existing?.uid_validity ?? ''),
+    patch.highestUid !== undefined ? Number(patch.highestUid) || 0 : (existing?.highest_uid ?? 0),
+    patch.highestModseq !== undefined ? String(patch.highestModseq) : (existing?.highest_modseq ?? ''),
+    nowIso(),
+  );
+}
+
+/**
+ * Per-folder sync cursor (uidvalidity / highest uid / modseq).
+ * @param {string} accountId
+ * @param {string} folder
+ */
+export async function getSyncState(accountId, folder) {
+  const row = getMailDb(accountId).prepare('SELECT * FROM sync_state WHERE folder = ?').get(folder);
+  return {
+    folder,
+    uidValidity: row?.uid_validity ?? '',
+    highestUid: row?.highest_uid ?? 0,
+    highestModseq: row?.highest_modseq ?? '',
+    updatedAt: row?.updated_at ?? '',
+  };
+}
+
+/**
+ * @param {string} accountId
+ * @param {string} folder
+ * @param {{ uidValidity?: string | number, highestUid?: number, highestModseq?: string | number }} patch
+ */
+export async function setSyncState(accountId, folder, patch) {
+  setSyncStateRow(getMailDb(accountId), folder, patch ?? {});
+  return getSyncState(accountId, folder);
+}
+
+/**
+ * Drop every cached message for a folder after a UIDVALIDITY reset.
+ * @param {string} accountId
+ * @param {string} folder
+ */
+export async function resetFolderCache(accountId, folder) {
+  const db = getMailDb(accountId);
+  const tx = db.transaction(() => {
+    const rows = db.prepare('SELECT message_row_id, thread_id FROM messages WHERE folder = ?').all(folder);
+    const delFts = db.prepare('DELETE FROM messages_fts WHERE message_row_id = ?');
+    const delRow = db.prepare('DELETE FROM messages WHERE message_row_id = ?');
+    for (const row of rows) {
+      delFts.run(row.message_row_id);
+      delRow.run(row.message_row_id);
+    }
+    for (const threadId of new Set(rows.map((row) => row.thread_id))) {
+      recomputeThread(db, threadId);
+    }
+    setSyncStateRow(db, folder, { highestUid: 0, highestModseq: '' });
+  });
+  tx();
+  return { removed: true };
+}
+
+/**
+ * Cached message count, optionally scoped to one folder.
+ * @param {string} accountId
+ * @param {string} [folder]
+ */
+export async function countCachedMessages(accountId, folder = '') {
+  const db = getMailDb(accountId);
+  return folder
+    ? (db.prepare('SELECT COUNT(*) AS n FROM messages WHERE folder = ?').get(folder)?.n ?? 0)
+    : (db.prepare('SELECT COUNT(*) AS n FROM messages').get()?.n ?? 0);
+}
+
+/**
+ * Cached IMAP folder list (avoids a LIST round-trip per archive/move).
+ * @param {string} accountId
+ */
+export async function getCachedFolders(accountId) {
+  const entry = readMeta(getMailDb(accountId), 'folders', null);
+  if (!entry || !Array.isArray(entry.folders)) return null;
+  return entry;
+}
+
+/**
+ * @param {string} accountId
+ * @param {Array<{ path: string, name: string, specialUse?: string | null }>} folders
+ */
+export async function setCachedFolders(accountId, folders) {
+  writeMeta(getMailDb(accountId), 'folders', { folders, fetchedAt: nowIso() });
+  return folders;
+}
+
+/**
+ * UIDs cached for a folder within the reconcile window (newest first).
+ * @param {string} accountId
+ * @param {string} folder
+ * @param {number} limit
+ */
+export async function listCachedUids(accountId, folder, limit = 200) {
+  return getMailDb(accountId)
+    .prepare('SELECT uid FROM messages WHERE folder = ? ORDER BY date_ms DESC LIMIT ?')
+    .all(folder, Math.max(1, Number(limit) || 200))
+    .map((row) => Number(row.uid))
+    .filter((uid) => Number.isFinite(uid));
+}
+
+/**
+ * Apply a FLAGS-only reconcile pass: update flags for uids the server still
+ * reports, delete cached rows the server no longer has (external move/delete).
+ * @param {string} accountId
+ * @param {string} folder
+ * @param {Map<number, { seen: boolean, flagged: boolean, answered: boolean }>} serverFlags
+ * @param {number[]} windowUids
+ */
+export async function reconcileFolderFlags(accountId, folder, serverFlags, windowUids) {
+  const db = getMailDb(accountId);
+  /** @type {{ updated: number, removed: number }} */
+  const result = { updated: 0, removed: 0 };
+
+  const tx = db.transaction(() => {
+    const threadIds = new Set();
+    for (const uid of windowUids) {
+      const row = db
+        .prepare('SELECT message_row_id, thread_id, seen, flagged, answered FROM messages WHERE folder = ? AND uid = ?')
+        .get(folder, String(uid));
+      if (!row) continue;
+
+      const flags = serverFlags.get(uid);
+      if (!flags) {
+        db.prepare('DELETE FROM messages_fts WHERE message_row_id = ?').run(row.message_row_id);
+        db.prepare('DELETE FROM messages WHERE message_row_id = ?').run(row.message_row_id);
+        threadIds.add(row.thread_id);
+        result.removed += 1;
+        continue;
+      }
+
+      const next = [flags.seen ? 1 : 0, flags.flagged ? 1 : 0, flags.answered ? 1 : 0];
+      if (next[0] !== row.seen || next[1] !== row.flagged || next[2] !== row.answered) {
+        db.prepare('UPDATE messages SET seen = ?, flagged = ?, answered = ? WHERE message_row_id = ?').run(
+          ...next,
+          row.message_row_id,
+        );
+        threadIds.add(row.thread_id);
+        result.updated += 1;
+      }
+    }
+    for (const threadId of threadIds) {
+      recomputeThread(db, threadId);
+    }
+  });
+  tx();
+  return result;
 }

--- a/server/email/imap-actions.js
+++ b/server/email/imap-actions.js
@@ -2,9 +2,7 @@
  * IMAP message mutations — flags, move, archive, delete (imapflow).
  */
 
-import { readAccountPassword, getEmailAccount } from './accounts.js';
-import { createImapClient, listImapFolders } from './imap.js';
-import { withImapErrors } from './imap-errors.js';
+import { listFoldersCached, withMailbox } from './imap-session.js';
 import {
   getCachedMessage,
   removeMessageFromCache,
@@ -84,36 +82,6 @@ export function resolveMailFolder(folders, preferred, role = '') {
 
 /**
  * @param {string} accountId
- * @param {(client: import('imapflow').ImapFlow, account: import('./accounts.js').EmailAccount) => Promise<unknown>} fn
- */
-async function withConnectedImap(accountId, fn) {
-  const account = await getEmailAccount(accountId);
-  if (!account) {
-    throw new Error('Email account not found');
-  }
-  const password = await readAccountPassword(accountId);
-  return withImapErrors(account, async () => {
-    const client = createImapClient(account, password);
-    try {
-      await client.connect();
-      return await fn(client, account);
-    } finally {
-      try {
-        await client.logout();
-      } catch {
-        /* ignore */
-      }
-      try {
-        await client.close();
-      } catch {
-        /* ignore */
-      }
-    }
-  });
-}
-
-/**
- * @param {string} accountId
  * @param {string} messageKey
  */
 async function resolveCachedMessage(accountId, messageKey) {
@@ -138,21 +106,16 @@ async function resolveCachedMessage(accountId, messageKey) {
 export async function setImapMessageFlags(accountId, messageKey, flags) {
   const { message, folder, uid } = await resolveCachedMessage(accountId, messageKey);
 
-  await withConnectedImap(accountId, async (client) => {
-    const lock = await client.getMailboxLock(folder);
-    try {
-      if (flags.seen === true) {
-        await client.messageFlagsAdd(uid, ['\\Seen'], { uid: true });
-      } else if (flags.seen === false) {
-        await client.messageFlagsRemove(uid, ['\\Seen'], { uid: true });
-      }
-      if (flags.flagged === true) {
-        await client.messageFlagsAdd(uid, ['\\Flagged'], { uid: true });
-      } else if (flags.flagged === false) {
-        await client.messageFlagsRemove(uid, ['\\Flagged'], { uid: true });
-      }
-    } finally {
-      lock.release();
+  await withMailbox(accountId, folder, async (client) => {
+    if (flags.seen === true) {
+      await client.messageFlagsAdd(uid, ['\\Seen'], { uid: true });
+    } else if (flags.seen === false) {
+      await client.messageFlagsRemove(uid, ['\\Seen'], { uid: true });
+    }
+    if (flags.flagged === true) {
+      await client.messageFlagsAdd(uid, ['\\Flagged'], { uid: true });
+    } else if (flags.flagged === false) {
+      await client.messageFlagsRemove(uid, ['\\Flagged'], { uid: true });
     }
   });
 
@@ -166,6 +129,74 @@ export async function setImapMessageFlags(accountId, messageKey, flags) {
 }
 
 /**
+ * Set flags on many messages with one STORE per folder (imapflow accepts a UID
+ * set), instead of one connection + one STORE per message.
+ *
+ * @param {string} accountId
+ * @param {string[]} messageKeys
+ * @param {{ seen?: boolean, flagged?: boolean }} flags
+ */
+export async function setImapMessageFlagsBulk(accountId, messageKeys, flags) {
+  /** @type {Map<string, Array<{ key: string, uid: number, message: Record<string, any> }>>} */
+  const byFolder = new Map();
+  /** @type {Array<{ id: string, ok: false, error: string }>} */
+  const failures = [];
+
+  for (const key of messageKeys) {
+    try {
+      const { message, folder, uid } = await resolveCachedMessage(accountId, key);
+      if (!byFolder.has(folder)) byFolder.set(folder, []);
+      byFolder.get(folder).push({ key, uid, message });
+    } catch (err) {
+      failures.push({
+        id: key,
+        ok: false,
+        error: err instanceof Error ? err.message : 'Message not found',
+      });
+    }
+  }
+
+  /** @type {Array<Record<string, unknown>>} */
+  const results = [...failures];
+
+  for (const [folder, entries] of byFolder) {
+    const uidSet = entries.map((entry) => entry.uid).join(',');
+    try {
+      await withMailbox(accountId, folder, async (client) => {
+        if (flags.seen === true) {
+          await client.messageFlagsAdd(uidSet, ['\\Seen'], { uid: true });
+        } else if (flags.seen === false) {
+          await client.messageFlagsRemove(uidSet, ['\\Seen'], { uid: true });
+        }
+        if (flags.flagged === true) {
+          await client.messageFlagsAdd(uidSet, ['\\Flagged'], { uid: true });
+        } else if (flags.flagged === false) {
+          await client.messageFlagsRemove(uidSet, ['\\Flagged'], { uid: true });
+        }
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : 'Bulk flag update failed';
+      for (const entry of entries) {
+        results.push({ id: entry.key, ok: false, error });
+      }
+      continue;
+    }
+
+    for (const entry of entries) {
+      const nextFlags = {
+        seen: flags.seen ?? entry.message.flags?.seen ?? false,
+        flagged: flags.flagged ?? entry.message.flags?.flagged ?? false,
+        answered: entry.message.flags?.answered ?? false,
+      };
+      await updateMessageFlags(accountId, entry.key, nextFlags);
+      results.push({ id: entry.key, ok: true, flags: nextFlags });
+    }
+  }
+
+  return results;
+}
+
+/**
  * Move a message to another folder.
  * @param {string} accountId
  * @param {string} messageKey
@@ -173,23 +204,18 @@ export async function setImapMessageFlags(accountId, messageKey, flags) {
  * @param {'trash' | 'archive' | 'junk' | ''} [role]
  */
 export async function moveImapMessage(accountId, messageKey, destFolder, role = '') {
-  const { message, folder, uid } = await resolveCachedMessage(accountId, messageKey);
-  const folders = await listImapFolders(accountId);
+  const { folder, uid } = await resolveCachedMessage(accountId, messageKey);
+  const folders = await listFoldersCached(accountId);
   const target = resolveMailFolder(folders, destFolder, role);
 
   let newUid = uid;
-  await withConnectedImap(accountId, async (client) => {
-    const lock = await client.getMailboxLock(folder);
-    try {
-      const moved = await client.messageMove(uid, target, { uid: true });
-      if (moved && typeof moved === 'object' && moved.uidMap) {
-        const mapped = moved.uidMap.get(uid);
-        if (mapped) {
-          newUid = mapped;
-        }
+  await withMailbox(accountId, folder, async (client) => {
+    const moved = await client.messageMove(uid, target, { uid: true });
+    if (moved && typeof moved === 'object' && moved.uidMap) {
+      const mapped = moved.uidMap.get(uid);
+      if (mapped) {
+        newUid = mapped;
       }
-    } finally {
-      lock.release();
     }
   });
 
@@ -203,7 +229,7 @@ export async function moveImapMessage(accountId, messageKey, destFolder, role = 
  * @param {string} messageKey
  */
 export async function archiveImapMessage(accountId, messageKey) {
-  const folders = await listImapFolders(accountId);
+  const folders = await listFoldersCached(accountId);
   const archiveFolder = resolveMailFolder(folders, 'Archive', 'archive');
   return moveImapMessage(accountId, messageKey, archiveFolder, 'archive');
 }
@@ -215,20 +241,15 @@ export async function archiveImapMessage(accountId, messageKey) {
  * @param {{ permanent?: boolean }} [options]
  */
 export async function deleteImapMessage(accountId, messageKey, options = {}) {
-  const { message, folder, uid } = await resolveCachedMessage(accountId, messageKey);
-  const folders = await listImapFolders(accountId);
+  const { folder, uid } = await resolveCachedMessage(accountId, messageKey);
+  const folders = await listFoldersCached(accountId);
   const trashFolder = resolveMailFolder(folders, 'Trash', 'trash');
   const folderLower = folder.toLowerCase();
 
   if (options.permanent || folderLower.includes('trash') || folderLower.includes('bin')) {
-    await withConnectedImap(accountId, async (client) => {
-      const lock = await client.getMailboxLock(folder);
-      try {
-        await client.messageFlagsAdd(uid, ['\\Deleted'], { uid: true });
-        await client.messageDelete(uid, { uid: true });
-      } finally {
-        lock.release();
-      }
+    await withMailbox(accountId, folder, async (client) => {
+      await client.messageFlagsAdd(uid, ['\\Deleted'], { uid: true });
+      await client.messageDelete(uid, { uid: true });
     });
     await removeMessageFromCache(accountId, messageKey);
     return { ok: true, deleted: true };

--- a/server/email/imap-session.js
+++ b/server/email/imap-session.js
@@ -1,0 +1,347 @@
+/**
+ * Persistent IMAP sessions — one long-lived ImapFlow client per account.
+ *
+ * Before this module every mail operation paid a full TCP + TLS + LOGIN round
+ * trip (a 100-message bulk action opened ~100 connections; archive opened 3).
+ * `withMailbox` borrows the shared client and holds the imapflow mailbox lock
+ * for the duration of the callback, so operations serialize per account without
+ * reconnecting. Idle sessions close after IDLE_CLOSE_MS.
+ */
+
+import { ImapFlow } from 'imapflow';
+import { getEmailAccount, readAccountPassword } from './accounts.js';
+import { withImapErrors } from './imap-errors.js';
+import { getCachedFolders, setCachedFolders } from './cache.js';
+
+/** Close a session after this long with no borrow. */
+export const IDLE_CLOSE_MS = 5 * 60_000;
+
+/** Cached folder lists older than this are refetched. */
+export const FOLDER_CACHE_TTL_MS = 24 * 60 * 60_000;
+
+/** Reconnect backoff ceiling after consecutive connect failures. */
+const MAX_BACKOFF_MS = 60_000;
+
+/**
+ * @typedef {object} ImapSession
+ * @property {import('imapflow').ImapFlow | null} client
+ * @property {Promise<import('imapflow').ImapFlow> | null} connecting
+ * @property {NodeJS.Timeout | null} idleTimer
+ * @property {number} borrowed
+ * @property {number} failures
+ */
+
+/** @type {Map<string, ImapSession>} */
+const sessions = new Map();
+
+/** Serializes borrows per account so one client is never used concurrently. */
+/** @type {Map<string, Promise<unknown>>} */
+const queues = new Map();
+
+function getSession(accountId) {
+  let session = sessions.get(accountId);
+  if (!session) {
+    session = { client: null, connecting: null, idleTimer: null, borrowed: 0, failures: 0 };
+    sessions.set(accountId, session);
+  }
+  return session;
+}
+
+function clearIdleTimer(session) {
+  if (session.idleTimer) {
+    clearTimeout(session.idleTimer);
+    session.idleTimer = null;
+  }
+}
+
+function scheduleIdleClose(accountId) {
+  const session = getSession(accountId);
+  clearIdleTimer(session);
+  session.idleTimer = setTimeout(() => {
+    if (session.borrowed === 0) {
+      void closeImapSession(accountId);
+    }
+  }, IDLE_CLOSE_MS);
+  session.idleTimer.unref?.();
+}
+
+/**
+ * Build the shared client for an account (exported for tests/injection).
+ * @param {import('./accounts.js').EmailAccount} account
+ * @param {string} password
+ */
+export function createSessionClient(account, password) {
+  return new ImapFlow({
+    host: account.imap.host,
+    port: account.imap.port,
+    secure: account.imap.tls,
+    auth: { user: account.username, pass: password },
+    logger: false,
+    emitLogs: false,
+  });
+}
+
+/**
+ * Connect (or reuse) the shared client for an account.
+ * @param {string} accountId
+ * @returns {Promise<{ client: import('imapflow').ImapFlow, account: import('./accounts.js').EmailAccount }>}
+ */
+async function acquireClient(accountId) {
+  const account = await getEmailAccount(accountId);
+  if (!account) {
+    throw new Error('Email account not found');
+  }
+  const session = getSession(accountId);
+
+  if (session.client && session.client.usable) {
+    return { client: session.client, account };
+  }
+
+  if (!session.connecting) {
+    if (session.failures > 0) {
+      const backoff = Math.min(MAX_BACKOFF_MS, 500 * 2 ** (session.failures - 1));
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+    }
+    const password = await readAccountPassword(accountId);
+    const client = createSessionClient(account, password);
+    client.on('error', () => {
+      /* surfaced by the awaiting operation; keeps the process alive */
+    });
+    client.on('close', () => {
+      if (sessions.get(accountId)?.client === client) {
+        getSession(accountId).client = null;
+      }
+    });
+    session.connecting = client
+      .connect()
+      .then(() => {
+        session.client = client;
+        session.failures = 0;
+        return client;
+      })
+      .catch((err) => {
+        session.failures += 1;
+        try {
+          void client.close();
+        } catch {
+          /* ignore */
+        }
+        throw err;
+      })
+      .finally(() => {
+        session.connecting = null;
+      });
+  }
+
+  await session.connecting;
+  return { client: session.client, account };
+}
+
+/**
+ * Run `fn` against the shared client with `folder` selected and locked.
+ * Operations for one account are serialized; a dropped connection is retried once.
+ *
+ * @template T
+ * @param {string} accountId
+ * @param {string | null} folder — null selects no mailbox (LIST, STATUS, …)
+ * @param {(client: import('imapflow').ImapFlow, account: import('./accounts.js').EmailAccount) => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export function withMailbox(accountId, folder, fn) {
+  const previous = queues.get(accountId) ?? Promise.resolve();
+  const run = previous.catch(() => {}).then(() => runBorrow(accountId, folder, fn));
+  queues.set(
+    accountId,
+    run.catch(() => {}),
+  );
+  return run;
+}
+
+async function runBorrow(accountId, folder, fn, retry = true) {
+  const session = getSession(accountId);
+  clearIdleTimer(session);
+  session.borrowed += 1;
+
+  try {
+    const { client, account } = await acquireClient(accountId);
+    return await withImapErrors(account, async () => {
+      if (!folder) {
+        return fn(client, account);
+      }
+      const lock = await client.getMailboxLock(folder);
+      try {
+        return await fn(client, account);
+      } finally {
+        lock.release();
+      }
+    });
+  } catch (err) {
+    const session2 = getSession(accountId);
+    const dead = !session2.client?.usable;
+    if (retry && dead) {
+      session2.client = null;
+      return runBorrow(accountId, folder, fn, false);
+    }
+    throw err;
+  } finally {
+    session.borrowed -= 1;
+    if (session.borrowed === 0) {
+      scheduleIdleClose(accountId);
+    }
+  }
+}
+
+/**
+ * Close the shared client for one account.
+ * @param {string} accountId
+ */
+export async function closeImapSession(accountId) {
+  const session = sessions.get(accountId);
+  if (!session) return;
+  clearIdleTimer(session);
+  const client = session.client;
+  session.client = null;
+  sessions.delete(accountId);
+  if (!client) return;
+  try {
+    await client.logout();
+  } catch {
+    /* ignore */
+  }
+  try {
+    await client.close();
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Close every open session (shutdown, tests). */
+export async function closeAllImapSessions() {
+  await Promise.all([...sessions.keys()].map((accountId) => closeImapSession(accountId)));
+  queues.clear();
+}
+
+/**
+ * Folder list for an account, served from `meta.folders` when fresh.
+ * @param {string} accountId
+ * @param {{ force?: boolean }} [options]
+ */
+export async function listFoldersCached(accountId, options = {}) {
+  if (!options.force) {
+    const cached = await getCachedFolders(accountId);
+    if (cached?.folders?.length) {
+      const age = Date.now() - new Date(cached.fetchedAt ?? 0).getTime();
+      if (Number.isFinite(age) && age < FOLDER_CACHE_TTL_MS) {
+        return cached.folders;
+      }
+    }
+  }
+
+  const folders = await withMailbox(accountId, null, async (client) => {
+    const list = await client.list();
+    return list.map((entry) => ({
+      path: entry.path,
+      name: entry.name,
+      specialUse: entry.specialUse ?? null,
+      subscribed: entry.subscribed ?? true,
+    }));
+  });
+
+  await setCachedFolders(accountId, folders);
+  return folders;
+}
+
+// ---------------------------------------------------------------------------
+// IDLE watchers
+// ---------------------------------------------------------------------------
+
+/** @type {Map<string, { client: import('imapflow').ImapFlow, stopped: boolean }>} */
+const watchers = new Map();
+
+/**
+ * Watch INBOX for new mail with a dedicated IDLE connection.
+ *
+ * The watcher gets its own client: imapflow holds the socket in IDLE, so
+ * sharing it with `withMailbox` would stall every other operation.
+ *
+ * @param {string} accountId
+ * @param {(info: { folder: string, reason: string }) => void | Promise<void>} onChange
+ */
+export async function startIdleWatcher(accountId, onChange, folder = 'INBOX') {
+  if (watchers.has(accountId)) {
+    return { started: false, reason: 'already_watching' };
+  }
+
+  const account = await getEmailAccount(accountId);
+  if (!account) {
+    throw new Error('Email account not found');
+  }
+  const password = await readAccountPassword(accountId);
+  const client = createSessionClient(account, password);
+  const entry = { client, stopped: false };
+  watchers.set(accountId, entry);
+
+  client.on('error', () => {
+    /* reconnect handled by the poller fallback */
+  });
+  client.on('exists', () => {
+    if (!entry.stopped) {
+      void Promise.resolve(onChange({ folder, reason: 'exists' })).catch(() => {});
+    }
+  });
+  client.on('flags', () => {
+    if (!entry.stopped) {
+      void Promise.resolve(onChange({ folder, reason: 'flags' })).catch(() => {});
+    }
+  });
+
+  try {
+    await client.connect();
+    await client.mailboxOpen(folder);
+    // imapflow enters IDLE on its own once a mailbox is open and idle.
+    return { started: true, folder };
+  } catch (err) {
+    watchers.delete(accountId);
+    entry.stopped = true;
+    try {
+      await client.close();
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
+/** Stop the IDLE watcher for one account. */
+export async function stopIdleWatcher(accountId) {
+  const entry = watchers.get(accountId);
+  if (!entry) return { stopped: false };
+  entry.stopped = true;
+  watchers.delete(accountId);
+  try {
+    await entry.client.logout();
+  } catch {
+    /* ignore */
+  }
+  try {
+    await entry.client.close();
+  } catch {
+    /* ignore */
+  }
+  return { stopped: true };
+}
+
+/** Stop every IDLE watcher (shutdown, tests). */
+export async function stopAllIdleWatchers() {
+  await Promise.all([...watchers.keys()].map((accountId) => stopIdleWatcher(accountId)));
+}
+
+/** Test helper — accounts with an active watcher. */
+export function watchedAccountsForTests() {
+  return [...watchers.keys()];
+}
+
+/** Test helper — accounts with an open session. */
+export function openSessionsForTests() {
+  return [...sessions.keys()];
+}

--- a/server/email/imap.js
+++ b/server/email/imap.js
@@ -1,5 +1,10 @@
 /**
- * IMAP connect, folder listing, and paginated message fetch (imapflow).
+ * IMAP connect, folder listing, and incremental message sync (imapflow).
+ *
+ * Sync is incremental: new mail is fetched with `UID lastSeen+1:*` (headers +
+ * text part only), and a cheap FLAGS-only pass over the visible window
+ * reconciles reads/deletes/moves made in another client. Full bodies and
+ * attachment metadata are downloaded lazily on first open (`ensureMessageBody`).
  */
 
 import { createHash } from 'node:crypto';
@@ -16,17 +21,40 @@ import {
   stripHtmlToText,
 } from './parse-body.js';
 import { sanitizeEmailHtml } from './sanitize-html.js';
-import { mergeMessagesIntoCache } from './cache.js';
+import {
+  countCachedMessages,
+  getCachedBody,
+  getCachedMessage,
+  getSyncState,
+  listCachedUids,
+  mergeMessagesIntoCache,
+  migrateJsonCacheIfNeeded,
+  reconcileFolderFlags,
+  resetFolderCache,
+  saveCachedBody,
+  setSyncState,
+} from './cache.js';
+import { listFoldersCached, withMailbox } from './imap-session.js';
 import { withImapErrors } from './imap-errors.js';
 
-/** Default page size for inbox fetch. */
+/** Default page size for the initial folder fill. */
 export const DEFAULT_FETCH_LIMIT = 50;
 
 /** Maximum messages per agent/tool request. */
 export const MAX_TOOL_LIMIT = 20;
 
+/** How many recent UIDs the FLAGS reconcile pass covers. */
+export const FLAGS_RECONCILE_WINDOW = 200;
+
+/** Cap on new messages ingested in one sync pass (protects a cold 5k mailbox). */
+export const MAX_NEW_PER_SYNC = 500;
+
+/** Skip inline text-part download above this size; the body loads lazily instead. */
+const MAX_PREVIEW_PART_BYTES = 256 * 1024;
+
 /**
- * Build an imapflow client for an account (caller must connect/disconnect).
+ * Build a one-shot imapflow client (connection tests; pooled work uses
+ * `withMailbox` from imap-session.js).
  * @param {import('./accounts.js').EmailAccount} account
  * @param {string} password
  */
@@ -45,7 +73,8 @@ export function createImapClient(account, password) {
 }
 
 /**
- * Test IMAP login for an account.
+ * Test IMAP login for an account. Deliberately unpooled — a credential check
+ * must not reuse (or poison) the live session.
  * @param {string} accountId
  */
 export async function testImapConnection(accountId) {
@@ -71,43 +100,16 @@ export async function testImapConnection(accountId) {
 }
 
 /**
- * List selectable IMAP folders.
+ * List selectable IMAP folders (served from the per-account folder cache).
  * @param {string} accountId
+ * @param {{ force?: boolean }} [options]
  */
-export async function listImapFolders(accountId) {
+export async function listImapFolders(accountId, options = {}) {
   const account = await getEmailAccount(accountId);
   if (!account) {
     throw new Error('Email account not found');
   }
-  const password = await readAccountPassword(accountId);
-  return withImapErrors(account, async () => {
-    const client = createImapClient(account, password);
-    try {
-      await client.connect();
-      const folders = [];
-      const list = await client.list();
-      for (const entry of list) {
-        folders.push({
-          path: entry.path,
-          name: entry.name,
-          specialUse: entry.specialUse ?? null,
-          subscribed: entry.subscribed ?? true,
-        });
-      }
-      return folders;
-    } finally {
-      try {
-        await client.logout();
-      } catch {
-        /* ignore */
-      }
-      try {
-        await client.close();
-      } catch {
-        /* ignore */
-      }
-    }
-  });
+  return listFoldersCached(accountId, options);
 }
 
 /**
@@ -176,6 +178,7 @@ export async function parseRawMessage(source, context) {
     bodyText,
     bodyHtml,
     bodyHash,
+    bodyComplete: true,
     hasAttachments: attachments.length > 0,
     attachments,
     inReplyTo,
@@ -185,9 +188,204 @@ export async function parseRawMessage(source, context) {
 }
 
 /**
- * Fetch recent messages from a folder and merge into cache.
+ * Walk an imapflow bodyStructure and return the first text/plain (else
+ * text/html) leaf small enough to fetch inline during sync.
+ * @param {Record<string, any> | undefined} node
+ */
+export function pickPreviewPart(node) {
+  if (!node) return null;
+  /** @type {Array<Record<string, any>>} */
+  const queue = [node];
+  /** @type {{ part: string, type: string, size: number } | null} */
+  let htmlFallback = null;
+
+  while (queue.length) {
+    const current = queue.shift();
+    const type = String(current?.type ?? '').toLowerCase();
+    const part = current?.part ? String(current.part) : '1';
+    const size = Number(current?.size) || 0;
+    const disposition = String(current?.disposition ?? '').toLowerCase();
+
+    if (Array.isArray(current?.childNodes) && current.childNodes.length) {
+      queue.push(...current.childNodes);
+      continue;
+    }
+    if (disposition === 'attachment' || size > MAX_PREVIEW_PART_BYTES) {
+      continue;
+    }
+    if (type === 'text/plain') {
+      return { part, type, size };
+    }
+    if (type === 'text/html' && !htmlFallback) {
+      htmlFallback = { part, type, size };
+    }
+  }
+
+  return htmlFallback;
+}
+
+/** Does this bodyStructure carry a real attachment part? */
+export function structureHasAttachments(node) {
+  if (!node) return false;
+  const queue = [node];
+  while (queue.length) {
+    const current = queue.shift();
+    if (Array.isArray(current?.childNodes) && current.childNodes.length) {
+      queue.push(...current.childNodes);
+      continue;
+    }
+    if (String(current?.disposition ?? '').toLowerCase() === 'attachment') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Build a message row from headers + body structure, without the full source.
+ * @param {{ uid: number, folder: string, headers?: Buffer, flags?: Set<string> | string[], bodyStructure?: object }} input
+ * @param {string} previewSource — decoded text of the preview part (may be empty)
+ */
+export async function parseEnvelopeMessage(input, previewSource = '') {
+  const headerBuffer = Buffer.isBuffer(input.headers)
+    ? input.headers
+    : Buffer.from(String(input.headers ?? ''));
+  const parsed = await simpleParser(headerBuffer);
+
+  const messageId = normalizeMessageId(parsed.messageId ?? '');
+  const references = Array.isArray(parsed.references)
+    ? parsed.references.map((ref) => normalizeMessageId(String(ref)))
+    : typeof parsed.references === 'string'
+      ? parsed.references.split(/\s+/).map((ref) => normalizeMessageId(ref))
+      : [];
+  const inReplyTo = parsed.inReplyTo ? normalizeMessageId(String(parsed.inReplyTo)) : '';
+  const subject = decodeMimeHeader(parsed.subject ?? '');
+  const from = formatFromAddress(
+    parsed.from?.value?.map((row) => ({ name: row.name, address: row.address })) ?? [],
+  );
+  const to = formatAddressList(
+    parsed.to?.value?.map((row) => ({ name: row.name, address: row.address })) ?? [],
+  );
+  const replyTo = formatFromAddress(
+    parsed.replyTo?.value?.map((row) => ({ name: row.name, address: row.address })) ?? [],
+  );
+
+  const looksHtml = /<\/?[a-z][\s\S]*>/i.test(previewSource);
+  const bodyText = looksHtml ? stripHtmlToText(previewSource) : previewSource;
+  const bodyPreview = buildBodyPreview(bodyText);
+  const bodyHash = createHash('sha256').update(bodyText).digest('hex');
+  const date = parsed.date ? parsed.date.toISOString() : new Date().toISOString();
+
+  return {
+    id: `${input.folder}:${input.uid}`,
+    uid: String(input.uid),
+    messageId,
+    threadId: computeThreadId({ messageId, inReplyTo, references, subject }),
+    folder: input.folder,
+    from,
+    to,
+    replyTo,
+    subject,
+    date,
+    bodyPreview,
+    bodyText,
+    bodyHash,
+    // Envelope sync stores text only; HTML arrives with the lazy body fetch so
+    // tracking markup for unopened mail never touches disk.
+    bodyComplete: false,
+    hasAttachments: structureHasAttachments(input.bodyStructure),
+    inReplyTo,
+    references,
+    flags: imapFlagsToObject(input.flags),
+  };
+}
+
+/**
+ * Decode one bodyPart buffer to text.
+ * @param {Map<string, Buffer> | undefined} bodyParts
+ * @param {string} part
+ */
+function readBodyPart(bodyParts, part) {
+  if (!bodyParts) return '';
+  const value = bodyParts instanceof Map ? bodyParts.get(part) : bodyParts?.[part];
+  if (!value) return '';
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+/**
+ * Fetch and store rows for a UID range.
+ * @param {import('imapflow').ImapFlow} client
+ * @param {string} folder
+ * @param {string} range
+ * @param {number} max
+ */
+async function fetchEnvelopeRange(client, folder, range, max) {
+  /** @type {Array<Record<string, unknown>>} */
+  const rows = [];
+  let highestUid = 0;
+
+  /** @type {Array<{ uid: number, flags: any, bodyStructure: any, headers: any }>} */
+  const descriptors = [];
+  for await (const message of client.fetch(
+    range,
+    { uid: true, flags: true, bodyStructure: true, headers: true },
+    { uid: true },
+  )) {
+    descriptors.push({
+      uid: message.uid,
+      flags: message.flags,
+      bodyStructure: message.bodyStructure,
+      headers: message.headers,
+    });
+    if (descriptors.length >= max) {
+      break;
+    }
+  }
+
+  for (const descriptor of descriptors) {
+    highestUid = Math.max(highestUid, descriptor.uid);
+    const preview = pickPreviewPart(descriptor.bodyStructure);
+    let previewText = '';
+    if (preview) {
+      try {
+        const fetched = await client.fetchOne(
+          String(descriptor.uid),
+          { uid: true, bodyParts: [preview.part] },
+          { uid: true },
+        );
+        previewText = readBodyPart(fetched?.bodyParts, preview.part);
+      } catch {
+        // A missing part must not abort the whole sync — the body loads lazily.
+      }
+    }
+    rows.push(await parseEnvelopeMessage({ ...descriptor, folder }, previewText));
+  }
+
+  return { rows, highestUid };
+}
+
+/**
+ * Read server flags for a set of UIDs (the reconcile pass).
+ * @param {import('imapflow').ImapFlow} client
+ * @param {number[]} uids
+ */
+async function fetchFlagsForUids(client, uids) {
+  /** @type {Map<number, { seen: boolean, flagged: boolean, answered: boolean }>} */
+  const flags = new Map();
+  if (!uids.length) return flags;
+
+  const range = uids.slice().sort((a, b) => a - b).join(',');
+  for await (const message of client.fetch(range, { uid: true, flags: true }, { uid: true })) {
+    flags.set(message.uid, imapFlagsToObject(message.flags));
+  }
+  return flags;
+}
+
+/**
+ * Incrementally sync one folder into the mail store.
+ *
  * @param {string} accountId
- * @param {{ folder?: string, limit?: number, offset?: number }} options
+ * @param {{ folder?: string, limit?: number, offset?: number, full?: boolean }} options
  */
 export async function syncFolderMessages(accountId, options = {}) {
   const account = await getEmailAccount(accountId);
@@ -195,69 +393,170 @@ export async function syncFolderMessages(accountId, options = {}) {
     throw new Error('Email account not found');
   }
 
+  await migrateJsonCacheIfNeeded(accountId);
+
   const folder = String(options.folder ?? account.folders[0] ?? 'INBOX');
   const limit = Math.min(200, Math.max(1, Number(options.limit) || DEFAULT_FETCH_LIMIT));
-  const offset = Math.max(0, Number(options.offset) || 0);
 
-  const password = await readAccountPassword(accountId);
-  return withImapErrors(account, async () => {
-    const client = createImapClient(account, password);
+  const state = await getSyncState(accountId, folder);
+  /** @type {{ rows: Array<Record<string, unknown>>, highestUid: number, uidValidity: string, modseq: string, reset: boolean }} */
+  const result = await withMailbox(accountId, folder, async (client) => {
+    const mailbox = client.mailbox;
+    const uidValidity = String(mailbox?.uidValidity ?? '');
+    const modseq = mailbox?.highestModseq ? String(mailbox.highestModseq) : '';
+    const reset = Boolean(state.uidValidity) && Boolean(uidValidity) && state.uidValidity !== uidValidity;
 
-    /** @type {Array<Record<string, unknown>>} */
-    const parsedMessages = [];
-    let highestUid = 0;
-
-    try {
-      await client.connect();
-      const lock = await client.getMailboxLock(folder);
-      try {
-        const status = await client.status(folder, { uidNext: true, messages: true });
-        if (!status.messages) {
-          return { messages: [], total: 0, folder, synced: 0 };
-        }
-
-        const search = await client.search({ all: true }, { uid: true });
-        const uids = Array.isArray(search) ? search.slice().sort((a, b) => b - a) : [];
-        const pageUids = uids.slice(offset, offset + limit);
-
-        for (const uid of pageUids) {
-          highestUid = Math.max(highestUid, uid);
-          const downloaded = await client.fetchOne(String(uid), { uid: true, flags: true, source: true });
-          if (!downloaded?.source) {
-            continue;
-          }
-          const source = Buffer.isBuffer(downloaded.source)
-            ? downloaded.source
-            : Buffer.from(String(downloaded.source));
-          const row = await parseRawMessage(source, {
-            uid,
-            folder,
-            flags: downloaded.flags,
-          });
-          parsedMessages.push(row);
-        }
-      } finally {
-        lock.release();
-      }
-    } finally {
-      try {
-        await client.logout();
-      } catch {
-        /* ignore */
-      }
-      try {
-        await client.close();
-      } catch {
-        /* ignore */
-      }
+    if (!mailbox?.exists) {
+      return { rows: [], highestUid: 0, uidValidity, modseq, reset };
     }
 
-    const cache = await mergeMessagesIntoCache(accountId, parsedMessages, folder, highestUid);
-    return {
-      messages: parsedMessages,
-      total: cache.messages.filter((row) => String(row.folder) === folder).length,
+    const cursor = reset || options.full ? 0 : state.highestUid;
+
+    if (cursor > 0) {
+      const { rows, highestUid } = await fetchEnvelopeRange(
+        client,
+        folder,
+        `${cursor + 1}:*`,
+        MAX_NEW_PER_SYNC,
+      );
+      // `uid:N:*` always returns at least the highest existing UID even when
+      // nothing is newer, so drop anything at or below the cursor.
+      const fresh = rows.filter((row) => Number(row.uid) > cursor);
+      return { rows: fresh, highestUid: Math.max(highestUid, cursor), uidValidity, modseq, reset };
+    }
+
+    // Cold start (or uidvalidity reset): newest `limit` messages.
+    const search = await client.search({ all: true }, { uid: true });
+    const uids = Array.isArray(search) ? search.slice().sort((a, b) => b - a) : [];
+    const pageUids = uids.slice(0, limit);
+    if (!pageUids.length) {
+      return { rows: [], highestUid: 0, uidValidity, modseq, reset };
+    }
+    const { rows, highestUid } = await fetchEnvelopeRange(
+      client,
       folder,
-      synced: parsedMessages.length,
-    };
+      pageUids.slice().sort((a, b) => a - b).join(','),
+      limit,
+    );
+    return { rows, highestUid, uidValidity, modseq, reset };
   });
+
+  if (result.reset) {
+    await resetFolderCache(accountId, folder);
+  }
+
+  await mergeMessagesIntoCache(accountId, result.rows, folder, result.highestUid);
+  await setSyncState(accountId, folder, {
+    uidValidity: result.uidValidity,
+    highestModseq: result.modseq,
+  });
+
+  const reconciled = await reconcileFolder(accountId, folder, {
+    changedSince: result.reset ? '' : state.highestModseq,
+  });
+
+  return {
+    messages: result.rows,
+    total: await countCachedMessages(accountId, folder),
+    folder,
+    synced: result.rows.length,
+    reconciled,
+    uidValidityReset: result.reset,
+  };
+}
+
+/**
+ * FLAGS-only pass over the visible window — picks up reads, stars, deletes and
+ * moves performed in another mail client, which previously drifted silently.
+ *
+ * @param {string} accountId
+ * @param {string} folder
+ * @param {{ window?: number, changedSince?: string }} [options]
+ */
+export async function reconcileFolder(accountId, folder, options = {}) {
+  const windowUids = await listCachedUids(
+    accountId,
+    folder,
+    Number(options.window) || FLAGS_RECONCILE_WINDOW,
+  );
+  if (!windowUids.length) {
+    return { updated: 0, removed: 0, checked: 0 };
+  }
+
+  const serverFlags = await withMailbox(accountId, folder, async (client) => {
+    // When the server advertises CONDSTORE and its HIGHESTMODSEQ has not moved
+    // since the last pass, nothing in the folder changed — skip the fetch
+    // entirely. A plain FLAGS fetch already reports both flags and existence,
+    // so `changedSince` buys nothing beyond this early-out.
+    const modseq = client.mailbox?.highestModseq ? String(client.mailbox.highestModseq) : '';
+    if (
+      client.enabled?.has?.('CONDSTORE') &&
+      options.changedSince &&
+      modseq &&
+      modseq === String(options.changedSince)
+    ) {
+      return null;
+    }
+    return fetchFlagsForUids(client, windowUids);
+  });
+
+  if (!serverFlags) {
+    return { updated: 0, removed: 0, checked: 0, skipped: 'unchanged_modseq' };
+  }
+
+  const applied = await reconcileFolderFlags(accountId, folder, serverFlags, windowUids);
+  return { ...applied, checked: windowUids.length };
+}
+
+/**
+ * Download and cache the full body (and attachment metadata) for one message.
+ * Called on first open — sync itself only stores headers + a text preview.
+ *
+ * @param {string} accountId
+ * @param {string} messageKey
+ * @param {{ force?: boolean }} [options]
+ */
+export async function ensureMessageBody(accountId, messageKey, options = {}) {
+  const message = await getCachedMessage(accountId, messageKey);
+  if (!message) {
+    throw new Error('Cached message not found');
+  }
+
+  if (!options.force) {
+    const cached = await getCachedBody(accountId, messageKey);
+    if (cached?.complete) {
+      return { ...message, bodyText: cached.bodyText, bodyHtml: cached.bodyHtml, cached: true };
+    }
+  }
+
+  const folder = String(message.folder ?? 'INBOX');
+  const uid = Number(message.uid);
+  if (!Number.isFinite(uid)) {
+    throw new Error('Message uid is invalid');
+  }
+
+  const source = await withMailbox(accountId, folder, async (client) => {
+    const downloaded = await client.fetchOne(String(uid), { uid: true, source: true }, { uid: true });
+    if (!downloaded?.source) {
+      return null;
+    }
+    return Buffer.isBuffer(downloaded.source)
+      ? downloaded.source
+      : Buffer.from(String(downloaded.source));
+  });
+
+  if (!source) {
+    throw new Error('Message source unavailable on the server');
+  }
+
+  const parsed = await parseRawMessage(source, { uid, folder, flags: [] });
+  const updated = await saveCachedBody(accountId, messageKey, {
+    bodyText: parsed.bodyText,
+    bodyHtml: parsed.bodyHtml,
+    bodyHash: parsed.bodyHash,
+    attachments: parsed.attachments,
+    complete: true,
+  });
+
+  return { ...updated, cached: false };
 }

--- a/server/email/mail-actions.js
+++ b/server/email/mail-actions.js
@@ -7,7 +7,16 @@ import {
   deleteImapMessage,
   moveImapMessage,
   setImapMessageFlags,
+  setImapMessageFlagsBulk,
 } from './imap-actions.js';
+
+/** Bulk actions that collapse to one STORE per folder. */
+const BULK_FLAG_ACTIONS = {
+  read: { seen: true },
+  unread: { seen: false },
+  flag: { flagged: true },
+  unflag: { flagged: false },
+};
 
 /**
  * @param {string} accountId
@@ -59,19 +68,18 @@ export async function bulkMessageAction(accountId, input) {
   }
 
   const action = String(input.action ?? '').trim().toLowerCase();
+
+  if (BULK_FLAG_ACTIONS[action]) {
+    const results = await setImapMessageFlagsBulk(accountId, ids, BULK_FLAG_ACTIONS[action]);
+    const failed = results.filter((row) => row.ok === false);
+    return { ok: failed.length === 0, results, failed: failed.length };
+  }
+
   const results = [];
 
   for (const messageKey of ids) {
     try {
-      if (action === 'read') {
-        results.push({ id: messageKey, ...(await setMessageFlags(accountId, messageKey, { seen: true })) });
-      } else if (action === 'unread') {
-        results.push({ id: messageKey, ...(await setMessageFlags(accountId, messageKey, { seen: false })) });
-      } else if (action === 'flag') {
-        results.push({ id: messageKey, ...(await setMessageFlags(accountId, messageKey, { flagged: true })) });
-      } else if (action === 'unflag') {
-        results.push({ id: messageKey, ...(await setMessageFlags(accountId, messageKey, { flagged: false })) });
-      } else if (action === 'archive') {
+      if (action === 'archive') {
         results.push({ id: messageKey, ...(await archiveMessage(accountId, messageKey)) });
       } else if (action === 'delete') {
         results.push({ id: messageKey, ...(await deleteMessage(accountId, messageKey)) });

--- a/server/email/middleware.js
+++ b/server/email/middleware.js
@@ -11,9 +11,15 @@ import {
   redactAccount,
   updateEmailAccount,
 } from './accounts.js';
-import { listCachedMessages, listCachedThread, readMessageCache } from './cache.js';
+import {
+  listCachedMessages,
+  listCachedThread,
+  listCachedThreads,
+  searchCachedMessages,
+} from './cache.js';
 import {
   listEmailFolders,
+  loadMessageBody,
   syncFolderMessages,
   testEmailConnection,
 } from './transport.js';
@@ -27,11 +33,8 @@ import {
   deleteMessage,
   bulkMessageAction,
 } from './mail-actions.js';
-import {
-  getOrBuildInboxSummary,
-  generateReplyVariants,
-  runAgentHooksAfterFolderSync,
-} from './agent.js';
+import { getOrBuildInboxSummary, generateReplyVariants } from './agent.js';
+import { syncFolderWithHooks } from './poller.js';
 import { handleEmailEventsSse } from './events.js';
 import {
   listAutomations,
@@ -145,6 +148,38 @@ export function createEmailMiddleware() {
         }
       }
 
+      if (url === '/api/email/search' && req.method === 'GET') {
+        const params = parseQuery(req.url ?? '');
+        const query = String(params.get('q') ?? params.get('query') ?? '').trim();
+        if (!query) {
+          sendJson(res, 400, { error: 'q is required' });
+          return;
+        }
+        const offset = Number(params.get('offset') ?? 0);
+        const limit = Number(params.get('limit') ?? 50);
+        const folder = params.get('folder') ?? undefined;
+        const accountId = String(params.get('accountId') ?? '').trim();
+
+        const accountIds = accountId
+          ? [accountId]
+          : (await listEmailAccounts()).map((account) => account.id);
+
+        const perAccount = await Promise.all(
+          accountIds.map(async (id) => {
+            const result = await searchCachedMessages(id, { query, folder, offset, limit });
+            return result.messages.map((message) => ({ ...message, accountId: id }));
+          }),
+        );
+
+        const messages = perAccount
+          .flat()
+          .sort((a, b) => new Date(String(b.date)).getTime() - new Date(String(a.date)).getTime())
+          .slice(0, Math.min(200, Math.max(1, limit || 50)));
+
+        sendJson(res, 200, { messages, total: messages.length, query });
+        return;
+      }
+
       if (url === '/api/email/messages/bulk' && req.method === 'POST') {
         const body = await readJsonBody(req);
         const accountId = String(body.accountId ?? '').trim();
@@ -222,11 +257,23 @@ export function createEmailMiddleware() {
           const body = await readJsonBody(req);
           const account = await getEmailAccount(accountId);
           const folder = String(body.folder ?? account?.folders?.[0] ?? 'INBOX');
-          const before = await readMessageCache(accountId);
-          const prevHighest = before.folderCursors?.[folder]?.highestUid ?? 0;
-          const result = await syncFolderMessages(accountId, body);
-          const incoming = Array.isArray(result.messages) ? result.messages : [];
-          await runAgentHooksAfterFolderSync(accountId, folder, incoming, prevHighest);
+          const result = await syncFolderWithHooks(accountId, folder, {
+            limit: body.limit,
+            full: body.full === true,
+          });
+          sendJson(res, 200, result);
+          return;
+        }
+
+        if (tail === 'threads' && req.method === 'GET') {
+          const params = parseQuery(req.url ?? '');
+          const result = await listCachedThreads(accountId, {
+            folder: params.get('folder') ?? undefined,
+            offset: Number(params.get('offset') ?? 0),
+            limit: Number(params.get('limit') ?? 50),
+            filter: params.get('filter') ?? undefined,
+            query: params.get('query') ?? undefined,
+          });
           sendJson(res, 200, result);
           return;
         }
@@ -248,6 +295,22 @@ export function createEmailMiddleware() {
           sendJson(res, 200, { account: redactAccount(account) });
           return;
         }
+      }
+
+      const bodyMatch = url.match(/^\/api\/email\/messages\/([^/]+)\/body$/);
+      if (bodyMatch && req.method === 'GET') {
+        const messageKey = decodeURIComponent(bodyMatch[1]);
+        const params = parseQuery(req.url ?? '');
+        const accountId = String(params.get('accountId') ?? '').trim();
+        if (!accountId) {
+          sendJson(res, 400, { error: 'accountId query param is required' });
+          return;
+        }
+        const message = await loadMessageBody(accountId, messageKey, {
+          force: params.get('force') === '1',
+        });
+        sendJson(res, 200, { message });
+        return;
       }
 
       const triageMatch = url.match(/^\/api\/email\/messages\/([^/]+)\/triage$/);

--- a/server/email/paths.js
+++ b/server/email/paths.js
@@ -30,6 +30,12 @@ export function emailCacheMessagesPath(accountId) {
   return path.join(emailCacheDir(accountId), 'messages.json');
 }
 
+/** SQLite mail store for one account (~/.minnow/email/mail-<accountId>.db). */
+export function emailDbPath(accountId) {
+  const slug = String(accountId ?? '').trim().replace(/[^A-Za-z0-9._-]/g, '_') || 'account';
+  return path.join(emailRootDir(), `mail-${slug}.db`);
+}
+
 /** Automation rules registry. */
 export function emailAutomationsPath() {
   return path.join(emailRootDir(), 'automations.json');

--- a/server/email/poller.js
+++ b/server/email/poller.js
@@ -1,14 +1,26 @@
 /**
- * Opt-in background email polling with agent hooks on new mail.
+ * Background email sync — IMAP IDLE push with an interval poller as fallback.
+ *
+ * IDLE carries the real-time load (new mail lands within seconds); the poller
+ * stays because some servers advertise IDLE and then never notify.
  */
 
 import { listEmailAccounts } from './accounts.js';
-import { readMessageCache } from './cache.js';
+import { getSyncState } from './cache.js';
 import { syncFolderMessages } from './transport.js';
 import { runAgentHooksAfterFolderSync } from './agent.js';
+import {
+  closeAllImapSessions,
+  startIdleWatcher,
+  stopAllIdleWatchers,
+  stopIdleWatcher,
+} from './imap-session.js';
 
 /** Minimum interval between poll ticks. */
 export const POLL_TICK_MS = 60_000;
+
+/** Debounce window for IDLE-triggered syncs (servers fire bursts). */
+export const IDLE_DEBOUNCE_MS = 2_000;
 
 /** @type {Map<string, number>} */
 const lastPolledAt = new Map();
@@ -17,6 +29,29 @@ const lastPolledAt = new Map();
 let pollTimer = null;
 
 let polling = false;
+
+/** @type {Map<string, NodeJS.Timeout>} */
+const idleDebounce = new Map();
+
+/**
+ * Sync one folder and run the agent hooks for genuinely new mail.
+ * @param {string} accountId
+ * @param {string} folder
+ * @param {{ background?: boolean, limit?: number, full?: boolean }} [options]
+ */
+export async function syncFolderWithHooks(accountId, folder, options = {}) {
+  const before = await getSyncState(accountId, folder);
+  const result = await syncFolderMessages(accountId, {
+    folder,
+    limit: options.limit ?? 50,
+    full: options.full === true,
+  });
+  const incoming = Array.isArray(result.messages) ? result.messages : [];
+  await runAgentHooksAfterFolderSync(accountId, folder, incoming, before.highestUid, {
+    background: options.background === true,
+  });
+  return result;
+}
 
 /**
  * Poll all accounts with pollingEnabled.
@@ -34,8 +69,11 @@ export async function runEmailPollTick() {
 
     for (const account of accounts) {
       if (!account.pollingEnabled) {
+        await stopIdleWatcher(account.id).catch(() => {});
         continue;
       }
+
+      await ensureIdleWatcher(account.id);
 
       const intervalMs = Math.max(5, account.pollingIntervalMinutes ?? 15) * 60_000;
       const last = lastPolledAt.get(account.id) ?? 0;
@@ -45,16 +83,8 @@ export async function runEmailPollTick() {
 
       for (const folder of account.folders ?? ['INBOX']) {
         try {
-          const before = await readMessageCache(account.id);
-          const prevHighest = before.folderCursors?.[folder]?.highestUid ?? 0;
-
-          const result = await syncFolderMessages(account.id, { folder, limit: 50 });
+          await syncFolderWithHooks(account.id, folder, { background: true });
           synced += 1;
-
-          const incoming = Array.isArray(result.messages) ? result.messages : [];
-          await runAgentHooksAfterFolderSync(account.id, folder, incoming, prevHighest, {
-            background: true,
-          });
         } catch (err) {
           console.warn(
             `[email] poll failed for ${account.id}/${folder}:`,
@@ -73,25 +103,84 @@ export async function runEmailPollTick() {
 }
 
 /**
+ * Start an INBOX IDLE watcher for an account (no-op if already watching or if
+ * the server refuses the connection — the poller still covers that account).
+ * @param {string} accountId
+ */
+export async function ensureIdleWatcher(accountId) {
+  try {
+    await startIdleWatcher(accountId, ({ folder }) => {
+      scheduleIdleSync(accountId, folder);
+    });
+    return { watching: true };
+  } catch (err) {
+    console.warn(
+      `[email] IDLE unavailable for ${accountId} (falling back to polling):`,
+      err instanceof Error ? err.message : err,
+    );
+    return { watching: false };
+  }
+}
+
+/** Open IDLE watchers for every polling-enabled account. */
+export async function startIdleWatchersForEnabledAccounts() {
+  const accounts = await listEmailAccounts();
+  for (const account of accounts) {
+    if (account.pollingEnabled) {
+      await ensureIdleWatcher(account.id);
+    }
+  }
+}
+
+/** Coalesce an IDLE burst into a single sync pass. */
+function scheduleIdleSync(accountId, folder) {
+  const key = `${accountId}\0${folder}`;
+  const pending = idleDebounce.get(key);
+  if (pending) {
+    clearTimeout(pending);
+  }
+  const timer = setTimeout(() => {
+    idleDebounce.delete(key);
+    void syncFolderWithHooks(accountId, folder, { background: true }).catch((err) => {
+      console.warn(
+        `[email] IDLE sync failed for ${accountId}/${folder}:`,
+        err instanceof Error ? err.message : err,
+      );
+    });
+  }, IDLE_DEBOUNCE_MS);
+  timer.unref?.();
+  idleDebounce.set(key, timer);
+}
+
+/**
  * Start the email poll loop after server bootstrap.
  */
 export function startEmailPollLoop() {
   if (pollTimer) {
     return;
   }
+  // Bring IDLE up at boot rather than waiting a full tick for push to start.
+  void startIdleWatchersForEnabledAccounts().catch(() => {});
   pollTimer = setInterval(() => {
     void runEmailPollTick().catch((err) => {
       console.warn('[email] poll tick failed:', err instanceof Error ? err.message : err);
     });
   }, POLL_TICK_MS);
+  pollTimer.unref?.();
 }
 
-/** Stop polling (shutdown). */
+/** Stop polling and IDLE watchers (shutdown). */
 export function stopEmailPollLoop() {
   if (pollTimer) {
     clearInterval(pollTimer);
     pollTimer = null;
   }
+  for (const timer of idleDebounce.values()) {
+    clearTimeout(timer);
+  }
+  idleDebounce.clear();
+  void stopAllIdleWatchers().catch(() => {});
+  void closeAllImapSessions().catch(() => {});
 }
 
 /** Reset poll state (tests). */

--- a/server/email/store.js
+++ b/server/email/store.js
@@ -1,0 +1,468 @@
+/**
+ * SQLite mail store for one email account (~/.minnow/email/mail-<accountId>.db).
+ * Modelled on server/brain/code/schema.js (WAL + cached handle per key).
+ *
+ * `message_row_id` is the stable primary key: moves rewrite `folder`/`uid`, but
+ * the row — and the triage/variants/bodies hanging off it — survive (MIN-350 D4).
+ * WAL + one write path per account ends the read-modify-write races (D5).
+ */
+
+import fs from 'node:fs';
+import Database from 'better-sqlite3';
+import { emailDbPath, emailRootDir } from './paths.js';
+import { getMinnowHome } from '../config/home.js';
+
+/** @type {Map<string, import('better-sqlite3').Database>} */
+const dbByCacheKey = new Map();
+
+/** LRU order for open handles — oldest at index 0. */
+const dbCacheLru = [];
+
+/** Cap open handles so many accounts do not leak file descriptors. */
+export const MAX_OPEN_MAIL_DBS = 8;
+
+/** Bump when a migration needs an FTS rebuild (stored in PRAGMA user_version). */
+export const MAIL_SCHEMA_VERSION = 1;
+
+/**
+ * @param {import('better-sqlite3').Database} database
+ */
+function initSchema(database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS messages (
+      message_row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT NOT NULL UNIQUE,
+      folder TEXT NOT NULL,
+      uid TEXT NOT NULL,
+      message_id TEXT NOT NULL DEFAULT '',
+      thread_id TEXT NOT NULL DEFAULT '',
+      from_addr TEXT NOT NULL DEFAULT '',
+      to_json TEXT NOT NULL DEFAULT '[]',
+      reply_to TEXT NOT NULL DEFAULT '',
+      subject TEXT NOT NULL DEFAULT '',
+      date TEXT NOT NULL DEFAULT '',
+      date_ms INTEGER NOT NULL DEFAULT 0,
+      body_preview TEXT NOT NULL DEFAULT '',
+      body_hash TEXT NOT NULL DEFAULT '',
+      has_attachments INTEGER NOT NULL DEFAULT 0,
+      in_reply_to TEXT NOT NULL DEFAULT '',
+      references_json TEXT NOT NULL DEFAULT '[]',
+      seen INTEGER NOT NULL DEFAULT 0,
+      flagged INTEGER NOT NULL DEFAULT 0,
+      answered INTEGER NOT NULL DEFAULT 0,
+      triage_json TEXT,
+      reply_variants_json TEXT,
+      UNIQUE (folder, uid)
+    );
+
+    CREATE TABLE IF NOT EXISTS bodies (
+      message_row_id INTEGER PRIMARY KEY
+        REFERENCES messages(message_row_id) ON DELETE CASCADE,
+      body_text TEXT NOT NULL DEFAULT '',
+      body_html TEXT,
+      complete INTEGER NOT NULL DEFAULT 0,
+      fetched_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS attachments (
+      message_row_id INTEGER NOT NULL
+        REFERENCES messages(message_row_id) ON DELETE CASCADE,
+      idx INTEGER NOT NULL,
+      filename TEXT NOT NULL DEFAULT 'attachment',
+      content_type TEXT NOT NULL DEFAULT 'application/octet-stream',
+      size INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (message_row_id, idx)
+    );
+
+    CREATE TABLE IF NOT EXISTS threads (
+      thread_id TEXT PRIMARY KEY,
+      subject TEXT NOT NULL DEFAULT '',
+      participants_json TEXT NOT NULL DEFAULT '[]',
+      message_count INTEGER NOT NULL DEFAULT 0,
+      unread_count INTEGER NOT NULL DEFAULT 0,
+      flagged INTEGER NOT NULL DEFAULT 0,
+      has_attachments INTEGER NOT NULL DEFAULT 0,
+      last_date TEXT NOT NULL DEFAULT '',
+      last_date_ms INTEGER NOT NULL DEFAULT 0,
+      folders_json TEXT NOT NULL DEFAULT '[]',
+      snippet TEXT NOT NULL DEFAULT '',
+      summary TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS sync_state (
+      folder TEXT PRIMARY KEY,
+      uid_validity TEXT NOT NULL DEFAULT '',
+      highest_uid INTEGER NOT NULL DEFAULT 0,
+      highest_modseq TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS contacts (
+      address TEXT PRIMARY KEY,
+      name TEXT NOT NULL DEFAULT '',
+      seen_count INTEGER NOT NULL DEFAULT 0,
+      replied_count INTEGER NOT NULL DEFAULT 0,
+      last_seen_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS outbox (
+      id TEXT PRIMARY KEY,
+      payload_json TEXT NOT NULL DEFAULT '{}',
+      dispatch_at TEXT NOT NULL DEFAULT '',
+      state TEXT NOT NULL DEFAULT 'pending',
+      error TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS automation_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      rule_id TEXT NOT NULL DEFAULT '',
+      message_row_id INTEGER,
+      action TEXT NOT NULL DEFAULT '',
+      outcome TEXT NOT NULL DEFAULT '',
+      detail TEXT NOT NULL DEFAULT '',
+      ran_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_messages_folder_date ON messages(folder, date_ms DESC);
+    CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id);
+    CREATE INDEX IF NOT EXISTS idx_messages_date ON messages(date_ms DESC);
+    CREATE INDEX IF NOT EXISTS idx_messages_message_id ON messages(message_id);
+    CREATE INDEX IF NOT EXISTS idx_automation_runs_rule ON automation_runs(rule_id);
+  `);
+
+  migrateMessagesFts(database);
+}
+
+/** FTS5 mirror over subject/from/body — replaces the substring scan (D10). */
+function createMessagesFtsTable(database) {
+  database.exec(`
+    CREATE VIRTUAL TABLE messages_fts USING fts5(
+      message_row_id UNINDEXED,
+      subject,
+      from_addr,
+      body,
+      tokenize='porter unicode61'
+    );
+  `);
+}
+
+/**
+ * @param {import('better-sqlite3').Database} database
+ */
+function migrateMessagesFts(database) {
+  const version = database.pragma('user_version', { simple: true });
+  const ftsExists = database
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'")
+    .get();
+
+  if (version >= MAIL_SCHEMA_VERSION) {
+    if (!ftsExists) createMessagesFtsTable(database);
+    return;
+  }
+
+  const tx = database.transaction(() => {
+    if (ftsExists) {
+      database.exec('DROP TABLE messages_fts');
+    }
+    createMessagesFtsTable(database);
+    database.exec(`
+      INSERT INTO messages_fts (message_row_id, subject, from_addr, body)
+      SELECT m.message_row_id, m.subject, m.from_addr,
+             COALESCE(b.body_text, m.body_preview)
+      FROM messages m LEFT JOIN bodies b USING (message_row_id);
+    `);
+    database.pragma(`user_version = ${MAIL_SCHEMA_VERSION}`);
+  });
+  tx();
+}
+
+/** Cache key includes MINNOW_HOME so parallel tests never share a handle. */
+function mailDbCacheKey(accountId) {
+  return `${getMinnowHome()}\0${String(accountId ?? '')}`;
+}
+
+function touchMailDbCache(cacheKey) {
+  const idx = dbCacheLru.indexOf(cacheKey);
+  if (idx >= 0) dbCacheLru.splice(idx, 1);
+  dbCacheLru.push(cacheKey);
+}
+
+function evictOldestMailDbIfNeeded() {
+  while (dbCacheLru.length >= MAX_OPEN_MAIL_DBS) {
+    const oldest = dbCacheLru.shift();
+    if (!oldest) break;
+    const db = dbByCacheKey.get(oldest);
+    if (db) {
+      db.close();
+      dbByCacheKey.delete(oldest);
+    }
+  }
+}
+
+/**
+ * Open (or reuse) the mail store for an account.
+ * @param {string} accountId
+ * @returns {import('better-sqlite3').Database}
+ */
+export function getMailDb(accountId) {
+  const key = String(accountId ?? '').trim();
+  if (!key) {
+    throw new Error('accountId is required');
+  }
+  const cacheKey = mailDbCacheKey(key);
+  const existing = dbByCacheKey.get(cacheKey);
+  if (existing) {
+    touchMailDbCache(cacheKey);
+    return existing;
+  }
+
+  evictOldestMailDbIfNeeded();
+
+  fs.mkdirSync(emailRootDir(), { recursive: true });
+  const db = new Database(emailDbPath(key));
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.pragma('busy_timeout = 5000');
+  initSchema(db);
+  dbByCacheKey.set(cacheKey, db);
+  touchMailDbCache(cacheKey);
+  return db;
+}
+
+/** Close all open mail store handles (tests, shutdown). */
+export function closeMailDbs() {
+  for (const db of dbByCacheKey.values()) {
+    db.close();
+  }
+  dbByCacheKey.clear();
+  dbCacheLru.length = 0;
+}
+
+/** Close the handle for one account without touching the others. */
+export function closeMailDb(accountId) {
+  const cacheKey = mailDbCacheKey(String(accountId ?? '').trim());
+  const db = dbByCacheKey.get(cacheKey);
+  if (!db) return false;
+  db.close();
+  dbByCacheKey.delete(cacheKey);
+  const idx = dbCacheLru.indexOf(cacheKey);
+  if (idx >= 0) dbCacheLru.splice(idx, 1);
+  return true;
+}
+
+/**
+ * Close and delete the mail store for one account (.db / -wal / -shm).
+ * @param {string} accountId
+ */
+export function deleteMailDb(accountId) {
+  closeMailDb(accountId);
+  const base = emailDbPath(accountId);
+  let removed = false;
+  for (const suffix of ['', '-wal', '-shm']) {
+    const filePath = `${base}${suffix}`;
+    if (fs.existsSync(filePath)) {
+      fs.rmSync(filePath, { force: true });
+      if (!suffix) removed = true;
+    }
+  }
+  return removed;
+}
+
+/** Test helper — count of open in-memory handles. */
+export function openMailDbCountForTests() {
+  return dbByCacheKey.size;
+}
+
+// ---------------------------------------------------------------------------
+// Row <-> message serialization
+// ---------------------------------------------------------------------------
+
+function parseJson(raw, fallback) {
+  if (typeof raw !== 'string' || !raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Convert a `messages` row (optionally joined with bodies) to the cache message
+ * shape the rest of server/email and the UI already consume.
+ * @param {Record<string, any>} row
+ * @param {{ attachments?: Array<Record<string, unknown>> }} [extra]
+ */
+export function rowToMessage(row, extra = {}) {
+  if (!row) return null;
+  /** @type {Record<string, unknown>} */
+  const message = {
+    id: row.id,
+    messageRowId: row.message_row_id,
+    uid: String(row.uid),
+    messageId: row.message_id ?? '',
+    threadId: row.thread_id ?? '',
+    folder: row.folder,
+    from: row.from_addr ?? '',
+    to: parseJson(row.to_json, []),
+    replyTo: row.reply_to ?? '',
+    subject: row.subject ?? '',
+    date: row.date ?? '',
+    bodyPreview: row.body_preview ?? '',
+    bodyHash: row.body_hash ?? '',
+    hasAttachments: Boolean(row.has_attachments),
+    attachments: extra.attachments ?? [],
+    inReplyTo: row.in_reply_to ?? '',
+    references: parseJson(row.references_json, []),
+    flags: {
+      seen: Boolean(row.seen),
+      flagged: Boolean(row.flagged),
+      answered: Boolean(row.answered),
+    },
+  };
+
+  if (row.body_text !== undefined && row.body_text !== null) {
+    message.bodyText = row.body_text;
+  }
+  if (row.body_html !== undefined && row.body_html !== null) {
+    message.bodyHtml = row.body_html;
+  }
+  if (row.triage_json) {
+    message.triage = parseJson(row.triage_json, undefined);
+  }
+  if (row.reply_variants_json) {
+    message.replyVariants = parseJson(row.reply_variants_json, undefined);
+  }
+  return message;
+}
+
+/** Load attachment metadata rows for a set of message row ids. */
+export function loadAttachments(db, messageRowIds) {
+  /** @type {Map<number, Array<Record<string, unknown>>>} */
+  const byRow = new Map();
+  if (!messageRowIds.length) return byRow;
+  const placeholders = messageRowIds.map(() => '?').join(',');
+  const rows = db
+    .prepare(
+      `SELECT message_row_id, idx, filename, content_type, size
+       FROM attachments WHERE message_row_id IN (${placeholders}) ORDER BY idx`,
+    )
+    .all(...messageRowIds);
+  for (const row of rows) {
+    if (!byRow.has(row.message_row_id)) byRow.set(row.message_row_id, []);
+    byRow.get(row.message_row_id).push({
+      filename: row.filename,
+      contentType: row.content_type,
+      size: row.size,
+    });
+  }
+  return byRow;
+}
+
+/** Attach `attachments` arrays to a batch of rows in one query. */
+export function hydrateAttachments(db, rows) {
+  const ids = rows.map((row) => row.message_row_id).filter((id) => Number.isFinite(id));
+  const byRow = loadAttachments(db, ids);
+  return rows.map((row) => rowToMessage(row, { attachments: byRow.get(row.message_row_id) ?? [] }));
+}
+
+/** Refresh the FTS mirror for one message. */
+export function reindexMessageFts(db, messageRowId) {
+  const row = db
+    .prepare(
+      `SELECT m.message_row_id, m.subject, m.from_addr,
+              COALESCE(b.body_text, m.body_preview) AS body
+       FROM messages m LEFT JOIN bodies b USING (message_row_id)
+       WHERE m.message_row_id = ?`,
+    )
+    .get(messageRowId);
+  db.prepare('DELETE FROM messages_fts WHERE message_row_id = ?').run(messageRowId);
+  if (!row) return;
+  db.prepare(
+    'INSERT INTO messages_fts (message_row_id, subject, from_addr, body) VALUES (?, ?, ?, ?)',
+  ).run(row.message_row_id, row.subject ?? '', row.from_addr ?? '', row.body ?? '');
+}
+
+/**
+ * Recompute the materialized `threads` rollup for one thread id.
+ * Called inside the caller's transaction after message writes.
+ */
+export function recomputeThread(db, threadId) {
+  const id = String(threadId ?? '');
+  if (!id) return;
+  const rows = db
+    .prepare(
+      `SELECT folder, subject, from_addr, date, date_ms, seen, flagged,
+              has_attachments, body_preview
+       FROM messages WHERE thread_id = ? ORDER BY date_ms ASC`,
+    )
+    .all(id);
+
+  if (!rows.length) {
+    db.prepare('DELETE FROM threads WHERE thread_id = ?').run(id);
+    return;
+  }
+
+  const last = rows[rows.length - 1];
+  const participants = [];
+  const folders = [];
+  for (const row of rows) {
+    if (row.from_addr && !participants.includes(row.from_addr)) participants.push(row.from_addr);
+    if (row.folder && !folders.includes(row.folder)) folders.push(row.folder);
+  }
+
+  db.prepare(
+    `INSERT INTO threads (
+       thread_id, subject, participants_json, message_count, unread_count,
+       flagged, has_attachments, last_date, last_date_ms, folders_json, snippet
+     ) VALUES (
+       @thread_id, @subject, @participants_json, @message_count, @unread_count,
+       @flagged, @has_attachments, @last_date, @last_date_ms, @folders_json, @snippet
+     )
+     ON CONFLICT(thread_id) DO UPDATE SET
+       subject = excluded.subject,
+       participants_json = excluded.participants_json,
+       message_count = excluded.message_count,
+       unread_count = excluded.unread_count,
+       flagged = excluded.flagged,
+       has_attachments = excluded.has_attachments,
+       last_date = excluded.last_date,
+       last_date_ms = excluded.last_date_ms,
+       folders_json = excluded.folders_json,
+       snippet = excluded.snippet`,
+  ).run({
+    thread_id: id,
+    subject: rows.find((row) => row.subject)?.subject ?? '',
+    participants_json: JSON.stringify(participants),
+    message_count: rows.length,
+    unread_count: rows.filter((row) => !row.seen).length,
+    flagged: rows.some((row) => row.flagged) ? 1 : 0,
+    has_attachments: rows.some((row) => row.has_attachments) ? 1 : 0,
+    last_date: last.date ?? '',
+    last_date_ms: last.date_ms ?? 0,
+    folders_json: JSON.stringify(folders),
+    snippet: last.body_preview ?? '',
+  });
+}
+
+/** Read a `meta` value as JSON. */
+export function readMeta(db, key, fallback = null) {
+  const row = db.prepare('SELECT value FROM meta WHERE key = ?').get(key);
+  return row ? parseJson(row.value, fallback) : fallback;
+}
+
+/** Write a `meta` value as JSON. */
+export function writeMeta(db, key, value) {
+  if (value === undefined || value === null) {
+    db.prepare('DELETE FROM meta WHERE key = ?').run(key);
+    return;
+  }
+  db.prepare(
+    'INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+  ).run(key, JSON.stringify(value));
+}

--- a/server/email/transport.js
+++ b/server/email/transport.js
@@ -34,3 +34,18 @@ export async function syncFolderMessages(accountId, options = {}) {
   }
   return imap.syncFolderMessages(accountId, options);
 }
+
+/**
+ * Download the full body for a message on first open (sync stores headers +
+ * a text preview only).
+ * @param {string} accountId
+ * @param {string} messageKey
+ * @param {{ force?: boolean }} [options]
+ */
+export async function loadMessageBody(accountId, messageKey, options = {}) {
+  const account = await getEmailAccount(accountId);
+  if (!account) {
+    throw new Error('Email account not found');
+  }
+  return imap.ensureMessageBody(accountId, messageKey, options);
+}

--- a/src/email/client.ts
+++ b/src/email/client.ts
@@ -186,6 +186,72 @@ export async function fetchEmailThread(
   return parseJson(res);
 }
 
+export interface EmailThreadSummary {
+  threadId: string;
+  subject: string;
+  participants: string[];
+  messageCount: number;
+  unreadCount: number;
+  flagged: boolean;
+  hasAttachments: boolean;
+  lastDate: string;
+  folders: string[];
+  snippet: string;
+  summary: string | null;
+}
+
+/** Conversation rollups for the thread list. */
+export async function fetchEmailThreads(
+  accountId: string,
+  query?: { folder?: string; offset?: number; limit?: number; filter?: string; query?: string },
+): Promise<{ threads: EmailThreadSummary[]; total: number }> {
+  const params = new URLSearchParams();
+  if (query?.folder) params.set('folder', query.folder);
+  if (query?.offset !== undefined) params.set('offset', String(query.offset));
+  if (query?.limit !== undefined) params.set('limit', String(query.limit));
+  if (query?.filter) params.set('filter', query.filter);
+  if (query?.query) params.set('query', query.query);
+  const qs = params.toString();
+  const res = await fetch(
+    `/api/email/accounts/${encodeURIComponent(accountId)}/threads${qs ? `?${qs}` : ''}`,
+  );
+  return parseJson(res);
+}
+
+/** Full-text search across folders (all accounts when accountId is omitted). */
+export async function searchEmail(query: {
+  q: string;
+  accountId?: string;
+  folder?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<{ messages: Array<EmailMessage & { accountId: string }>; total: number }> {
+  const params = new URLSearchParams({ q: query.q });
+  if (query.accountId) params.set('accountId', query.accountId);
+  if (query.folder) params.set('folder', query.folder);
+  if (query.limit !== undefined) params.set('limit', String(query.limit));
+  if (query.offset !== undefined) params.set('offset', String(query.offset));
+  const res = await fetch(`/api/email/search?${params.toString()}`);
+  return parseJson(res);
+}
+
+/**
+ * Load the full body for a message. Sync stores headers plus a text preview,
+ * so the HTML part arrives on first open.
+ */
+export async function fetchEmailMessageBody(
+  accountId: string,
+  messageId: string,
+  options?: { force?: boolean },
+): Promise<{ message: EmailMessage }> {
+  const params = new URLSearchParams({ accountId });
+  if (options?.force) params.set('force', '1');
+  const res = await fetch(
+    `/api/email/messages/${encodeURIComponent(messageId)}/body?${params.toString()}`,
+  );
+  return parseJson(res);
+}
+
 export async function triageEmailMessage(
   accountId: string,
   messageId: string,

--- a/test/email/agent-triage-failure.test.mjs
+++ b/test/email/agent-triage-failure.test.mjs
@@ -12,6 +12,7 @@ import {
   readMessageCache,
   writeMessageCache,
 } from '../../server/email/cache.js';
+import { closeMailDbs } from '../../server/email/store.js';
 
 const ACCOUNT_ID = 'acct-triage-failure-test';
 const MESSAGE_KEY = 'INBOX:42';
@@ -46,6 +47,8 @@ before(async () => {
 });
 
 after(async () => {
+  // Windows will not unlink an open SQLite file.
+  closeMailDbs();
   if (savedHome === undefined) {
     delete process.env.MINNOW_HOME;
   } else {

--- a/test/email/incremental-sync.test.mjs
+++ b/test/email/incremental-sync.test.mjs
@@ -1,0 +1,385 @@
+/**
+ * Incremental IMAP sync — UID-range fetch, lazy bodies, flags reconcile (MIN-351).
+ *
+ * Run with --experimental-test-module-mocks (see test/run-all.mjs).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, beforeEach, describe, mock, test } from 'node:test';
+
+const ACCOUNT_ID = 'acct-incremental-sync';
+
+const ACCOUNT = {
+  id: ACCOUNT_ID,
+  username: 'me@example.com',
+  address: 'me@example.com',
+  folders: ['INBOX'],
+  imap: { host: 'imap.example.com', port: 993, tls: true },
+};
+
+let tempHome;
+let savedHome;
+
+/** Records every mailbox borrow so we can assert on connection reuse. */
+const borrows = [];
+
+/** Mutable fake server state, reset per test. */
+let server;
+
+function makeServer() {
+  return {
+    uidValidity: '100',
+    highestModseq: '50',
+    /** @type {Map<number, { flags: string[], headers: string, parts: Record<string, string>, structure: object }>} */
+    messages: new Map(),
+    fetchCalls: [],
+  };
+}
+
+function headerBlock({ subject, from, messageId, date, to = 'me@example.com' }) {
+  return [
+    `From: ${from}`,
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    `Message-ID: ${messageId}`,
+    `Date: ${date}`,
+    '',
+    '',
+  ].join('\r\n');
+}
+
+function seed(uid, overrides = {}) {
+  server.messages.set(uid, {
+    flags: overrides.flags ?? [],
+    headers: headerBlock({
+      subject: overrides.subject ?? `Message ${uid}`,
+      from: overrides.from ?? 'Alice <alice@example.com>',
+      messageId: overrides.messageId ?? `<msg-${uid}@example.com>`,
+      date: overrides.date ?? 'Wed, 01 Jul 2026 10:00:00 +0000',
+    }),
+    parts: overrides.parts ?? { 1: `Body text for message ${uid}.` },
+    structure: overrides.structure ?? { type: 'text/plain', part: '1', size: 40 },
+    source: overrides.source,
+  });
+}
+
+/** Parse an imapflow UID range string against the seeded uids. */
+function resolveRange(range) {
+  const uids = [...server.messages.keys()].sort((a, b) => a - b);
+  const out = new Set();
+  for (const chunk of String(range).split(',')) {
+    const [lo, hi] = chunk.split(':');
+    if (hi === '*') {
+      const from = Number(lo);
+      for (const uid of uids) if (uid >= from) out.add(uid);
+      // imapflow/RFC: `N:*` always yields at least the highest existing UID.
+      if (uids.length) out.add(uids[uids.length - 1]);
+    } else if (hi !== undefined) {
+      for (const uid of uids) if (uid >= Number(lo) && uid <= Number(hi)) out.add(uid);
+    } else if (server.messages.has(Number(lo))) {
+      out.add(Number(lo));
+    }
+  }
+  return [...out].sort((a, b) => a - b);
+}
+
+const fakeClient = {
+  get mailbox() {
+    return {
+      uidValidity: server.uidValidity,
+      highestModseq: server.highestModseq,
+      exists: server.messages.size,
+    };
+  },
+  enabled: new Set(),
+  async search() {
+    return [...server.messages.keys()];
+  },
+  async *fetch(range, query) {
+    server.fetchCalls.push({ range, query });
+    for (const uid of resolveRange(range)) {
+      const entry = server.messages.get(uid);
+      const row = { uid, flags: new Set(entry.flags) };
+      if (query.bodyStructure) row.bodyStructure = entry.structure;
+      if (query.headers) row.headers = Buffer.from(entry.headers);
+      yield row;
+    }
+  },
+  async fetchOne(uid, query) {
+    const entry = server.messages.get(Number(uid));
+    if (!entry) return null;
+    if (query.source) {
+      return { uid: Number(uid), source: Buffer.from(entry.source ?? '') };
+    }
+    const bodyParts = new Map();
+    for (const part of query.bodyParts ?? []) {
+      if (entry.parts[part] !== undefined) {
+        bodyParts.set(part, Buffer.from(entry.parts[part]));
+      }
+    }
+    return { uid: Number(uid), bodyParts };
+  },
+};
+
+before(async () => {
+  savedHome = process.env.MINNOW_HOME;
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'minnow-inc-sync-'));
+  process.env.MINNOW_HOME = tempHome;
+
+  mock.module('../../server/email/accounts.js', {
+    namedExports: {
+      getEmailAccount: async () => ACCOUNT,
+      readAccountPassword: async () => 'pw',
+      listEmailAccounts: async () => [ACCOUNT],
+    },
+  });
+
+  mock.module('../../server/email/imap-session.js', {
+    namedExports: {
+      withMailbox: async (accountId, folder, fn) => {
+        borrows.push({ accountId, folder });
+        return fn(fakeClient, ACCOUNT);
+      },
+      listFoldersCached: async () => [
+        { path: 'INBOX', name: 'INBOX', specialUse: null },
+        { path: 'Archive', name: 'Archive', specialUse: '\\Archive' },
+      ],
+      startIdleWatcher: async () => ({ started: true }),
+      stopIdleWatcher: async () => ({ stopped: true }),
+      stopAllIdleWatchers: async () => {},
+      closeAllImapSessions: async () => {},
+    },
+  });
+});
+
+after(async () => {
+  const { closeMailDbs } = await import('../../server/email/store.js');
+  closeMailDbs();
+  mock.reset();
+  if (savedHome === undefined) {
+    delete process.env.MINNOW_HOME;
+  } else {
+    process.env.MINNOW_HOME = savedHome;
+  }
+  await fs.rm(tempHome, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  const { writeMessageCache } = await import('../../server/email/cache.js');
+  await writeMessageCache(ACCOUNT_ID, { messages: [], folderCursors: {} });
+  server = makeServer();
+  borrows.length = 0;
+});
+
+describe('bodyStructure helpers', () => {
+  test('pickPreviewPart prefers text/plain and skips attachments', async () => {
+    const { pickPreviewPart, structureHasAttachments } = await import('../../server/email/imap.js');
+
+    const multipart = {
+      type: 'multipart/mixed',
+      childNodes: [
+        { type: 'text/html', part: '1', size: 900 },
+        { type: 'text/plain', part: '2', size: 120 },
+        { type: 'application/pdf', part: '3', size: 90_000, disposition: 'attachment' },
+      ],
+    };
+
+    assert.deepEqual(pickPreviewPart(multipart), { part: '2', type: 'text/plain', size: 120 });
+    assert.equal(structureHasAttachments(multipart), true);
+  });
+
+  test('pickPreviewPart falls back to html and skips oversized parts', async () => {
+    const { pickPreviewPart, structureHasAttachments } = await import('../../server/email/imap.js');
+
+    const htmlOnly = { type: 'multipart/alternative', childNodes: [{ type: 'text/html', part: '1', size: 400 }] };
+    assert.equal(pickPreviewPart(htmlOnly).part, '1');
+    assert.equal(structureHasAttachments(htmlOnly), false);
+
+    const huge = { type: 'text/plain', part: '1', size: 5_000_000 };
+    assert.equal(pickPreviewPart(huge), null, 'a giant text part is left for the lazy body fetch');
+  });
+});
+
+describe('syncFolderMessages', () => {
+  test('cold start fills the newest page and records uidvalidity', async () => {
+    const { syncFolderMessages } = await import('../../server/email/imap.js');
+    const { getSyncState, getCachedMessage } = await import('../../server/email/cache.js');
+
+    seed(1, { subject: 'First' });
+    seed(2, { subject: 'Second' });
+
+    const result = await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    assert.equal(result.synced, 2);
+    assert.equal(result.uidValidityReset, false);
+
+    const state = await getSyncState(ACCOUNT_ID, 'INBOX');
+    assert.equal(state.highestUid, 2);
+    assert.equal(state.uidValidity, '100');
+
+    const first = await getCachedMessage(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(first.subject, 'First');
+    assert.equal(first.bodyText, 'Body text for message 1.');
+    assert.equal(first.bodyHtml, undefined, 'sync stores text only — HTML loads lazily');
+  });
+
+  test('second sync fetches only UIDs above the cursor', async () => {
+    const { syncFolderMessages } = await import('../../server/email/imap.js');
+    const { countCachedMessages } = await import('../../server/email/cache.js');
+
+    seed(1);
+    seed(2);
+    await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    server.fetchCalls.length = 0;
+    seed(3, { subject: 'Fresh' });
+    const result = await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    assert.equal(result.synced, 1, 'only the new message is ingested');
+    assert.equal(result.messages[0].subject, 'Fresh');
+    assert.equal(await countCachedMessages(ACCOUNT_ID, 'INBOX'), 3);
+
+    const newMailFetch = server.fetchCalls.find((call) => call.query.headers);
+    assert.equal(newMailFetch.range, '3:*', 'the range starts one past the stored cursor');
+  });
+
+  test('an unchanged mailbox re-ingests nothing', async () => {
+    const { syncFolderMessages } = await import('../../server/email/imap.js');
+
+    seed(1);
+    seed(2);
+    await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    const result = await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+    assert.equal(result.synced, 0, '`N:*` returns the highest uid, which must be filtered out');
+    assert.equal(result.total, 2);
+  });
+
+  test('external read and delete are reflected by the reconcile pass', async () => {
+    const { syncFolderMessages } = await import('../../server/email/imap.js');
+    const { getCachedMessage } = await import('../../server/email/cache.js');
+
+    seed(1);
+    seed(2);
+    await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+    assert.equal((await getCachedMessage(ACCOUNT_ID, 'INBOX:1')).flags.seen, false);
+
+    // Another mail client reads uid 1 and deletes uid 2.
+    server.messages.get(1).flags = ['\\Seen'];
+    server.messages.delete(2);
+
+    const result = await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    assert.equal(result.reconciled.updated, 1);
+    assert.equal(result.reconciled.removed, 1);
+    assert.equal((await getCachedMessage(ACCOUNT_ID, 'INBOX:1')).flags.seen, true);
+    assert.equal(await getCachedMessage(ACCOUNT_ID, 'INBOX:2'), null);
+  });
+
+  test('CONDSTORE skips the reconcile fetch when HIGHESTMODSEQ has not moved', async () => {
+    const { syncFolderMessages } = await import('../../server/email/imap.js');
+
+    fakeClient.enabled = new Set(['CONDSTORE']);
+    try {
+      seed(1);
+      seed(2);
+      await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+      server.fetchCalls.length = 0;
+      const quiet = await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+      assert.equal(quiet.reconciled.skipped, 'unchanged_modseq');
+      assert.equal(
+        server.fetchCalls.filter((call) => call.query.flags && !call.query.headers).length,
+        0,
+        'no FLAGS fetch is issued for an unchanged mailbox',
+      );
+
+      // A flag change on the server bumps modseq, so the next pass reconciles.
+      server.highestModseq = '51';
+      server.messages.get(1).flags = ['\\Seen'];
+      const busy = await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+      assert.equal(busy.reconciled.updated, 1);
+    } finally {
+      fakeClient.enabled = new Set();
+    }
+  });
+
+  test('a uidvalidity change clears the folder and refills it', async () => {
+    const { syncFolderMessages } = await import('../../server/email/imap.js');
+    const { getCachedMessage, getSyncState } = await import('../../server/email/cache.js');
+
+    seed(1, { subject: 'Old world' });
+    await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    server = makeServer();
+    server.uidValidity = '999';
+    seed(1, { subject: 'New world', messageId: '<new-1@example.com>' });
+
+    const result = await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    assert.equal(result.uidValidityReset, true);
+    assert.equal((await getCachedMessage(ACCOUNT_ID, 'INBOX:1')).subject, 'New world');
+    assert.equal((await getSyncState(ACCOUNT_ID, 'INBOX')).uidValidity, '999');
+  });
+});
+
+describe('ensureMessageBody', () => {
+  test('downloads the full source once and caches html + attachments', async () => {
+    const { syncFolderMessages, ensureMessageBody } = await import('../../server/email/imap.js');
+
+    seed(1, {
+      source: [
+        'From: Alice <alice@example.com>',
+        'To: me@example.com',
+        'Subject: Message 1',
+        'Message-ID: <msg-1@example.com>',
+        'Date: Wed, 01 Jul 2026 10:00:00 +0000',
+        'Content-Type: text/html; charset=utf-8',
+        '',
+        '<p>Full <b>html</b> body.</p>',
+      ].join('\r\n'),
+    });
+
+    await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    const loaded = await ensureMessageBody(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(loaded.cached, false);
+    assert.match(loaded.bodyHtml, /<b>html<\/b>/);
+    assert.match(loaded.bodyText, /Full/);
+
+    const again = await ensureMessageBody(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(again.cached, true, 'a second open is served from the store');
+  });
+});
+
+describe('connection reuse', () => {
+  test('a bulk flag action opens one mailbox borrow per folder', async () => {
+    const { syncFolderMessages } = await import('../../server/email/imap.js');
+    const { bulkMessageAction } = await import('../../server/email/mail-actions.js');
+
+    for (let uid = 1; uid <= 10; uid += 1) seed(uid);
+    await syncFolderMessages(ACCOUNT_ID, { folder: 'INBOX' });
+
+    // messageFlagsAdd is only exercised through the pool in this test.
+    const stores = [];
+    fakeClient.messageFlagsAdd = async (uidSet, flags) => {
+      stores.push({ uidSet, flags });
+      return true;
+    };
+
+    borrows.length = 0;
+    const ids = Array.from({ length: 10 }, (_, index) => `INBOX:${index + 1}`);
+    const result = await bulkMessageAction(ACCOUNT_ID, { ids, action: 'read' });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.results.length, 10);
+    assert.equal(borrows.length, 1, 'ten messages, one mailbox borrow');
+    assert.equal(stores.length, 1, 'one STORE with a UID set, not ten');
+    assert.equal(stores[0].uidSet, '1,2,3,4,5,6,7,8,9,10');
+
+    delete fakeClient.messageFlagsAdd;
+  });
+});

--- a/test/email/mail-store.test.mjs
+++ b/test/email/mail-store.test.mjs
@@ -1,0 +1,430 @@
+/**
+ * SQLite mail store — identity, FTS search, thread rollups, concurrency (MIN-351).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, beforeEach, describe, test } from 'node:test';
+
+import {
+  countCachedMessages,
+  getCachedBody,
+  getCachedMessage,
+  getFolderUnreadCounts,
+  getSyncState,
+  listCachedMessages,
+  listCachedThread,
+  listCachedThreads,
+  listCachedUids,
+  mergeMessagesIntoCache,
+  migrateJsonCacheIfNeeded,
+  reconcileFolderFlags,
+  removeMessageFromCache,
+  resetFolderCache,
+  saveCachedBody,
+  searchCachedMessages,
+  setSyncState,
+  updateMessageFlags,
+  updateMessageFolder,
+  updateMessageTriage,
+  updateReplyVariants,
+  writeMessageCache,
+} from '../../server/email/cache.js';
+import { closeMailDbs } from '../../server/email/store.js';
+import { emailCacheMessagesPath } from '../../server/email/paths.js';
+
+const ACCOUNT_ID = 'acct-mail-store-test';
+
+let tempHome;
+let savedHome;
+
+function message(overrides = {}) {
+  return {
+    uid: '1',
+    folder: 'INBOX',
+    messageId: '<a@example.com>',
+    threadId: '<thread-a@example.com>',
+    from: 'Alice <alice@example.com>',
+    to: ['me@example.com'],
+    subject: 'Quarterly contract',
+    date: '2026-07-01T10:00:00.000Z',
+    bodyPreview: 'Please review the contract',
+    bodyText: 'Please review the contract before Friday.',
+    bodyHash: 'hash-a',
+    hasAttachments: false,
+    attachments: [],
+    inReplyTo: '',
+    references: [],
+    flags: { seen: false, flagged: false, answered: false },
+    ...overrides,
+  };
+}
+
+before(async () => {
+  savedHome = process.env.MINNOW_HOME;
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'minnow-mail-store-'));
+  process.env.MINNOW_HOME = tempHome;
+});
+
+after(async () => {
+  closeMailDbs();
+  if (savedHome === undefined) {
+    delete process.env.MINNOW_HOME;
+  } else {
+    process.env.MINNOW_HOME = savedHome;
+  }
+  await fs.rm(tempHome, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await writeMessageCache(ACCOUNT_ID, { messages: [], folderCursors: {} });
+});
+
+describe('mail store identity', () => {
+  test('assigns folder:uid ids and keeps them stable across a move', async () => {
+    await mergeMessagesIntoCache(ACCOUNT_ID, [message()], 'INBOX', 1);
+
+    const before = await getCachedMessage(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(before.id, 'INBOX:1');
+    await updateMessageTriage(ACCOUNT_ID, 'INBOX:1', { urgency: 'high', summary: 'Sign it' });
+
+    await updateMessageFolder(ACCOUNT_ID, 'INBOX:1', 'Archive', '77');
+
+    const moved = await getCachedMessage(ACCOUNT_ID, 'INBOX:1');
+    assert.ok(moved, 'the original id still resolves after a move');
+    assert.equal(moved.folder, 'Archive');
+    assert.equal(moved.uid, '77');
+    assert.equal(moved.triage.urgency, 'high', 'triage survives the move');
+    assert.equal(moved.messageRowId, before.messageRowId);
+  });
+
+  test('same uid in two folders resolves to distinct messages (D4)', async () => {
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [
+        message({ uid: '5', folder: 'INBOX', subject: 'Inbox five', messageId: '<i5@x>' }),
+        message({ uid: '5', folder: 'Sent', subject: 'Sent five', messageId: '<s5@x>' }),
+      ],
+      'INBOX',
+      5,
+    );
+
+    const inbox = await getCachedMessage(ACCOUNT_ID, 'INBOX:5');
+    const sent = await getCachedMessage(ACCOUNT_ID, 'Sent:5');
+    assert.equal(inbox.subject, 'Inbox five');
+    assert.equal(sent.subject, 'Sent five');
+
+    // The ambiguous bare-uid form no longer silently picks the first match.
+    assert.equal(await getCachedMessage(ACCOUNT_ID, '5'), null);
+  });
+
+  test('reply variants and triage hang off the stable row', async () => {
+    await mergeMessagesIntoCache(ACCOUNT_ID, [message()], 'INBOX', 1);
+    await updateReplyVariants(ACCOUNT_ID, 'INBOX:1', [
+      { id: 'v1', label: 'Brief yes', body: 'Sounds good.', createdAt: '2026-07-01T11:00:00.000Z' },
+    ]);
+    const row = await getCachedMessage(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(row.replyVariants.length, 1);
+    assert.equal(row.replyVariants[0].label, 'Brief yes');
+  });
+});
+
+describe('mail store queries', () => {
+  test('FTS search matches body text, not just subject and sender (D10)', async () => {
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [
+        message({ uid: '1', bodyText: 'The invoice is attached for review.', bodyPreview: 'invoice' }),
+        message({
+          uid: '2',
+          messageId: '<b@example.com>',
+          threadId: '<thread-b@example.com>',
+          subject: 'Lunch',
+          bodyText: 'Want to grab lunch tomorrow?',
+          bodyPreview: 'lunch',
+        }),
+      ],
+      'INBOX',
+      2,
+    );
+
+    const hits = await searchCachedMessages(ACCOUNT_ID, { query: 'invoice' });
+    assert.equal(hits.total, 1);
+    assert.equal(hits.messages[0].uid, '1');
+
+    const none = await searchCachedMessages(ACCOUNT_ID, { query: 'nonexistentterm' });
+    assert.equal(none.total, 0);
+  });
+
+  test('search reindexes when a lazy body arrives', async () => {
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [message({ bodyText: 'preview only', bodyPreview: 'preview only' })],
+      'INBOX',
+      1,
+    );
+    assert.equal((await searchCachedMessages(ACCOUNT_ID, { query: 'zeppelin' })).total, 0);
+
+    await saveCachedBody(ACCOUNT_ID, 'INBOX:1', {
+      bodyText: 'The zeppelin schedule is confirmed.',
+      bodyHtml: '<p>The zeppelin schedule is confirmed.</p>',
+      complete: true,
+    });
+
+    assert.equal((await searchCachedMessages(ACCOUNT_ID, { query: 'zeppelin' })).total, 1);
+    const body = await getCachedBody(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(body.complete, true);
+    assert.match(body.bodyHtml, /zeppelin/);
+  });
+
+  test('a re-sync preview never overwrites a fully downloaded body', async () => {
+    await mergeMessagesIntoCache(ACCOUNT_ID, [message({ bodyText: 'preview text' })], 'INBOX', 1);
+    await saveCachedBody(ACCOUNT_ID, 'INBOX:1', {
+      bodyText: 'the complete plain body',
+      bodyHtml: '<p>the complete body</p>',
+      complete: true,
+    });
+
+    // The server re-reports the same uid; sync only ever carries the preview.
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [message({ bodyText: 'preview text', bodyComplete: false })],
+      'INBOX',
+      1,
+    );
+
+    const body = await getCachedBody(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(body.bodyText, 'the complete plain body');
+    assert.equal(body.bodyHtml, '<p>the complete body</p>', 'the HTML part is not dropped');
+    assert.equal(body.complete, true);
+  });
+
+  test('thread rollups track count, unread, and last date', async () => {
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [
+        message({ uid: '1', date: '2026-07-01T10:00:00.000Z' }),
+        message({
+          uid: '2',
+          messageId: '<a2@example.com>',
+          date: '2026-07-02T10:00:00.000Z',
+          from: 'Bob <bob@example.com>',
+          bodyPreview: 'Signed and returned',
+          flags: { seen: true, flagged: false, answered: false },
+        }),
+      ],
+      'INBOX',
+      2,
+    );
+
+    const { threads, total } = await listCachedThreads(ACCOUNT_ID, {});
+    assert.equal(total, 1);
+    assert.equal(threads[0].messageCount, 2);
+    assert.equal(threads[0].unreadCount, 1);
+    assert.equal(threads[0].lastDate, '2026-07-02T10:00:00.000Z');
+    assert.equal(threads[0].snippet, 'Signed and returned');
+    assert.deepEqual(threads[0].participants, [
+      'Alice <alice@example.com>',
+      'Bob <bob@example.com>',
+    ]);
+
+    await updateMessageFlags(ACCOUNT_ID, 'INBOX:1', { seen: true, flagged: true });
+    const after = await listCachedThreads(ACCOUNT_ID, {});
+    assert.equal(after.threads[0].unreadCount, 0);
+    assert.equal(after.threads[0].flagged, true);
+
+    const ordered = await listCachedThread(ACCOUNT_ID, '<thread-a@example.com>');
+    assert.deepEqual(
+      ordered.map((row) => row.uid),
+      ['1', '2'],
+      'thread messages are oldest-first',
+    );
+  });
+
+  test('unread counts and filters are folder-scoped', async () => {
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [
+        message({ uid: '1' }),
+        message({ uid: '2', messageId: '<c@x>', folder: 'Archive', threadId: '<thread-c@x>' }),
+      ],
+      'INBOX',
+      1,
+    );
+
+    assert.deepEqual(await getFolderUnreadCounts(ACCOUNT_ID), { INBOX: 1, Archive: 1 });
+    const unread = await listCachedMessages(ACCOUNT_ID, { folder: 'INBOX', filter: 'unread' });
+    assert.equal(unread.total, 1);
+    assert.equal(await countCachedMessages(ACCOUNT_ID, 'Archive'), 1);
+  });
+});
+
+describe('sync state and reconcile', () => {
+  test('merge advances the folder cursor monotonically', async () => {
+    await mergeMessagesIntoCache(ACCOUNT_ID, [message({ uid: '9' })], 'INBOX', 9);
+    assert.equal((await getSyncState(ACCOUNT_ID, 'INBOX')).highestUid, 9);
+
+    await mergeMessagesIntoCache(ACCOUNT_ID, [], 'INBOX', 4);
+    assert.equal(
+      (await getSyncState(ACCOUNT_ID, 'INBOX')).highestUid,
+      9,
+      'a lower highestUid never rewinds the cursor',
+    );
+
+    await setSyncState(ACCOUNT_ID, 'INBOX', { uidValidity: '123', highestModseq: '77' });
+    const state = await getSyncState(ACCOUNT_ID, 'INBOX');
+    assert.equal(state.uidValidity, '123');
+    assert.equal(state.highestUid, 9, 'a partial patch leaves other columns alone');
+  });
+
+  test('flags reconcile applies external reads and drops vanished messages', async () => {
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [
+        message({ uid: '1' }),
+        message({ uid: '2', messageId: '<b@x>', threadId: '<thread-b@x>' }),
+      ],
+      'INBOX',
+      2,
+    );
+
+    const serverFlags = new Map([[1, { seen: true, flagged: true, answered: false }]]);
+    const result = await reconcileFolderFlags(ACCOUNT_ID, 'INBOX', serverFlags, [1, 2]);
+
+    assert.equal(result.updated, 1);
+    assert.equal(result.removed, 1, 'uid 2 is gone from the server, so it leaves the store');
+
+    const kept = await getCachedMessage(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(kept.flags.seen, true);
+    assert.equal(kept.flags.flagged, true);
+    assert.equal(await getCachedMessage(ACCOUNT_ID, 'INBOX:2'), null);
+  });
+
+  test('uidvalidity reset clears the folder and its cursor', async () => {
+    await mergeMessagesIntoCache(ACCOUNT_ID, [message(), message({ uid: '2', messageId: '<b@x>' })], 'INBOX', 2);
+    await mergeMessagesIntoCache(
+      ACCOUNT_ID,
+      [message({ uid: '3', folder: 'Sent', messageId: '<s@x>', threadId: '<t-s@x>' })],
+      'Sent',
+      3,
+    );
+
+    await resetFolderCache(ACCOUNT_ID, 'INBOX');
+
+    assert.equal(await countCachedMessages(ACCOUNT_ID, 'INBOX'), 0);
+    assert.equal(await countCachedMessages(ACCOUNT_ID, 'Sent'), 1, 'other folders are untouched');
+    assert.equal((await getSyncState(ACCOUNT_ID, 'INBOX')).highestUid, 0);
+    assert.deepEqual(await listCachedUids(ACCOUNT_ID, 'INBOX'), []);
+  });
+});
+
+describe('concurrent writers', () => {
+  test('interleaved flag and triage writes both survive (D5)', async () => {
+    await mergeMessagesIntoCache(ACCOUNT_ID, [message()], 'INBOX', 1);
+
+    await Promise.all([
+      updateMessageFlags(ACCOUNT_ID, 'INBOX:1', { seen: true, flagged: false }),
+      updateMessageTriage(ACCOUNT_ID, 'INBOX:1', { urgency: 'high', summary: 'Contract' }),
+      updateReplyVariants(ACCOUNT_ID, 'INBOX:1', [
+        { id: 'v1', label: 'Yes', body: 'ok', createdAt: '2026-07-01T11:00:00.000Z' },
+      ]),
+    ]);
+
+    const row = await getCachedMessage(ACCOUNT_ID, 'INBOX:1');
+    assert.equal(row.flags.seen, true, 'the flag write was not clobbered');
+    assert.equal(row.triage.urgency, 'high', 'the triage write was not clobbered');
+    assert.equal(row.replyVariants.length, 1, 'the variants write was not clobbered');
+  });
+
+  test('many parallel writers across messages lose no updates', async () => {
+    const rows = Array.from({ length: 25 }, (_, index) =>
+      message({
+        uid: String(index + 1),
+        messageId: `<m${index}@example.com>`,
+        threadId: `<thread-${index}@example.com>`,
+      }),
+    );
+    await mergeMessagesIntoCache(ACCOUNT_ID, rows, 'INBOX', 25);
+
+    await Promise.all(
+      rows.map((row, index) =>
+        updateMessageTriage(ACCOUNT_ID, `INBOX:${row.uid}`, { urgency: 'low', summary: `s${index}` }),
+      ),
+    );
+
+    const { messages } = await listCachedMessages(ACCOUNT_ID, { limit: 200 });
+    assert.equal(messages.length, 25);
+    assert.equal(
+      messages.filter((row) => row.triage?.summary).length,
+      25,
+      'every triage write landed',
+    );
+  });
+});
+
+describe('json migration', () => {
+  test('imports a legacy messages.json once and retires the file', async () => {
+    const legacyAccount = 'acct-legacy-json';
+    const filePath = emailCacheMessagesPath(legacyAccount);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        folderCursors: { INBOX: { highestUid: 12 } },
+        inboxSummary: { generatedAt: '2026-07-01T00:00:00.000Z', stats: { high: 1 } },
+        messages: [
+          {
+            id: 'INBOX:12',
+            uid: '12',
+            folder: 'INBOX',
+            threadId: '<legacy@example.com>',
+            from: 'Carol <carol@example.com>',
+            to: ['me@example.com'],
+            subject: 'Legacy row',
+            date: '2026-06-01T00:00:00.000Z',
+            bodyPreview: 'legacy preview',
+            bodyText: 'legacy body text',
+            triage: { urgency: 'high', summary: 'Legacy triage' },
+          },
+        ],
+      }),
+      'utf8',
+    );
+
+    const first = await migrateJsonCacheIfNeeded(legacyAccount);
+    assert.equal(first.migrated, true);
+    assert.equal(first.messages, 1);
+
+    const row = await getCachedMessage(legacyAccount, 'INBOX:12');
+    assert.equal(row.subject, 'Legacy row');
+    assert.equal(row.triage.urgency, 'high');
+    assert.equal((await getSyncState(legacyAccount, 'INBOX')).highestUid, 12);
+    assert.equal(
+      (await searchCachedMessages(legacyAccount, { query: 'legacy' })).total,
+      1,
+      'migrated rows are searchable',
+    );
+
+    await assert.rejects(() => fs.access(filePath), 'the JSON cache is retired after import');
+    await fs.access(`${filePath}.migrated`);
+
+    const second = await migrateJsonCacheIfNeeded(legacyAccount);
+    assert.equal(second.migrated, false, 'migration is idempotent');
+  });
+});
+
+describe('deletes', () => {
+  test('removing a message drops its FTS entry and thread rollup', async () => {
+    await mergeMessagesIntoCache(ACCOUNT_ID, [message()], 'INBOX', 1);
+    assert.equal((await searchCachedMessages(ACCOUNT_ID, { query: 'contract' })).total, 1);
+
+    await removeMessageFromCache(ACCOUNT_ID, 'INBOX:1');
+
+    assert.equal((await searchCachedMessages(ACCOUNT_ID, { query: 'contract' })).total, 0);
+    assert.equal((await listCachedThreads(ACCOUNT_ID, {})).total, 0);
+    await assert.rejects(() => removeMessageFromCache(ACCOUNT_ID, 'INBOX:1'), /not found/i);
+  });
+});

--- a/test/test-config.mjs
+++ b/test/test-config.mjs
@@ -81,6 +81,8 @@ export const PATH_RUNNER_RULES = [
   { pattern: 'test/chat/super-plan/stages.test.mts', runner: 'tsx-mocks-loader' },
   { pattern: 'test/super-plan/controller-lifecycle.test.mts', runner: 'tsx-mocks-loader' },
   { pattern: 'test/ui/orchestrate-finish-dashboard.test.mjs', runner: 'tsx-mocks-loader' },
+  // Mocks server/email/{accounts,imap-session}.js to drive sync against a fake server.
+  { pattern: 'test/email/incremental-sync.test.mjs', runner: 'tsx-mocks' },
   { pattern: 'test/server/**/*.test.mjs', runner: 'tsx-mocks' },
   { pattern: 'test/workspace/*.test.js', runner: 'tsx-mocks' },
   { pattern: 'test/terminal/shell-profiles.test.mjs', runner: 'tsx-mocks' },


### PR DESCRIPTION
Phase 1 of the [world-class email spec](documentation/plans/email-world-class-spec.md). Closes [MIN-351](https://linear.app/minnowai/issue/MIN-351/phase-1-sqlite-mail-store-imap-connection-pool-incremental-sync).

## Why

Two things dominated latency and correctness in the Email app:

- **The JSON cache.** Every message — full `bodyText` and `bodyHtml` inline — lived in one pretty-printed file that was fully rewritten on every flag flip. On a 5k-message mailbox a single star click rewrote tens of MB, and because every mutation was a read-modify-write with no lock, the poller, SSE agent hooks, and UI actions raced each other (a flag write could erase a concurrent triage write).
- **Connection-per-operation IMAP.** A star click paid a full TCP + TLS + LOGIN. `archiveImapMessage` opened *three* connections. A 100-message bulk action opened ~100, sequentially. Sync also re-downloaded the full RFC822 source of the whole page every time, with no incremental fetch and no flags resync — so reads, stars, and deletes made in another mail client drifted silently and forever.

## What changed

### Storage — SQLite mail store

`server/email/store.js` (new) owns a per-account DB at `~/.minnow/email/mail-<accountId>.db` in WAL mode, following the `server/brain/code/schema.js` pattern: `messages`, `bodies`, `attachments`, `threads`, `sync_state`, `contacts`, `outbox`, `automation_runs`, `meta`, plus an FTS5 mirror over subject/sender/body.

- `message_row_id` is the stable PK, and the public `id` is **never rewritten on a move** — so triage, reply variants, and cached bodies survive it (**D4**). The ambiguous bare-uid lookup now resolves only when it matches exactly one row, so UID 5 in `INBOX` can no longer shadow UID 5 in `Sent`.
- WAL plus a single write path per account ends the lost-update races (**D5**).
- FTS5 replaces the substring scan and indexes **bodies**, not just headers (**D10**).
- One-time, idempotent import from `messages.json`; the file is retired to `.migrated` only after a row-count check (per the Part 7 constraint).

`cache.js` was rewritten onto the store but **keeps its exported async API**, so `agent.js`, `triage.js`, `smtp.js`, `attachments.js`, and `tool-handler.js` needed no changes.

### Connections — session pool

`server/email/imap-session.js` (new) holds one long-lived ImapFlow client per account. All reads and mutations borrow it via `withMailbox(accountId, folder, fn)`, which serializes per account, retries once on a dropped socket, and closes after 5 minutes idle. The folder list is cached in `meta`, so archive/move stop paying a `LIST` each. Bulk flag actions collapse to **one STORE with a UID set per folder** instead of one call per message.

### Sync — incremental + lazy + push

- New mail via `UID lastSeen+1:*`, fetching **headers plus the first text part only**.
- A FLAGS-only reconcile over the newest 200 UIDs applies external reads/stars and drops mail deleted or moved elsewhere.
- `UIDVALIDITY` changes clear the folder and refill it.
- CONDSTORE is used to **skip the reconcile entirely** when `HIGHESTMODSEQ` hasn't moved.
- Bodies are lazy: full source, HTML, and attachment metadata download on first open (`ensureMessageBody`), which keeps tracking markup for unopened mail off disk.
- An IMAP IDLE watcher per polling-enabled account drives a debounced sync. It gets its **own connection** — IDLE parks the socket, so sharing the pooled client would stall every other operation. The interval poller stays as the fallback for servers with broken IDLE.
- Deleting an account now tears down its session, watcher, and DB file.

### API

`GET /accounts/:id/threads` (conversation rollups), `GET /search?q=` (FTS, across all accounts when `accountId` is omitted), `GET /messages/:id/body` (lazy fetch), with matching helpers in `src/email/client.ts`.

## Verification

`npm run test:email` — **83 pass, 0 fail**. 24 are new, across `test/email/mail-store.test.mjs` and `test/email/incremental-sync.test.mjs` (fake IMAP server via `mock.module`): stable ids across moves, cross-folder uid collisions, FTS incl. reindex on lazy body arrival, thread rollups, concurrent writers, JSON migration, UID-range fetch, flags reconcile, uidvalidity reset, CONDSTORE skip, lazy bodies, and one-borrow bulk actions.

`npx tsc --noEmit` reports only the **pre-existing** `src/ui/context-usage-surface.ts` error, untouched by this branch.

Measured against the phase exit criteria:

| Exit criterion | Result |
|---|---|
| Full resync of a 5k-message mailbox < 60s | 5k-row store ingest **2.2s**, leaving ~58s for network |
| Star click round-trip < 300ms warm | Store-side flag write **0.2ms**; the rest is one STORE on a warm pooled connection |
| Two concurrent writers lose zero updates | Covered by tests (interleaved flag/triage/variants, 25 parallel writers) |
| External read/delete reflected within one IDLE cycle | Covered by the reconcile test |

Thread page (50 of 1200) **3ms**, FTS **<1ms**.

## Notes for the reviewer

Three bugs I introduced and then caught, in case they're worth a second look:

1. `writeMessageCache` initially left stale `sync_state` cursors behind, so a whole-store replace would leave the next sync asking for `UID cursor+1:*` against an empty store and skipping everything. Caught by a cross-test interference failure.
2. A re-sync carries only the preview text, and could overwrite an already fully-downloaded body — dropping the HTML part. `saveBodyRow` now refuses to downgrade a complete body.
3. My first CONDSTORE path issued *two* fetches where one sufficed (strictly worse than no CONDSTORE). It now uses `HIGHESTMODSEQ` for an early-out instead.

`test/email/agent-triage-failure.test.mjs` gained a `closeMailDbs()` in its teardown — Windows won't unlink an open SQLite file. `test/test-config.mjs` routes the new sync test to the `tsx-mocks` runner since it uses `mock.module`.

Out of scope, as the spec sequences them: API auth and the `Access-Control-Allow-Origin: *` removal are Phase 2 (still the P0 security item); the conversation-list UI, optimistic updates, and virtualization are Phase 3/6. The `contacts`/`outbox`/`automation_runs` tables are created here but not yet written to — they land in Phases 3–5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
