### PR TITLE
🐛 Aggregate orchestrator board token metrics (MIN-414)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -252,6 +252,8 @@ Kanban delivery from plans under `documentation/plans/`. Tools: `board_init`, `b
 
 State: `Chat.orchestratePlanPath`, `ChatGroup.orchestrateBoard`, [`src/ui/orchestrate-board.ts`](../src/ui/orchestrate-board.ts).
 
+**Board metrics strip (MIN-414):** When the main column is in board view, the bottom inference metrics panel rolls up **all planner + member chat** token totals (ledger-first per chat) and averages per-chat tok/s (completion-weighted via [`averageStatsSegments`](../src/chat/orchestrate/stats-math.ts)). Implementation: [`src/chat/orchestrate/board-stats-aggregate.ts`](../src/chat/orchestrate/board-stats-aggregate.ts); refreshed on board live updates and chat switches so focusing a member chat does not reset totals.
+
 ### Experts
 
 Personas under `src/chat/prompts/experts/<id>/`. Chats: `Chat.kind === 'expert'`, memory under `pages/experts/<id>/facts/`. UI: Experts' Lab on desktop + `#/experts`.

--- a/src/chat/orchestrate/board-stats-aggregate.ts
+++ b/src/chat/orchestrate/board-stats-aggregate.ts
@@ -1,0 +1,169 @@
+/**
+ * Aggregate token metrics across planner + member chats on an orchestrate board (MIN-414).
+ */
+
+import { resolveModelInfo } from '../../api/models';
+import {
+  getActiveBoardGroup,
+  getPlannerChatForGroup,
+  listBoardGroupChatIds,
+} from '../../state/chat-groups';
+import { findChatById, sessionState } from '../../state/sessions';
+import { isBoardViewActive } from '../../ui/view-mode-toggle';
+import { updateStrip } from '../../ui/stats';
+import type { Chat, ChatGroup, Stats, Usage } from '../../types';
+import { averageStatsSegments, sumUsageSegments } from './stats-math';
+
+export interface BoardAggregateMetrics {
+  stats: Stats;
+  usage: Usage;
+  costUsd: number | null;
+}
+
+function collectUsageFromChatHistory(chat: Chat): Usage[] {
+  const segments: Usage[] = [];
+  for (const msg of chat.history) {
+    if (msg.role === 'assistant' && msg.usage) segments.push(msg.usage);
+  }
+  return segments;
+}
+
+/** Per-chat cumulative usage: token ledger when populated, otherwise assistant history sum. */
+export function chatCumulativeUsage(chat: Chat): Usage | null {
+  const totals = chat.tokenLedger?.totals;
+  if (totals && totals.totalTokens > 0) {
+    return {
+      prompt_tokens: totals.promptTokens,
+      completion_tokens: totals.completionTokens,
+      total_tokens: totals.totalTokens,
+    };
+  }
+  const historySegments = collectUsageFromChatHistory(chat);
+  if (!historySegments.length) return null;
+  return sumUsageSegments(historySegments);
+}
+
+/** Latest turn stats/usage pair for board speed averaging. */
+export function latestTurnStatsPair(chat: Chat): { stats: Stats; usage: Usage } | null {
+  const ls = chat.lastStats;
+  if (
+    ls &&
+    (ls.tokens_per_second != null ||
+      ls.time_to_first_token != null ||
+      ls.generation_time != null)
+  ) {
+    return {
+      stats: {
+        tokens_per_second: ls.tokens_per_second ?? undefined,
+        time_to_first_token: ls.time_to_first_token ?? undefined,
+        generation_time: ls.generation_time ?? undefined,
+        stop_reason: ls.stop_reason ?? undefined,
+      },
+      usage: {
+        prompt_tokens: ls.prompt_tokens ?? undefined,
+        completion_tokens: ls.completion_tokens ?? undefined,
+        total_tokens: ls.total_tokens ?? undefined,
+      },
+    };
+  }
+  for (let i = chat.history.length - 1; i >= 0; i--) {
+    const row = chat.history[i];
+    if (row.role !== 'assistant') continue;
+    if (!row.stats && !row.usage) continue;
+    return {
+      stats: row.stats ?? {},
+      usage: row.usage ?? {},
+    };
+  }
+  return null;
+}
+
+/** Sum usage and average per-chat speed across all chats linked to a board folder. */
+export function aggregateBoardMetrics(group: ChatGroup): BoardAggregateMetrics {
+  const chats = sessionState?.chats ?? [];
+  const chatIds = listBoardGroupChatIds(group, chats);
+
+  const usageSegments: Usage[] = [];
+  const statsPairs: Array<{ stats: Stats; usage: Usage }> = [];
+  let costUsd = 0;
+  let hasCost = false;
+
+  for (const chatId of chatIds) {
+    const chat = findChatById(chatId);
+    if (!chat) continue;
+
+    const usage = chatCumulativeUsage(chat);
+    if (usage) usageSegments.push(usage);
+
+    const pair = latestTurnStatsPair(chat);
+    if (
+      pair &&
+      (pair.stats.tokens_per_second != null ||
+        pair.stats.time_to_first_token != null ||
+        pair.stats.generation_time != null)
+    ) {
+      statsPairs.push(pair);
+    }
+
+    const chatCost = chat.tokenLedger?.totals?.costUsd;
+    if (chatCost != null && chatCost > 0) {
+      costUsd += chatCost;
+      hasCost = true;
+    }
+  }
+
+  return {
+    stats: averageStatsSegments(statsPairs),
+    usage: sumUsageSegments(usageSegments),
+    costUsd: hasCost ? costUsd : null,
+  };
+}
+
+/** True when the metrics strip should show board-wide rollups instead of one chat. */
+export function shouldUseBoardAggregateStats(): boolean {
+  if (!isBoardViewActive()) return false;
+  const group = getActiveBoardGroup();
+  return Boolean(group?.orchestrateBoard);
+}
+
+/** Refresh the bottom metrics strip for the active chat or board aggregate context. */
+export function refreshMetricsStripForChat(chat: Chat): void {
+  if (shouldUseBoardAggregateStats()) {
+    const group = getActiveBoardGroup()!;
+    const { stats, usage, costUsd } = aggregateBoardMetrics(group);
+    const planner = getPlannerChatForGroup(group);
+    const modelId = planner?.modelId?.trim() || chat.modelId?.trim() || '';
+    updateStrip(
+      stats,
+      usage,
+      resolveModelInfo(modelId, planner?.modelInfo ?? chat.modelInfo ?? {}),
+      { costUsd },
+    );
+    return;
+  }
+
+  const mid = chat.modelId?.trim() || '';
+  const ls = chat.lastStats;
+  const hasNumeric =
+    ls &&
+    (ls.tokens_per_second != null ||
+      ls.time_to_first_token != null ||
+      ls.generation_time != null ||
+      ls.total_tokens != null);
+  if (hasNumeric) {
+    const stats: Stats = {
+      tokens_per_second: ls!.tokens_per_second ?? undefined,
+      time_to_first_token: ls!.time_to_first_token ?? undefined,
+      generation_time: ls!.generation_time ?? undefined,
+      stop_reason: ls!.stop_reason ?? undefined,
+    };
+    const usage: Usage = {
+      total_tokens: ls!.total_tokens ?? undefined,
+      prompt_tokens: ls!.prompt_tokens ?? undefined,
+      completion_tokens: ls!.completion_tokens ?? undefined,
+    };
+    updateStrip(stats, usage, resolveModelInfo(mid, chat.modelInfo || {}));
+  } else {
+    updateStrip({}, {}, resolveModelInfo(mid, chat.modelInfo || {}));
+  }
+}

--- a/src/chat/orchestrate/stats-aggregate.ts
+++ b/src/chat/orchestrate/stats-aggregate.ts
@@ -11,6 +11,10 @@ import type { Chat, FinalizedResponseMeta } from '../../types';
 import { buildLastStatsSnapshot, updateStrip } from '../../ui/stats';
 import { renderSidebar } from '../../ui/sidebar';
 import { aggregateOrchestrateTurnMeta } from './stats-math';
+import {
+  refreshMetricsStripForChat,
+  shouldUseBoardAggregateStats,
+} from './board-stats-aggregate';
 
 export { aggregateOrchestrateTurnMeta, averageStatsSegments, sumUsageSegments } from './stats-math';
 
@@ -55,7 +59,10 @@ export function applyOrchestrateAggregatedStatsToChat(
   chat.lastStats = buildLastStatsSnapshot(aggregated.stats, aggregated.usage);
 
   const active = getActiveChat();
-  if (active.id === chat.id) {
+  if (shouldUseBoardAggregateStats()) {
+    refreshMetricsStripForChat(active);
+    renderSidebar();
+  } else if (active.id === chat.id) {
     const modelId =
       (document.getElementById('modelSelect') as HTMLSelectElement | null)?.value ||
       chat.modelId ||

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -216,6 +216,10 @@ import {
 } from '../config/tool-calls-meta';
 import { setStatus } from '../ui/status';
 import { applyOrchestrateAggregatedStatsToChat } from '../chat/orchestrate/stats-aggregate';
+import {
+  refreshMetricsStripForChat,
+  shouldUseBoardAggregateStats,
+} from '../chat/orchestrate/board-stats-aggregate';
 import { buildLastStatsSnapshot, updateStrip } from '../ui/stats';
 import { resolveOutboundSystemMessages } from '../chat/prompts/compose-context';
 import { estimateTokensFromText } from '../chat/prompts/token-estimate';
@@ -2258,6 +2262,9 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
       }
       renderSidebar();
       scheduleSaveSessions();
+      if (shouldUseBoardAggregateStats()) {
+        refreshMetricsStripForChat(getActiveChat());
+      }
 
       // Push-now during final prose: inject steer and run another model round in this turn.
       if (chat.pendingSteerMessage?.trim()) {

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -56,7 +56,7 @@ import {
 import { isBoardViewActive } from './view-mode-toggle';
 import { closeDrawer } from './settings';
 import { setStatus } from './status';
-import { updateStrip } from './stats';
+import { refreshMetricsStripForChat } from '../chat/orchestrate/board-stats-aggregate';
 import { refreshContextUsageRing } from './context-usage-ring';
 import { resetCodeChangeTotals, recomputeWorkspaceCodeChangeTotals } from '../usage/code-change-ledger';
 import { sessionState } from '../state/sessions';
@@ -123,30 +123,7 @@ export { resolveModelInfo, showCachedModelInfo } from '../api/models';
 let suppressBubbleScroll = false;
 
 export function renderStatsForChat(chat: Chat): void {
-  const mid = chat.modelId?.trim() || '';
-  const ls = chat.lastStats;
-  const hasNumeric =
-    ls &&
-    (ls.tokens_per_second != null ||
-      ls.time_to_first_token != null ||
-      ls.generation_time != null ||
-      ls.total_tokens != null);
-  if (hasNumeric) {
-    const stats: Stats = {
-      tokens_per_second: ls!.tokens_per_second ?? undefined,
-      time_to_first_token: ls!.time_to_first_token ?? undefined,
-      generation_time: ls!.generation_time ?? undefined,
-      stop_reason: ls!.stop_reason ?? undefined,
-    };
-    const usage: Usage = {
-      total_tokens: ls!.total_tokens ?? undefined,
-      prompt_tokens: ls!.prompt_tokens ?? undefined,
-      completion_tokens: ls!.completion_tokens ?? undefined,
-    };
-    updateStrip(stats, usage, resolveModelInfo(mid, chat.modelInfo || {}));
-  } else {
-    updateStrip({}, {}, resolveModelInfo(mid, chat.modelInfo || {}));
-  }
+  refreshMetricsStripForChat(chat);
   refreshContextUsageRing();
   if (isHubMounted()) refreshHubLiveData();
 }

--- a/src/ui/orchestrate-board.ts
+++ b/src/ui/orchestrate-board.ts
@@ -90,6 +90,7 @@ import {
   type OrchestrateBoardTimerContext,
 } from '../state/orchestrate-board-store';
 import { normalizeModeId } from '../chat/modes/types';
+import { refreshMetricsStripForChat } from '../chat/orchestrate/board-stats-aggregate';
 import { subscribeBoardChanges, emitBoardChange } from '../state/orchestrate-board-events';
 import {
   countBoardLogAlerts,
@@ -3265,6 +3266,7 @@ export function refreshActiveBoardIfMounted(): void {
   const root = mount.querySelector(':scope > .board-root') as HTMLElement | null;
   if (root && board && root.querySelector('.board-main')) {
     refreshBoardDom(root, group, plannerChat, board);
+    refreshMetricsStripForChat(plannerChat);
     return;
   }
   if (root && !board) return;

--- a/src/ui/stats.ts
+++ b/src/ui/stats.ts
@@ -125,11 +125,17 @@ export function updateStatsExpandPreview(): void {
   preview.textContent = `${tps} t/s · ${total} tokens${archiveChip}${disabledChip}`;
 }
 
+export interface UpdateStripOptions {
+  /** Override cost chip (e.g. board-wide rollup). */
+  costUsd?: number | null;
+}
+
 /** Refresh bottom metrics strip and token bars from latest turn data. */
 export function updateStrip(
   stats: Stats | undefined,
   usage: Usage | undefined,
-  modelInfo: ModelInfo | undefined
+  modelInfo: ModelInfo | undefined,
+  options?: UpdateStripOptions,
 ): void {
   const s = stats || {};
   const u = usage || {};
@@ -165,12 +171,16 @@ export function updateStrip(
 
   set('stripTotal', u.total_tokens != null ? String(u.total_tokens) : '—', u.total_tokens == null);
 
-  const ledger = getActiveChat().tokenLedger;
-  const lastEntry = ledger?.entries?.[ledger.entries.length - 1];
-  const costLabel =
-    lastEntry?.costUsd != null && lastEntry.costUsd > 0
-      ? formatUsd(lastEntry.costUsd)
-      : '—';
+  let costLabel = '—';
+  if (options?.costUsd != null && options.costUsd > 0) {
+    costLabel = formatUsd(options.costUsd);
+  } else if (options?.costUsd === undefined) {
+    const ledger = getActiveChat().tokenLedger;
+    const lastEntry = ledger?.entries?.[ledger.entries.length - 1];
+    if (lastEntry?.costUsd != null && lastEntry.costUsd > 0) {
+      costLabel = formatUsd(lastEntry.costUsd);
+    }
+  }
   set('stripCost', costLabel, costLabel === '—');
 
   const p = u.prompt_tokens ?? 0;

--- a/test/orchestrate/board-stats-aggregate.test.mts
+++ b/test/orchestrate/board-stats-aggregate.test.mts
@@ -1,0 +1,250 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+import {
+  aggregateBoardMetrics,
+  chatCumulativeUsage,
+  latestTurnStatsPair,
+} from '../../src/chat/orchestrate/board-stats-aggregate.ts';
+import {
+  createEmptyChatObject,
+  sessionState,
+  setSessionStateForTests,
+} from '../../src/state/sessions.ts';
+import type { Chat, ChatGroup } from '../../src/types.ts';
+
+function makeChat(overrides: Partial<Chat> & Pick<Chat, 'id'>): Chat {
+  return {
+    ...createEmptyChatObject('test-model', '/workspace'),
+    ...overrides,
+  };
+}
+
+function makeBoardGroup(): ChatGroup {
+  return {
+    id: 'group-11111111-1111-1111-1111-111111111111',
+    name: 'Board',
+    workspacePath: '/workspace',
+    collapsed: false,
+    order: 0,
+    createdAt: 1,
+    plannerChatId: 'planner-11111111-1111-1111-1111-111111111111',
+    orchestrateBoard: {
+      planPath: 'documentation/plans/test.md',
+      waves: [{ id: 'w1', title: 'Wave 1', collapsed: false }],
+      tasks: [
+        {
+          id: 'T1',
+          title: 'Task 1',
+          status: 'complete',
+          category: 'build',
+          waveId: 'w1',
+          chatId: 'member-11111111-1111-1111-1111-111111111111',
+        },
+        {
+          id: 'T2',
+          title: 'Task 2',
+          status: 'complete',
+          category: 'build',
+          waveId: 'w1',
+          chatId: 'member-22222222-2222-2222-2222-222222222222',
+        },
+        {
+          id: 'T3',
+          title: 'Task 3',
+          status: 'complete',
+          category: 'build',
+          waveId: 'w1',
+          chatId: 'member-33333333-3333-3333-3333-333333333333',
+        },
+      ],
+      autoRunning: false,
+      lastUpdatedAt: 1,
+    },
+  };
+}
+
+describe('board stats aggregate (MIN-414)', () => {
+  afterEach(() => {
+    setSessionStateForTests(null);
+  });
+
+  test('chatCumulativeUsage prefers token ledger totals over history', () => {
+    const chat = makeChat({
+      id: 'chat-a',
+      history: [
+        {
+          role: 'assistant',
+          content: 'old',
+          usage: { prompt_tokens: 999, completion_tokens: 999, total_tokens: 1998 },
+        },
+      ],
+      tokenLedger: {
+        entries: [],
+        totals: {
+          promptTokens: 100,
+          completionTokens: 40,
+          totalTokens: 140,
+          costUsd: 0,
+          completionCount: 1,
+        },
+        bySource: {},
+      },
+    });
+    const usage = chatCumulativeUsage(chat);
+    assert.deepEqual(usage, {
+      prompt_tokens: 100,
+      completion_tokens: 40,
+      total_tokens: 140,
+    });
+  });
+
+  test('aggregateBoardMetrics sums tokens across planner and member chats', () => {
+    const group = makeBoardGroup();
+    const planner = makeChat({
+      id: 'planner-11111111-1111-1111-1111-111111111111',
+      modeId: 'orchestrate',
+    });
+    planner.lastStats = {
+      tokens_per_second: 10,
+      time_to_first_token: 0.2,
+      generation_time: 1,
+      total_tokens: 300,
+      prompt_tokens: 200,
+      completion_tokens: 100,
+      stop_reason: null,
+    };
+    planner.tokenLedger = {
+      entries: [],
+      totals: {
+        promptTokens: 200,
+        completionTokens: 100,
+        totalTokens: 300,
+        costUsd: 0,
+        completionCount: 1,
+      },
+      bySource: {},
+    };
+
+    const member1 = makeChat({
+      id: 'member-11111111-1111-1111-1111-111111111111',
+      modeId: 'build',
+    });
+    member1.lastStats = {
+      tokens_per_second: 20,
+      time_to_first_token: 0.4,
+      generation_time: 2,
+      total_tokens: 500,
+      prompt_tokens: 400,
+      completion_tokens: 100,
+      stop_reason: null,
+    };
+    member1.tokenLedger = {
+      entries: [],
+      totals: {
+        promptTokens: 400,
+        completionTokens: 100,
+        totalTokens: 500,
+        costUsd: 0,
+        completionCount: 1,
+      },
+      bySource: {},
+    };
+
+    const member2 = makeChat({
+      id: 'member-22222222-2222-2222-2222-222222222222',
+      modeId: 'build',
+    });
+    member2.lastStats = {
+      tokens_per_second: 30,
+      time_to_first_token: 0.6,
+      generation_time: 3,
+      total_tokens: 700,
+      prompt_tokens: 500,
+      completion_tokens: 200,
+      stop_reason: null,
+    };
+    member2.tokenLedger = {
+      entries: [],
+      totals: {
+        promptTokens: 500,
+        completionTokens: 200,
+        totalTokens: 700,
+        costUsd: 0,
+        completionCount: 1,
+      },
+      bySource: {},
+    };
+
+    const member3 = makeChat({
+      id: 'member-33333333-3333-3333-3333-333333333333',
+      modeId: 'build',
+    });
+    member3.lastStats = {
+      tokens_per_second: 40,
+      time_to_first_token: 0.8,
+      generation_time: 4,
+      total_tokens: 900,
+      prompt_tokens: 600,
+      completion_tokens: 300,
+      stop_reason: null,
+    };
+    member3.tokenLedger = {
+      entries: [],
+      totals: {
+        promptTokens: 600,
+        completionTokens: 300,
+        totalTokens: 900,
+        costUsd: 0,
+        completionCount: 1,
+      },
+      bySource: {},
+    };
+
+    setSessionStateForTests({
+      version: 6,
+      activeId: planner.id,
+      sidebarCollapsed: false,
+      chats: [planner, member1, member2, member3],
+      groups: [group],
+    });
+
+    const metrics = aggregateBoardMetrics(group);
+    assert.equal(metrics.usage.prompt_tokens, 1700);
+    assert.equal(metrics.usage.completion_tokens, 700);
+    assert.equal(metrics.usage.total_tokens, 2400);
+    assert.equal(metrics.stats.tokens_per_second, 30);
+    assert.ok(
+      metrics.stats.time_to_first_token != null &&
+        Math.abs(metrics.stats.time_to_first_token - 0.5) < 1e-9,
+    );
+    assert.equal(metrics.stats.generation_time, 2.5);
+  });
+
+  test('latestTurnStatsPair reads lastStats snapshot', () => {
+    const chat = makeChat({
+      id: 'chat-b',
+      lastStats: {
+        tokens_per_second: 12.5,
+        time_to_first_token: 0.15,
+        generation_time: 0.9,
+        total_tokens: 42,
+        prompt_tokens: 30,
+        completion_tokens: 12,
+      },
+    });
+    const pair = latestTurnStatsPair(chat);
+    assert.deepEqual(pair, {
+      stats: {
+        tokens_per_second: 12.5,
+        time_to_first_token: 0.15,
+        generation_time: 0.9,
+        stop_reason: undefined,
+      },
+      usage: {
+        prompt_tokens: 30,
+        completion_tokens: 12,
+        total_tokens: 42,
+      },
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **MIN-414**: the orchestrator board metrics panel now shows **aggregate board usage** instead of stats from the last focused member chat.

## Changes

- Added `board-stats-aggregate.ts` to roll up token totals across planner + member chats (ledger-first per chat, history fallback)
- Speed (tok/s) is averaged across per-chat latest turn stats, weighted by completion tokens (same weighting as MIN-36)
- `renderStatsForChat` routes through board aggregation when board view is active
- Board live refresh (`refreshActiveBoardIfMounted`) keeps the metrics strip in sync during runs
- Background member chat completions refresh the strip while board view is open
- `updateStrip` accepts an optional board-wide `costUsd` override

## Acceptance

- [x] Board with 3+ member chats → metrics show combined totals
- [x] Speed reflects board average, not last-open chat only
- [x] Matches sum of per-chat metrics when all chats idle (ledger totals)

## Tests

- `test/orchestrate/board-stats-aggregate.test.mts` — aggregation math for totals, weighted tok/s, and per-chat helpers

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-414](https://linear.app/minnowai/issue/MIN-414/orchestrator-board-token-metrics)

<div><a href="https://cursor.com/agents/bc-162da1db-3e1a-4872-85f0-89f08fd0e7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-162da1db-3e1a-4872-85f0-89f08fd0e7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

