### PR TITLE
Harden email against tracking, CSS bleed, and unintended sends (MIN-352)

### DIFF
--- a/documentation/plans/email-world-class-spec.md
+++ b/documentation/plans/email-world-class-spec.md
@@ -142,7 +142,9 @@ New `server/email/imap-session.js`:
 
 ### 2.3 API changes (`middleware.js`)
 
-- **Auth**: require `Authorization: Bearer <session token>` minted by the app shell at boot; drop `Access-Control-Allow-Origin: *` (same-origin; no CORS headers at all). 401 otherwise. This is Phase 2's first item and is non-negotiable before LAN access ships.
+- **Auth**: ✅ shipped, but as a global `/api/*` gate rather than an email-specific
+  Bearer header — see "Phase 2 — As built" below. Same-origin, no CORS headers at all,
+  401 otherwise.
 - New routes:
 
 | Method | Route | Purpose |
@@ -276,9 +278,33 @@ Fix D1 (import), D2 (cc end-to-end minimal: compose → send → nodemailer), D3
 SQLite store + migration; connection pool; incremental sync + flags reconcile; lazy bodies; IDLE; `/threads` route; FTS search route. Cache module keeps its exported API surface where possible so UI changes stay small.
 **Exit criteria**: star click round-trip < 300ms warm; full resync of 5k-message mailbox < 60s; two concurrent writers lose zero updates (stress test); external read/delete reflected within one IDLE cycle.
 
-### Phase 2 — Security hardening
-Bearer-token auth + same-origin (blocks LAN plan until done); remote-image blocking + proxy; iframe body isolation; outbox-based send (undo window doubles as send confirmation); rate-limit `/send` (N/min per account).
+### Phase 2 — Security hardening ✅ shipped (MIN-352)
+Token auth + same-origin (blocks LAN plan until done); remote-image blocking + proxy; iframe body isolation; outbox-based send (undo window doubles as send confirmation); rate-limit `/send` (N/min per account).
 **Exit criteria**: cross-origin fetch from a test page gets 401; opening a tracking-pixel fixture makes zero external requests; CSS bleed fixture renders identically in both themes.
+
+As built:
+
+- **Auth** landed earlier with MIN-381 as a global `/api/*` gate
+  (`server/runtime/auth-middleware.js`): per-boot token in `~/.minnow/session-token`,
+  sent as `X-Minnow-Token`, plus Host validation. No CORS header is emitted anywhere.
+  The Bearer scheme in §2.3 was not used — the same guarantee, one gate for every API.
+- **Remote content** is parked at sanitize time, before storage
+  (`server/email/remote-content.js`), covering `src`/`srcset`/`background`/`poster`
+  and `url()` in style attributes. Originals move to `data-minnow-remote-*` so
+  "Load images" can restore them. `cid:`/`data:` sources are left alone.
+  Outbound mail is unaffected — only `sanitizeInboundEmailHtml` blocks.
+- **Bodies** render in a sandboxed `<iframe srcdoc>` (`src/ui/email/email-body.ts`)
+  with a mail-specific reset and `img-src 'self' data: cid:`, so the frame cannot
+  reach the sender's host even if the parking above ever misses an attribute.
+  Never `allow-scripts`.
+- **Images**, once allowed, are fetched by `server/email/image-proxy.js` with no
+  referrer or cookies and an SSRF guard that re-validates every redirect hop.
+  Per-sender allowlist in `~/.minnow/email/image-allowlist.json`.
+- **Send** goes through an in-memory outbox with an 8s undo window
+  (`server/email/outbox.js`); `/send` returns `202` with the queued entry.
+  The `confirmed: true` body field is gone — it was never a capability check.
+  A send still in its window when the app quits is dropped, not delivered.
+- **Rate limit**: 20 sends/min per account, charged at queue time, `429` + `Retry-After`.
 
 ### Phase 3 — Core mail completeness
 Attachments down/up (+ compose attach UI), drafts autosave (+ IMAP Drafts APPEND), Sent APPEND, conversation list UI + virtualization + optimistic store, keyboard model, bcc, contact autocomplete, snooze, send later, signatures, unified inbox.

--- a/server/email/image-allowlist.js
+++ b/server/email/image-allowlist.js
@@ -1,0 +1,96 @@
+/**
+ * Per-sender remote-image allowlist — persisted in
+ * ~/.minnow/email/image-allowlist.json.
+ *
+ * Remote content is blocked for every message (see `remote-content.js`). This
+ * is the "always load images from this sender" escape hatch, keyed on the
+ * sender's email address so the decision follows the correspondent rather than
+ * an individual message.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { emailImageAllowlistPath } from './paths.js';
+
+/**
+ * Reduce a From header to a bare, comparable address.
+ * `"Acme News" <News@Acme.COM>` -> `news@acme.com`
+ * @param {string | null | undefined} from
+ */
+export function normalizeSender(from) {
+  const raw = String(from ?? '').trim();
+  const angled = /<([^>]+)>/.exec(raw);
+  return (angled ? angled[1] : raw).trim().toLowerCase();
+}
+
+/** @returns {Promise<string[]>} */
+export async function listImageAllowlist() {
+  try {
+    const raw = await fs.readFile(emailImageAllowlistPath(), 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed?.senders) ? parsed.senders.map(normalizeSender).filter(Boolean) : [];
+  } catch (err) {
+    if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+/**
+ * @param {string[]} senders
+ */
+async function writeImageAllowlist(senders) {
+  const filePath = emailImageAllowlistPath();
+  // Don't depend on ensureMinnowLayout having run; a first-write on a fresh
+  // profile must not fail just because nothing has touched ~/.minnow/email yet.
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.writeFile(
+    tmp,
+    `${JSON.stringify({ version: 1, senders, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+    'utf8',
+  );
+  await fs.rename(tmp, filePath);
+}
+
+/**
+ * @param {string} from
+ * @returns {Promise<string[]>} the updated allowlist
+ */
+export async function allowImagesFromSender(from) {
+  const sender = normalizeSender(from);
+  if (!sender) {
+    throw new Error('sender is required');
+  }
+  const senders = await listImageAllowlist();
+  if (!senders.includes(sender)) {
+    senders.push(sender);
+    await writeImageAllowlist(senders);
+  }
+  return senders;
+}
+
+/**
+ * @param {string} from
+ * @returns {Promise<string[]>} the updated allowlist
+ */
+export async function blockImagesFromSender(from) {
+  const sender = normalizeSender(from);
+  const senders = await listImageAllowlist();
+  const next = senders.filter((row) => row !== sender);
+  if (next.length !== senders.length) {
+    await writeImageAllowlist(next);
+  }
+  return next;
+}
+
+/**
+ * @param {string} from
+ * @returns {Promise<boolean>}
+ */
+export async function isSenderAllowed(from) {
+  const sender = normalizeSender(from);
+  if (!sender) return false;
+  return (await listImageAllowlist()).includes(sender);
+}

--- a/server/email/image-proxy.js
+++ b/server/email/image-proxy.js
@@ -1,0 +1,139 @@
+/**
+ * Local fetcher for remote email images.
+ *
+ * When the user chooses to load images, the request must not go out from the
+ * renderer: a direct fetch carries the Referer, any ambient cookies, and the
+ * browser's own fingerprint to the sender's tracking host. Routing through the
+ * server strips all of that — the sender learns only that some IP fetched the
+ * image, with no message correlation from headers.
+ *
+ * Only reachable for allowed images; see `remote-content.js` for the blocking
+ * that makes this opt-in.
+ */
+
+import net from 'node:net';
+import { isPrivateIpAddress, resolveHostnameIps } from '../webhooks/ssrf.js';
+
+/** Cap on proxied image size — enough for banner art, not for exfiltration. */
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+
+/** Remote hosts get one shot; a hung tracker must not pin a socket open. */
+const FETCH_TIMEOUT_MS = 10_000;
+
+/** CDNs redirect constantly, but each hop is re-validated. */
+const MAX_REDIRECTS = 3;
+
+/**
+ * Reject anything that is not a public http(s) endpoint.
+ *
+ * Note: the address is validated, then fetched by hostname, so a hostile DNS
+ * server could in principle answer differently for the two lookups. Pinning the
+ * resolved address through `fetch` is not expressible with the global fetch, and
+ * the residual window only matters to an attacker who already controls the
+ * user's resolver — at which point the LAN is theirs regardless.
+ *
+ * @param {string} rawUrl
+ * @returns {Promise<URL>}
+ */
+async function validateImageUrl(rawUrl) {
+  const trimmed = String(rawUrl ?? '').trim();
+  if (!trimmed) {
+    throw new Error('url is required');
+  }
+  if (trimmed.length > 2048) {
+    throw new Error('url too long');
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error('url must be an absolute http(s) URL');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('url must use http or https');
+  }
+
+  const hostname = (parsed.hostname || '').trim().toLowerCase();
+  if (!hostname) {
+    throw new Error('url must have a hostname');
+  }
+
+  const addrs = net.isIP(hostname) ? [hostname] : await resolveHostnameIps(hostname);
+  if (addrs.length === 0) {
+    throw new Error('url host does not resolve');
+  }
+  if (addrs.some((addr) => isPrivateIpAddress(addr))) {
+    throw new Error('url must not point to private/internal addresses');
+  }
+
+  return parsed;
+}
+
+/**
+ * Fetch a remote image with no referrer, no credentials, and no redirect
+ * laundering past the SSRF check.
+ * @param {string} rawUrl
+ * @returns {Promise<{ body: Buffer, contentType: string }>}
+ */
+export async function fetchRemoteImage(rawUrl) {
+  let target = await validateImageUrl(rawUrl);
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    let res;
+    try {
+      res = await fetch(target, {
+        method: 'GET',
+        redirect: 'manual',
+        credentials: 'omit',
+        referrerPolicy: 'no-referrer',
+        signal: controller.signal,
+        headers: {
+          // A bare Accept keeps the request from advertising anything the
+          // sender could fingerprint. No Referer, no Cookie, no User-Agent
+          // beyond the runtime default.
+          Accept: 'image/*',
+        },
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) {
+        throw new Error('redirect without a location');
+      }
+      // Re-validate: a public host must not be able to bounce us onto the LAN.
+      target = await validateImageUrl(new URL(location, target).toString());
+      continue;
+    }
+
+    if (!res.ok) {
+      throw new Error(`upstream responded ${res.status}`);
+    }
+
+    const contentType = (res.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
+    if (!contentType.startsWith('image/')) {
+      throw new Error('upstream did not return an image');
+    }
+
+    const declared = Number(res.headers.get('content-length') ?? 0);
+    if (declared > MAX_IMAGE_BYTES) {
+      throw new Error('image too large');
+    }
+
+    const body = Buffer.from(await res.arrayBuffer());
+    if (body.byteLength > MAX_IMAGE_BYTES) {
+      throw new Error('image too large');
+    }
+
+    return { body, contentType };
+  }
+
+  throw new Error('too many redirects');
+}

--- a/server/email/imap.js
+++ b/server/email/imap.js
@@ -20,7 +20,7 @@ import {
   formatFromAddress,
   stripHtmlToText,
 } from './parse-body.js';
-import { sanitizeEmailHtml } from './sanitize-html.js';
+import { sanitizeInboundEmailHtml } from './sanitize-html.js';
 import {
   countCachedMessages,
   getCachedBody,
@@ -142,7 +142,7 @@ export async function parseRawMessage(source, context) {
   const rawHtml = parsed.html ? String(parsed.html) : '';
   const htmlText = rawHtml ? stripHtmlToText(rawHtml) : '';
   const bodyText = plain.trim() || htmlText;
-  const bodyHtml = rawHtml ? sanitizeEmailHtml(rawHtml) : undefined;
+  const bodyHtml = rawHtml ? sanitizeInboundEmailHtml(rawHtml) : undefined;
   const bodyPreview = buildBodyPreview(bodyText);
   const bodyHash = createHash('sha256').update(bodyText).digest('hex');
 

--- a/server/email/middleware.js
+++ b/server/email/middleware.js
@@ -24,7 +24,14 @@ import {
   testEmailConnection,
 } from './transport.js';
 import { triageMessage } from './triage.js';
-import { draftReply, sendEmail, sendReplyVariant } from './smtp.js';
+import { draftReply, resolveReplyVariantSend } from './smtp.js';
+import { cancelSend, enqueueSend, listOutbox } from './outbox.js';
+import { fetchRemoteImage } from './image-proxy.js';
+import {
+  allowImagesFromSender,
+  blockImagesFromSender,
+  listImageAllowlist,
+} from './image-allowlist.js';
 import { improveComposeText } from './compose-ai.js';
 import {
   setMessageFlags,
@@ -116,6 +123,39 @@ export function createEmailMiddleware() {
 
       if (url === '/api/email/events' && req.method === 'GET') {
         handleEmailEventsSse(req, res);
+        return;
+      }
+
+      // Remote images are fetched server-side so the renderer never contacts
+      // the sender's host directly (no Referer, no cookies, no fingerprint).
+      if (url === '/api/email/image-proxy' && req.method === 'GET') {
+        const params = parseQuery(req.url ?? '');
+        const target = String(params.get('url') ?? '');
+        const image = await fetchRemoteImage(target);
+        res.statusCode = 200;
+        res.setHeader('Content-Type', image.contentType);
+        res.setHeader('Cache-Control', 'private, max-age=3600');
+        res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+        res.end(image.body);
+        return;
+      }
+
+      if (url === '/api/email/image-allowlist' && req.method === 'GET') {
+        sendJson(res, 200, { senders: await listImageAllowlist() });
+        return;
+      }
+
+      if (url === '/api/email/image-allowlist' && req.method === 'POST') {
+        const body = await readJsonBody(req);
+        const senders = await allowImagesFromSender(String(body.sender ?? ''));
+        sendJson(res, 200, { senders });
+        return;
+      }
+
+      if (url === '/api/email/image-allowlist' && req.method === 'DELETE') {
+        const params = parseQuery(req.url ?? '');
+        const senders = await blockImagesFromSender(String(params.get('sender') ?? ''));
+        sendJson(res, 200, { senders });
         return;
       }
 
@@ -404,18 +444,14 @@ export function createEmailMiddleware() {
           sendJson(res, 400, { error: 'accountId and threadId are required' });
           return;
         }
-        if (!body.confirmed) {
-          sendJson(res, 400, { error: 'Send requires explicit user confirmation (confirmed: true)' });
-          return;
-        }
-        const result = await sendReplyVariant({
+        const payload = await resolveReplyVariantSend({
           accountId,
           threadId,
           messageKey,
           variantId,
-          confirmed: true,
         });
-        sendJson(res, 200, result);
+        const entry = enqueueSend(payload);
+        sendJson(res, 202, { queued: true, entry });
         return;
       }
 
@@ -448,17 +484,40 @@ export function createEmailMiddleware() {
         return;
       }
 
+      // Send queues into the outbox rather than delivering inline; the undo
+      // window is the send gate. Returns the queued entry, not a receipt.
       if (url === '/api/email/send' && req.method === 'POST') {
         const body = await readJsonBody(req);
-        const result = await sendEmail(body);
-        sendJson(res, 200, result);
+        const entry = enqueueSend(body);
+        sendJson(res, 202, { queued: true, entry });
+        return;
+      }
+
+      if (url === '/api/email/outbox' && req.method === 'GET') {
+        sendJson(res, 200, { entries: listOutbox() });
+        return;
+      }
+
+      const outboxMatch = url.match(/^\/api\/email\/outbox\/([^/]+)$/);
+      if (outboxMatch && req.method === 'DELETE') {
+        const entry = cancelSend(decodeURIComponent(outboxMatch[1]));
+        sendJson(res, 200, { entry });
         return;
       }
 
       sendJson(res, 404, { error: 'Not found' });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Email request failed';
-      sendJson(res, 400, { error: message });
+      // Rate limiting reports 429 so the client can distinguish "slow down"
+      // from "malformed request".
+      const status = Number(/** @type {{ status?: number }} */ (err)?.status) || 400;
+      if (status === 429) {
+        const retryAfterMs = Number(/** @type {{ retryAfterMs?: number }} */ (err)?.retryAfterMs);
+        if (Number.isFinite(retryAfterMs)) {
+          res.setHeader('Retry-After', String(Math.ceil(retryAfterMs / 1000)));
+        }
+      }
+      sendJson(res, status, { error: message });
     }
   };
 }

--- a/server/email/outbox.js
+++ b/server/email/outbox.js
@@ -1,0 +1,175 @@
+/**
+ * Outbound queue with an undo window.
+ *
+ * Send used to be gated by a `confirmed: true` field on the request body, which
+ * is not a capability check at all — anything that can reach the endpoint can
+ * set it. The real gate is now structural: a send is parked for a few seconds
+ * and anyone can cancel it during that window, so an unattended or unintended
+ * send has to survive a period where the user can see and stop it. It also
+ * replaces the `window.confirm` dialog with something less trained-away.
+ *
+ * The queue is in-memory: the window is seconds long, and durability would mean
+ * persisting message bodies to disk. A send still in the window when the app
+ * quits is dropped rather than delivered — the same tradeoff Gmail's undo makes.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { sendEmail } from './smtp.js';
+import { consumeSendAllowance } from './send-rate-limit.js';
+import { emitEmailEvent } from './events.js';
+
+/** How long a queued send can be recalled. */
+export const UNDO_WINDOW_MS = 8_000;
+
+/** Effective window; only tests shorten it, so they don't sleep for real. */
+let undoWindowMs = UNDO_WINDOW_MS;
+
+/**
+ * @typedef {object} OutboxEntry
+ * @property {string} id
+ * @property {string} accountId
+ * @property {string} to
+ * @property {string} subject
+ * @property {'queued' | 'sending' | 'sent' | 'failed' | 'cancelled'} status
+ * @property {string} queuedAt
+ * @property {string} sendAt
+ * @property {string | null} error
+ */
+
+/** @type {Map<string, { entry: OutboxEntry, input: Record<string, unknown>, timer: NodeJS.Timeout }>} */
+const queue = new Map();
+
+/** Terminal entries linger briefly so the UI can render the outcome. */
+const RETAIN_TERMINAL_MS = 60_000;
+
+/**
+ * @param {{ entry: OutboxEntry }} row
+ * @returns {OutboxEntry}
+ */
+function publicEntry(row) {
+  return { ...row.entry };
+}
+
+/**
+ * Queue a send. Returns immediately; delivery happens after the undo window.
+ * @param {Record<string, unknown>} input
+ * @returns {OutboxEntry}
+ */
+export function enqueueSend(input) {
+  const accountId = String(input.accountId ?? '').trim();
+  const to = String(input.to ?? '').trim();
+  const subject = String(input.subject ?? '').trim();
+  if (!accountId) throw new Error('accountId is required');
+  if (!to || !subject) throw new Error('to and subject are required');
+
+  // Charge the allowance at queue time so a flood is refused up front rather
+  // than after the user has been told each message is on its way.
+  consumeSendAllowance(accountId);
+
+  const now = Date.now();
+  const id = randomUUID();
+  /** @type {OutboxEntry} */
+  const entry = {
+    id,
+    accountId,
+    to,
+    subject,
+    status: 'queued',
+    queuedAt: new Date(now).toISOString(),
+    sendAt: new Date(now + undoWindowMs).toISOString(),
+    error: null,
+  };
+
+  const timer = setTimeout(() => {
+    void deliver(id);
+  }, undoWindowMs);
+  // Never hold the process open for a pending send.
+  timer.unref?.();
+
+  queue.set(id, { entry, input: { ...input, accountId, to, subject }, timer });
+  emitEmailEvent('outbox_queued', { entry: { ...entry } });
+  return { ...entry };
+}
+
+/**
+ * @param {string} id
+ */
+async function deliver(id) {
+  const row = queue.get(id);
+  if (!row || row.entry.status !== 'queued') {
+    return;
+  }
+
+  row.entry.status = 'sending';
+  emitEmailEvent('outbox_sending', { entry: { ...row.entry } });
+
+  try {
+    const result = await sendEmail({
+      .../** @type {any} */ (row.input),
+      // The undo window is the confirmation; nothing reaches here without
+      // having survived it.
+      confirmed: true,
+    });
+    row.entry.status = 'sent';
+    row.entry.error = null;
+    emitEmailEvent('outbox_sent', { entry: { ...row.entry }, messageId: result.messageId ?? null });
+  } catch (err) {
+    row.entry.status = 'failed';
+    row.entry.error = err instanceof Error ? err.message : 'Send failed';
+    emitEmailEvent('outbox_failed', { entry: { ...row.entry } });
+  }
+
+  const sweep = setTimeout(() => queue.delete(id), RETAIN_TERMINAL_MS);
+  sweep.unref?.();
+}
+
+/**
+ * Recall a send that is still inside its undo window.
+ * @param {string} id
+ * @returns {OutboxEntry}
+ */
+export function cancelSend(id) {
+  const row = queue.get(String(id ?? ''));
+  if (!row) {
+    throw new Error('Outbox entry not found');
+  }
+  if (row.entry.status !== 'queued') {
+    throw new Error(`Cannot cancel a message that is already ${row.entry.status}`);
+  }
+
+  clearTimeout(row.timer);
+  row.entry.status = 'cancelled';
+  emitEmailEvent('outbox_cancelled', { entry: { ...row.entry } });
+
+  const sweep = setTimeout(() => queue.delete(row.entry.id), RETAIN_TERMINAL_MS);
+  sweep.unref?.();
+  return { ...row.entry };
+}
+
+/**
+ * @returns {OutboxEntry[]} newest first
+ */
+export function listOutbox() {
+  return [...queue.values()]
+    .map(publicEntry)
+    .sort((a, b) => new Date(b.queuedAt).getTime() - new Date(a.queuedAt).getTime());
+}
+
+/** Drop every queued send and clear timers (tests). */
+export function resetOutboxForTests() {
+  for (const row of queue.values()) {
+    clearTimeout(row.timer);
+  }
+  queue.clear();
+  undoWindowMs = UNDO_WINDOW_MS;
+}
+
+/** Shorten the undo window so tests don't wait out the real one. */
+export function setUndoWindowForTests(ms) {
+  undoWindowMs = Number(ms) || UNDO_WINDOW_MS;
+}
+
+/** Current undo window, in ms. */
+export function getUndoWindowMs() {
+  return undoWindowMs;
+}

--- a/server/email/paths.js
+++ b/server/email/paths.js
@@ -40,3 +40,8 @@ export function emailDbPath(accountId) {
 export function emailAutomationsPath() {
   return path.join(emailRootDir(), 'automations.json');
 }
+
+/** Senders whose remote images load without asking. */
+export function emailImageAllowlistPath() {
+  return path.join(emailRootDir(), 'image-allowlist.json');
+}

--- a/server/email/remote-content.js
+++ b/server/email/remote-content.js
@@ -1,0 +1,101 @@
+/**
+ * Remote-content blocking for inbound email HTML.
+ *
+ * A newsletter reaches the network the moment its body renders, so a tracking
+ * pixel leaks the reader's IP address and exact read time back to the sender
+ * before anyone clicks anything. Every remote URL is therefore stripped while
+ * the body is sanitized — before it is ever stored — and parked in a
+ * `data-minnow-remote-*` attribute, so a cached body cannot fetch anything on
+ * its own no matter how it is later rendered.
+ *
+ * The reader re-attaches them through the local image proxy once the user asks
+ * (`src/ui/email/email-body.ts`, which mirrors the attribute names below).
+ */
+
+/** Prefix for every parked URL attribute. Mirrored in `src/ui/email/email-body.ts`. */
+export const REMOTE_ATTR_PREFIX = 'data-minnow-remote-';
+
+/** URL-bearing attributes that trigger a fetch on render. */
+const URL_ATTRS = ['src', 'srcset', 'background', 'poster'];
+
+/** Matches `http:`, `https:` and protocol-relative `//host` URLs. */
+const REMOTE_URL = /^\s*(?:https?:)?\/\//i;
+
+/** Matches a CSS `url(...)` token, quoted or bare. Also catches `image-set()` members. */
+const CSS_URL = /url\(\s*(['"]?)([^'")]*)\1\s*\)/gi;
+
+/**
+ * `cid:` and `data:` URLs resolve without touching the network, so they stay.
+ * @param {string | null | undefined} value
+ */
+function isRemoteUrl(value) {
+  return REMOTE_URL.test(String(value ?? ''));
+}
+
+/**
+ * A srcset is a candidate list; one remote entry taints the whole attribute,
+ * so it is parked wholesale rather than picked apart.
+ * @param {string} value
+ */
+function srcsetHasRemote(value) {
+  return String(value)
+    .split(',')
+    .some((candidate) => isRemoteUrl(candidate.trim().split(/\s+/)[0]));
+}
+
+/**
+ * Replace remote `url(...)` tokens with `none`, which is valid in every
+ * property that accepts a url (background, background-image, list-style-image).
+ * @param {string} style
+ * @returns {{ style: string, blocked: boolean }}
+ */
+function stripRemoteCssUrls(style) {
+  let blocked = false;
+  const next = String(style).replace(CSS_URL, (match, _quote, url) => {
+    if (!isRemoteUrl(url)) return match;
+    blocked = true;
+    return 'none';
+  });
+  return { style: next, blocked };
+}
+
+/**
+ * DOMPurify `afterSanitizeAttributes` hook: park every remote reference on the
+ * node it came from.
+ * @param {Element} node
+ */
+export function blockRemoteContentHook(node) {
+  if (typeof node.getAttribute !== 'function') return;
+
+  for (const attr of URL_ATTRS) {
+    if (!node.hasAttribute(attr)) continue;
+    const value = node.getAttribute(attr) ?? '';
+    const remote = attr === 'srcset' ? srcsetHasRemote(value) : isRemoteUrl(value);
+    if (!remote) continue;
+    // Remove rather than blank: an empty `src` re-requests the host document
+    // in some engines, which is exactly the beacon we are trying to suppress.
+    node.removeAttribute(attr);
+    node.setAttribute(`${REMOTE_ATTR_PREFIX}${attr}`, value);
+  }
+
+  if (node.hasAttribute('style')) {
+    const original = node.getAttribute('style') ?? '';
+    const { style, blocked } = stripRemoteCssUrls(original);
+    if (blocked) {
+      node.setAttribute('style', style);
+      node.setAttribute(`${REMOTE_ATTR_PREFIX}style`, original);
+    }
+  }
+}
+
+/**
+ * Count parked references in a sanitized body, for the "N images blocked"
+ * banner. Attribute-based so it needs no extra cache column.
+ * @param {string | null | undefined} html
+ */
+export function countBlockedRemoteRefs(html) {
+  const matches = String(html ?? '').match(
+    new RegExp(`${REMOTE_ATTR_PREFIX}(?:src|srcset|background|poster|style)=`, 'gi'),
+  );
+  return matches ? matches.length : 0;
+}

--- a/server/email/sanitize-html.js
+++ b/server/email/sanitize-html.js
@@ -3,6 +3,7 @@
  */
 
 import DOMPurify from 'isomorphic-dompurify';
+import { blockRemoteContentHook } from './remote-content.js';
 
 /** Skip caching very large HTML bodies; plain text fallback remains. */
 const MAX_HTML_CHARS = 512_000;
@@ -32,23 +33,47 @@ const PURIFY_CONFIG = {
 
 /**
  * @param {string | undefined | null} html
+ * @param {{ blockRemoteContent?: boolean }} [options]
  * @returns {string | undefined}
  */
-export function sanitizeEmailHtml(html) {
+export function sanitizeEmailHtml(html, options = {}) {
   const raw = String(html ?? '').trim();
   if (!raw || raw.length > MAX_HTML_CHARS) {
     return undefined;
   }
 
-  let clean = DOMPurify.sanitize(raw, PURIFY_CONFIG);
-  for (let i = 0; i < 3; i += 1) {
-    const next = DOMPurify.sanitize(clean, PURIFY_CONFIG);
-    if (next === clean) {
-      break;
-    }
-    clean = next;
+  // Hooks are global to the DOMPurify instance, so they are installed only for
+  // the duration of this (synchronous) call — otherwise outbound mail composed
+  // in a later call would get its own images stripped too.
+  if (options.blockRemoteContent) {
+    DOMPurify.addHook('afterSanitizeAttributes', blockRemoteContentHook);
   }
+  try {
+    let clean = DOMPurify.sanitize(raw, PURIFY_CONFIG);
+    for (let i = 0; i < 3; i += 1) {
+      const next = DOMPurify.sanitize(clean, PURIFY_CONFIG);
+      if (next === clean) {
+        break;
+      }
+      clean = next;
+    }
 
-  const trimmed = String(clean).trim();
-  return trimmed || undefined;
+    const trimmed = String(clean).trim();
+    return trimmed || undefined;
+  } finally {
+    if (options.blockRemoteContent) {
+      DOMPurify.removeHook('afterSanitizeAttributes', blockRemoteContentHook);
+    }
+  }
+}
+
+/**
+ * Sanitize a body that arrived from the network. Identical to
+ * {@link sanitizeEmailHtml} but with remote content parked, so a stored body
+ * can never beacon on render. Use this for anything inbound.
+ * @param {string | undefined | null} html
+ * @returns {string | undefined}
+ */
+export function sanitizeInboundEmailHtml(html) {
+  return sanitizeEmailHtml(html, { blockRemoteContent: true });
 }

--- a/server/email/send-rate-limit.js
+++ b/server/email/send-rate-limit.js
@@ -1,0 +1,61 @@
+/**
+ * Per-account send rate limiting.
+ *
+ * A compromised renderer, a runaway automation, or a loop in a reply rule can
+ * all turn the send path into a spam cannon using the user's own credentials —
+ * which gets the account blacklisted, not just the app. The cap is well above
+ * any plausible human sending rate, so it only ever trips on a malfunction.
+ */
+
+/** Sends allowed per account per window. */
+const MAX_SENDS_PER_WINDOW = 20;
+
+/** Sliding window length. */
+const WINDOW_MS = 60_000;
+
+/** @type {Map<string, number[]>} accountId -> send timestamps within the window */
+const sendTimestamps = new Map();
+
+/**
+ * @param {string} accountId
+ * @param {number} now
+ * @returns {number[]} timestamps still inside the window
+ */
+function recentSends(accountId, now) {
+  const cutoff = now - WINDOW_MS;
+  const kept = (sendTimestamps.get(accountId) ?? []).filter((ts) => ts > cutoff);
+  if (kept.length === 0) {
+    sendTimestamps.delete(accountId);
+  } else {
+    sendTimestamps.set(accountId, kept);
+  }
+  return kept;
+}
+
+/**
+ * Record one send, or throw when the account is over its limit.
+ * @param {string} accountId
+ * @param {number} [now]
+ */
+export function consumeSendAllowance(accountId, now = Date.now()) {
+  const key = String(accountId ?? '').trim() || 'unknown';
+  const recent = recentSends(key, now);
+  if (recent.length >= MAX_SENDS_PER_WINDOW) {
+    const retryAfterMs = Math.max(0, recent[0] + WINDOW_MS - now);
+    const err = new Error(
+      `Send rate limit reached for this account (${MAX_SENDS_PER_WINDOW}/min). Try again in ${Math.ceil(retryAfterMs / 1000)}s.`,
+    );
+    // Surfaced as HTTP 429 by the middleware.
+    /** @type {Error & { status?: number, retryAfterMs?: number }} */ (err).status = 429;
+    /** @type {Error & { status?: number, retryAfterMs?: number }} */ (err).retryAfterMs =
+      retryAfterMs;
+    throw err;
+  }
+  recent.push(now);
+  sendTimestamps.set(key, recent);
+}
+
+/** Reset all counters (tests). */
+export function resetSendRateLimitForTests() {
+  sendTimestamps.clear();
+}

--- a/server/email/smtp.js
+++ b/server/email/smtp.js
@@ -103,14 +103,16 @@ export async function draftReply(input) {
 }
 
 /**
- * Send an email after explicit user confirmation.
- * @param {{ accountId: string, to: string, subject: string, body: string, bodyHtml?: string, cc?: string, bcc?: string, inReplyTo?: string, references?: string, confirmed: boolean }} input
+ * Deliver an email over SMTP.
+ *
+ * Not the user-facing entry point: callers go through `enqueueSend` in
+ * `outbox.js`, whose undo window is the actual send gate. This used to demand a
+ * `confirmed: true` field, which proved nothing — any caller that could reach
+ * the function could set it.
+ *
+ * @param {{ accountId: string, to: string, subject: string, body: string, bodyHtml?: string, cc?: string, bcc?: string, inReplyTo?: string, references?: string }} input
  */
 export async function sendEmail(input) {
-  if (!input.confirmed) {
-    throw new Error('Send requires explicit user confirmation (confirmed: true)');
-  }
-
   const account = await getEmailAccount(input.accountId);
   if (!account) {
     throw new Error('Email account not found');
@@ -157,14 +159,14 @@ export async function sendEmail(input) {
 }
 
 /**
- * Send a pre-generated reply variant after explicit confirmation.
- * @param {{ accountId: string, threadId: string, messageKey: string, variantId: string, confirmed: boolean }} input
+ * Resolve a pre-generated reply variant into a ready-to-send payload.
+ *
+ * Kept separate from delivery so the caller can hand the payload to the outbox
+ * and give the user an undo window, rather than sending straight away.
+ *
+ * @param {{ accountId: string, threadId: string, messageKey: string, variantId: string }} input
  */
-export async function sendReplyVariant(input) {
-  if (!input.confirmed) {
-    throw new Error('Send requires explicit user confirmation (confirmed: true)');
-  }
-
+export async function resolveReplyVariantSend(input) {
   const account = await getEmailAccount(input.accountId);
   if (!account) {
     throw new Error('Email account not found');
@@ -188,13 +190,12 @@ export async function sendReplyVariant(input) {
 
   const headers = computeReplyHeaders(thread, account);
 
-  return sendEmail({
+  return {
     accountId: input.accountId,
     to: headers.to,
     subject: headers.subject,
     body: String(variant.body ?? ''),
     inReplyTo: headers.inReplyTo,
     references: headers.references,
-    confirmed: true,
-  });
+  };
 }

--- a/src/email/client-ext.ts
+++ b/src/email/client-ext.ts
@@ -8,6 +8,7 @@ import type {
   EmailDraft,
   EmailInboxSummary,
   EmailMessage,
+  OutboxEntry,
   ReplyVariant,
 } from './client';
 import { withSessionToken } from '../api/session-token.ts';
@@ -132,18 +133,19 @@ export async function regenerateReplyVariants(input: {
   return parseJson(res);
 }
 
+/** Queue a reply variant. Recallable during its undo window, like any send. */
 export async function sendReplyVariant(input: {
   accountId: string;
   messageId: string;
   threadId: string;
   variantId: string;
-}): Promise<{ ok: boolean }> {
+}): Promise<{ queued: boolean; entry: OutboxEntry }> {
   const res = await fetch(
     `/api/email/messages/${encodeURIComponent(input.messageId)}/reply-variants/${encodeURIComponent(input.variantId)}/send`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...input, confirmed: true }),
+      body: JSON.stringify(input),
     },
   );
   return parseJson(res);

--- a/src/email/client.ts
+++ b/src/email/client.ts
@@ -296,6 +296,22 @@ export async function improveEmailText(input: {
   return parseJson(res);
 }
 
+/** A send parked in the outbox during its undo window. */
+export interface OutboxEntry {
+  id: string;
+  accountId: string;
+  to: string;
+  subject: string;
+  status: 'queued' | 'sending' | 'sent' | 'failed' | 'cancelled';
+  queuedAt: string;
+  sendAt: string;
+  error: string | null;
+}
+
+/**
+ * Queue a message. It is not delivered immediately — the returned entry can be
+ * recalled with {@link cancelOutboxSend} until `sendAt`.
+ */
 export async function sendEmailMessage(input: {
   accountId: string;
   to: string;
@@ -306,12 +322,58 @@ export async function sendEmailMessage(input: {
   bcc?: string;
   inReplyTo?: string;
   references?: string;
-  confirmed: boolean;
-}): Promise<{ ok: boolean; messageId?: string }> {
+}): Promise<{ queued: boolean; entry: OutboxEntry }> {
   const res = await fetch('/api/email/send', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
   });
   return parseJson(res);
+}
+
+export async function fetchOutbox(): Promise<{ entries: OutboxEntry[] }> {
+  const res = await fetch('/api/email/outbox');
+  return parseJson(res);
+}
+
+/** Recall a queued send. Fails once the undo window has closed. */
+export async function cancelOutboxSend(id: string): Promise<{ entry: OutboxEntry }> {
+  const res = await fetch(`/api/email/outbox/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  return parseJson(res);
+}
+
+/**
+ * Reduce a From header to a bare, comparable address.
+ * Mirrors `normalizeSender` in `server/email/image-allowlist.js`.
+ */
+export function normalizeSender(from: string | null | undefined): string {
+  const raw = String(from ?? '').trim();
+  const angled = /<([^>]+)>/.exec(raw);
+  return (angled ? angled[1] : raw).trim().toLowerCase();
+}
+
+/** Senders whose remote images load without asking. */
+export async function fetchImageAllowlist(): Promise<string[]> {
+  const res = await fetch('/api/email/image-allowlist');
+  const data = await parseJson<{ senders: string[] }>(res);
+  return data.senders;
+}
+
+export async function allowImagesFromSender(sender: string): Promise<string[]> {
+  const res = await fetch('/api/email/image-allowlist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sender }),
+  });
+  const data = await parseJson<{ senders: string[] }>(res);
+  return data.senders;
+}
+
+export async function blockImagesFromSender(sender: string): Promise<string[]> {
+  const res = await fetch(
+    `/api/email/image-allowlist?sender=${encodeURIComponent(sender)}`,
+    { method: 'DELETE' },
+  );
+  const data = await parseJson<{ senders: string[] }>(res);
+  return data.senders;
 }

--- a/src/styles/email.css
+++ b/src/styles/email.css
@@ -252,38 +252,60 @@
   word-break: break-word;
 }
 
+/*
+ * Formatted bodies live inside a sandboxed iframe, so the app stylesheet can no
+ * longer reach their contents — the typography and image rules that used to sit
+ * here now ship as the frame's own reset (MAIL_RESET_CSS in email-body.ts).
+ * Only the frame element itself is styled from out here.
+ */
 .email-thread-body.html-body {
   white-space: normal;
+  overflow-x: hidden;
 }
 
-.email-thread-body.html-body img {
-  max-width: 100%;
-  height: auto;
+.email-body-frame {
+  display: block;
+  width: 100%;
+  min-height: 40px;
+  border: 0;
+  /* The frame paints its own light surface; a matching backdrop keeps the
+     edges from flashing dark before load. */
+  background: #ffffff;
+  border-radius: 6px;
+  color-scheme: light;
 }
 
-.email-thread-body.html-body table {
-  max-width: 100%;
-  border-collapse: collapse;
-}
-
-.email-thread-body.html-body a {
-  color: var(--mn-accent);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.email-thread-body.html-body blockquote {
-  margin: 0.75em 0;
-  padding-left: 12px;
-  border-left: 1px solid var(--mn-border);
+.email-remote-notice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--mn-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mn-accent) 8%, transparent);
+  font-size: 12.5px;
   color: var(--mn-fg-muted);
 }
 
-.email-thread-body.html-body pre {
-  white-space: pre-wrap;
-  overflow-x: auto;
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 13px;
+.email-remote-notice-text {
+  flex: 1 1 auto;
+}
+
+.email-remote-notice button {
+  flex: 0 0 auto;
+  padding: 3px 9px;
+  border: 1px solid var(--mn-border);
+  border-radius: 6px;
+  background: var(--mn-bg);
+  color: var(--mn-fg);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.email-remote-notice button:hover {
+  border-color: var(--mn-accent);
 }
 
 .email-thread-triage {
@@ -2043,4 +2065,50 @@
   .email-reader-primary-actions .email-btn-icon {
     padding: 8px;
   }
+}
+
+/*
+ * Undo toast for queued sends. Fixed to the viewport rather than the mail
+ * layout so it survives the composer unmounting the moment a send is queued.
+ */
+.email-undo-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  z-index: 60;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  border: 1px solid var(--mn-border);
+  border-radius: 10px;
+  background: var(--mn-bg-elevated, var(--mn-bg));
+  color: var(--mn-fg);
+  box-shadow: 0 6px 24px rgb(0 0 0 / 28%);
+  font-size: 13px;
+}
+
+.email-undo-toast-text {
+  white-space: nowrap;
+}
+
+.email-undo-toast-btn {
+  padding: 4px 12px;
+  border: 1px solid var(--mn-accent);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--mn-accent);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.email-undo-toast-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--mn-accent) 14%, transparent);
+}
+
+.email-undo-toast-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
 }

--- a/src/ui/email/email-body.ts
+++ b/src/ui/email/email-body.ts
@@ -1,9 +1,22 @@
 /**
- * Safe HTML rendering for email message bodies in the reading pane.
+ * Mail body rendering.
+ *
+ * Bodies are hostile documents written by strangers, so they are never injected
+ * into the app DOM. Each one renders inside a sandboxed iframe with its own
+ * reset stylesheet, which fixes three things at once: sender CSS can no longer
+ * restyle the app (and app CSS can no longer mangle the mail), a newsletter
+ * built for a white background stays readable under a dark app theme, and the
+ * frame's CSP gives a second, browser-enforced guarantee that nothing is
+ * fetched from the sender's servers.
+ *
+ * Remote content is parked server-side at sanitize time (see
+ * `server/email/remote-content.js`); the same parking is repeated here so that
+ * bodies cached before that landed are covered too.
  */
 
 import DOMPurify from 'dompurify';
 import type { EmailMessage } from '../../email/client';
+import { withSessionToken } from '../../api/session-token';
 
 const EMAIL_PURIFY_CONFIG = {
   USE_PROFILES: { html: true },
@@ -27,28 +40,216 @@ const EMAIL_PURIFY_CONFIG = {
   ],
 };
 
+/** Mirrors `REMOTE_ATTR_PREFIX` in `server/email/remote-content.js`. */
+const REMOTE_ATTR_PREFIX = 'data-minnow-remote-';
+
+/** URL-bearing attributes that trigger a fetch on render. */
+const URL_ATTRS = ['src', 'srcset', 'background', 'poster'] as const;
+
+const REMOTE_URL = /^\s*(?:https?:)?\/\//i;
+const CSS_URL = /url\(\s*(['"]?)([^'")]*)\1\s*\)/gi;
+
 type BodySource = Pick<EmailMessage, 'bodyHtml' | 'bodyText' | 'bodyPreview'>;
 
 /** Reader toggle: formatted HTML vs plain-text alternative. */
 export type EmailBodyViewMode = 'html' | 'plain';
+
+export interface EmailBodyRenderOptions {
+  viewMode?: EmailBodyViewMode;
+  /** Re-attach parked images through the local proxy. */
+  loadRemoteImages?: boolean;
+  /** Reports how many remote references were withheld, for the "load images" bar. */
+  onRemoteContent?: (info: { blockedCount: number }) => void;
+}
 
 /** True when the message has both sanitized HTML and a plain-text alternative. */
 export function emailBodySupportsViewToggle(message: BodySource): boolean {
   return Boolean(message.bodyHtml?.trim() && (message.bodyText ?? message.bodyPreview ?? '').trim());
 }
 
-/** Harden external links opened from formatted mail bodies. */
-function secureLinks(root: HTMLElement): void {
-  root.querySelectorAll('a[href]').forEach((anchor) => {
-    const href = anchor.getAttribute('href') ?? '';
-    const lower = href.trim().toLowerCase();
-    if (lower.startsWith('javascript:') || lower.startsWith('vbscript:') || lower.startsWith('data:')) {
-      anchor.removeAttribute('href');
-      return;
-    }
-    anchor.setAttribute('target', '_blank');
-    anchor.setAttribute('rel', 'noopener noreferrer');
+function isRemoteUrl(value: string | null | undefined): boolean {
+  return REMOTE_URL.test(String(value ?? ''));
+}
+
+/** Route a remote URL through the local proxy, which strips referrer and cookies. */
+function proxied(url: string): string {
+  return withSessionToken(`/api/email/image-proxy?url=${encodeURIComponent(url)}`);
+}
+
+/** A srcset is a candidate list; proxy each candidate but keep the descriptors. */
+function proxiedSrcset(value: string): string {
+  return value
+    .split(',')
+    .map((candidate) => {
+      const parts = candidate.trim().split(/\s+/);
+      const url = parts.shift() ?? '';
+      if (!isRemoteUrl(url)) return candidate.trim();
+      return [proxied(url), ...parts].join(' ');
+    })
+    .join(', ');
+}
+
+function rewriteCssUrls(style: string, load: boolean): { style: string; blocked: number } {
+  let blocked = 0;
+  const next = style.replace(CSS_URL, (match, _quote, url: string) => {
+    if (!isRemoteUrl(url)) return match;
+    if (load) return `url("${proxied(url)}")`;
+    blocked += 1;
+    return 'none';
   });
+  return { style: next, blocked };
+}
+
+/**
+ * Park or re-attach every remote reference on one element.
+ * @returns how many references were withheld
+ */
+function applyRemotePolicy(el: Element, load: boolean): number {
+  let blocked = 0;
+
+  for (const attr of URL_ATTRS) {
+    const parkedName = `${REMOTE_ATTR_PREFIX}${attr}`;
+    // Either the server already parked it, or this is a legacy cached body
+    // where the live attribute is still pointing at the sender's host.
+    const parked = el.getAttribute(parkedName);
+    const live = el.getAttribute(attr);
+    const original = parked ?? (isRemoteUrl(live) ? live : null);
+    if (!original) continue;
+
+    if (load) {
+      el.setAttribute(attr, attr === 'srcset' ? proxiedSrcset(original) : proxied(original));
+      el.removeAttribute(parkedName);
+    } else {
+      el.removeAttribute(attr);
+      el.setAttribute(parkedName, original);
+      blocked += 1;
+    }
+  }
+
+  const parkedStyle = el.getAttribute(`${REMOTE_ATTR_PREFIX}style`);
+  const liveStyle = el.getAttribute('style');
+  const originalStyle = parkedStyle ?? liveStyle;
+  if (originalStyle && CSS_URL.test(originalStyle)) {
+    CSS_URL.lastIndex = 0;
+    const result = rewriteCssUrls(originalStyle, load);
+    el.setAttribute('style', result.style);
+    if (load) {
+      el.removeAttribute(`${REMOTE_ATTR_PREFIX}style`);
+    } else if (result.blocked > 0) {
+      el.setAttribute(`${REMOTE_ATTR_PREFIX}style`, originalStyle);
+      blocked += result.blocked;
+    }
+  }
+  CSS_URL.lastIndex = 0;
+
+  return blocked;
+}
+
+/**
+ * Apply the remote-content policy across a parsed body.
+ *
+ * Takes an inert root (a `<template>`'s content) so nothing has been fetched by
+ * the time it runs.
+ *
+ * @param load re-attach images through the proxy instead of withholding them
+ * @returns how many remote references were withheld
+ */
+export function applyRemoteContentPolicy(root: ParentNode, load: boolean): number {
+  let blocked = 0;
+  root.querySelectorAll('*').forEach((el) => {
+    blocked += applyRemotePolicy(el, load);
+    if (el.tagName === 'A') secureLink(el);
+  });
+  return blocked;
+}
+
+/** Harden external links so a click can't reach back into the app. */
+function secureLink(anchor: Element): void {
+  const href = anchor.getAttribute('href') ?? '';
+  const lower = href.trim().toLowerCase();
+  if (lower.startsWith('javascript:') || lower.startsWith('vbscript:') || lower.startsWith('data:')) {
+    anchor.removeAttribute('href');
+    return;
+  }
+  anchor.setAttribute('target', '_blank');
+  anchor.setAttribute('rel', 'noopener noreferrer');
+}
+
+/**
+ * Reset stylesheet for the frame.
+ *
+ * Deliberately theme-independent: mail is authored against a white background,
+ * so recolouring it to match a dark app theme is what makes newsletters
+ * unreadable. The surface stays light in both themes and the app frame around
+ * it carries the theming instead.
+ */
+const MAIL_RESET_CSS = `
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: #ffffff;
+    color: #1a1a1a;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+  body { padding: 12px; }
+  img, video { max-width: 100%; height: auto; }
+  table { max-width: 100%; border-collapse: collapse; }
+  a { color: #0b5fff; }
+  blockquote {
+    margin: 0 0 0 8px;
+    padding-left: 10px;
+    border-left: 2px solid #d0d0d0;
+    color: #555;
+  }
+  pre { white-space: pre-wrap; }
+  /* Withheld images collapse to a marker instead of a broken-image icon. */
+  [${REMOTE_ATTR_PREFIX}src], [${REMOTE_ATTR_PREFIX}srcset] {
+    display: inline-block;
+    min-width: 12px;
+    min-height: 12px;
+    background: repeating-linear-gradient(45deg, #f2f2f2, #f2f2f2 4px, #e6e6e6 4px, #e6e6e6 8px);
+    border: 1px dashed #c8c8c8;
+    border-radius: 2px;
+  }
+`;
+
+/**
+ * Build the frame document.
+ *
+ * The CSP is the backstop for the whole remote-content story: even if the
+ * parking above missed an attribute, `img-src` permits only same-origin (the
+ * proxy) and inline data, so the sender's host is unreachable from here.
+ */
+function buildSrcdoc(bodyHtml: string): string {
+  const csp = [
+    "default-src 'none'",
+    "img-src 'self' data: cid:",
+    "style-src 'unsafe-inline'",
+    'font-src data:',
+    "form-action 'none'",
+  ].join('; ');
+
+  return [
+    '<!doctype html><html><head>',
+    `<meta http-equiv="Content-Security-Policy" content="${csp}">`,
+    '<meta name="referrer" content="no-referrer">',
+    `<style>${MAIL_RESET_CSS}</style>`,
+    '</head><body>',
+    bodyHtml,
+    '</body></html>',
+  ].join('');
+}
+
+/** Grow the frame to its content so the reading pane scrolls, not the frame. */
+function fitFrameToContent(frame: HTMLIFrameElement): void {
+  const doc = frame.contentDocument;
+  if (!doc?.body) return;
+  const height = Math.max(doc.body.scrollHeight, doc.documentElement?.scrollHeight ?? 0);
+  frame.style.height = `${height}px`;
 }
 
 /**
@@ -58,8 +259,10 @@ function secureLinks(root: HTMLElement): void {
 export function renderEmailBody(
   mount: HTMLElement,
   message: BodySource,
-  viewMode: EmailBodyViewMode = 'html',
+  opts: EmailBodyRenderOptions = {},
 ): void {
+  const viewMode = opts.viewMode ?? 'html';
+
   mount.replaceChildren();
   const html = message.bodyHtml?.trim();
   const plain = message.bodyText ?? message.bodyPreview ?? '';
@@ -67,17 +270,39 @@ export function renderEmailBody(
   if (viewMode === 'plain' && html && plain.trim()) {
     mount.classList.remove('html-body');
     mount.textContent = plain;
+    opts.onRemoteContent?.({ blockedCount: 0 });
     return;
   }
 
-  if (html) {
-    mount.classList.add('html-body');
-    const clean = DOMPurify.sanitize(html, EMAIL_PURIFY_CONFIG);
-    mount.innerHTML = clean;
-    secureLinks(mount);
+  if (!html) {
+    mount.classList.remove('html-body');
+    mount.textContent = plain;
+    opts.onRemoteContent?.({ blockedCount: 0 });
     return;
   }
 
-  mount.classList.remove('html-body');
-  mount.textContent = plain;
+  mount.classList.add('html-body');
+  const clean = DOMPurify.sanitize(html, EMAIL_PURIFY_CONFIG);
+
+  // A <template> fragment is inert: parsing into it does not fetch anything, so
+  // the rewrite below happens before any URL could be dereferenced.
+  const template = document.createElement('template');
+  template.innerHTML = clean;
+
+  const load = opts.loadRemoteImages === true;
+  const blockedCount = applyRemoteContentPolicy(template.content, load);
+
+  const frame = document.createElement('iframe');
+  frame.className = 'email-body-frame';
+  // No allow-scripts, ever. allow-same-origin is what lets us measure the
+  // content height; on its own it grants no script execution, but the two
+  // together would let the frame reach out of the sandbox.
+  frame.setAttribute('sandbox', 'allow-same-origin allow-popups allow-popups-to-escape-sandbox');
+  frame.setAttribute('referrerpolicy', 'no-referrer');
+  frame.setAttribute('title', 'Message body');
+  frame.srcdoc = buildSrcdoc(template.innerHTML);
+  frame.addEventListener('load', () => fitFrameToContent(frame));
+
+  mount.appendChild(frame);
+  opts.onRemoteContent?.({ blockedCount });
 }

--- a/src/ui/email/email-compose.ts
+++ b/src/ui/email/email-compose.ts
@@ -16,6 +16,7 @@ import {
   resolveReplyTarget,
 } from "../../email/reply-headers";
 import { createComposeBodyEditor } from "./email-compose-editor";
+import { showSendUndoToast } from "./email-undo-toast";
 
 export type ComposeMode = "reply" | "replyAll" | "forward" | "new";
 
@@ -28,6 +29,8 @@ export interface EmailComposeOptions {
   onStatus?: (state: "ok" | "err", message: string) => void;
   onSent?: () => void;
   onRefresh?: () => void;
+  /** Prefilled fields, used to restore a composer after an undone send. */
+  draft?: { to?: string; cc?: string; subject?: string; body?: string };
 }
 
 function el<K extends keyof HTMLElementTagNameMap>(
@@ -235,6 +238,17 @@ export function mountEmailCompose(
   };
 
   const applyModeDefaults = () => {
+    // A restored draft is what the user actually typed, so it wins over
+    // anything the reply/forward defaults would compute.
+    if (options.draft) {
+      const { to, cc, subject, body } = options.draft;
+      if (to !== undefined) toInput.value = to;
+      if (cc !== undefined) ccInput.value = cc;
+      if (subject !== undefined) subjectInput.value = subject;
+      if (body !== undefined) bodyEditor.setPlainText(body);
+      return;
+    }
+
     const latest = options.messages?.[options.messages.length - 1];
     const accountEmail =
       options.account.username || options.account.fromAddress || "";
@@ -484,9 +498,6 @@ export function mountEmailCompose(
       return;
     }
 
-    const ok = window.confirm(`Send to ${to}?\n\nSubject: ${subject}`);
-    if (!ok) return;
-
     const latest = options.messages?.[options.messages.length - 1];
     const replyHeaders =
       options.mode !== "new" && latest
@@ -497,7 +508,8 @@ export function mountEmailCompose(
         : undefined;
 
     try {
-      await sendEmailMessage({
+      // Queued, not sent: the undo window below is what confirms the send.
+      const { entry } = await sendEmailMessage({
         accountId: options.account.id,
         to,
         cc: cc || undefined,
@@ -506,10 +518,17 @@ export function mountEmailCompose(
         bodyHtml,
         inReplyTo: replyHeaders?.inReplyTo,
         references: replyHeaders?.references,
-        confirmed: true,
       });
 
-      options.onStatus?.("ok", "Email sent");
+      showSendUndoToast(entry, {
+        onStatus: options.onStatus,
+        // Put the draft back in front of the user rather than silently
+        // discarding what they just wrote.
+        onUndo: () => {
+          mountEmailCompose(mount, { ...options, draft: { to, cc, subject, body } });
+        },
+      });
+
       options.onSent?.();
     } catch (err) {
       options.onStatus?.(

--- a/src/ui/email/email-dashboard.ts
+++ b/src/ui/email/email-dashboard.ts
@@ -9,6 +9,7 @@ import {
   regenerateReplyVariants,
   sendReplyVariant,
 } from '../../email/client-ext';
+import { showSendUndoToast } from './email-undo-toast';
 
 export interface EmailDashboardOptions {
   account: EmailAccount;
@@ -69,16 +70,15 @@ function renderVariantChips(
     chip.textContent = variant.label;
     chip.title = variant.body.slice(0, 120);
     chip.addEventListener('click', async () => {
-      const ok = window.confirm(`Send "${variant.label}" reply to this thread?`);
-      if (!ok) return;
       try {
-        await sendReplyVariant({
+        // Queued rather than sent — the undo toast is the confirmation step.
+        const { entry } = await sendReplyVariant({
           accountId: account.id,
           messageId: highlight.messageId,
           threadId: highlight.threadId,
           variantId: variant.id,
         });
-        options.onStatus?.('ok', 'Reply sent');
+        showSendUndoToast(entry, { onStatus: options.onStatus });
       } catch (err) {
         options.onStatus?.('err', err instanceof Error ? err.message : 'Send failed');
       }

--- a/src/ui/email/email-layout.ts
+++ b/src/ui/email/email-layout.ts
@@ -6,7 +6,13 @@
 
 import type { EmailAccount, EmailMessage } from "../../email/client";
 
-import { syncEmailFolder, fetchEmailThread } from "../../email/client";
+import {
+  allowImagesFromSender,
+  fetchEmailThread,
+  fetchImageAllowlist,
+  normalizeSender,
+  syncEmailFolder,
+} from "../../email/client";
 
 import {
   archiveEmailMessage,
@@ -28,6 +34,16 @@ import {
 } from "./email-body";
 
 import { EMAIL_ICONS } from "./email-icons";
+
+/**
+ * Senders allowed to load remote images, cached for the session. `null` until
+ * the first fetch resolves — bodies paint blocked in the meantime, so a slow
+ * request can never cause images to load before the allowlist is known.
+ */
+let imageAllowlist: string[] | null = null;
+
+/** Messages the user opted into for this session only ("Load images" once). */
+const imagesLoadedFor = new Set<string>();
 
 export interface EmailLayoutOptions {
   account: EmailAccount;
@@ -71,6 +87,91 @@ function iconBtn(
   btn.innerHTML = svg;
 
   return btn;
+}
+
+/**
+ * Render one message body plus the remote-content bar.
+ *
+ * Images stay withheld until the user asks for this message, or has previously
+ * trusted the sender — see `server/email/remote-content.js` for why they are
+ * blocked in the first place.
+ */
+function renderBodyWithRemoteControls(
+  msg: EmailMessage,
+  viewMode: EmailBodyViewMode,
+  onStatus?: (state: "ok" | "err", message: string) => void,
+): HTMLElement {
+  const wrap = el("div", "email-thread-body-wrap");
+  const sender = normalizeSender(msg.from);
+
+  const paint = (load: boolean): void => {
+    wrap.replaceChildren();
+
+    const notice = el("div", "email-remote-notice");
+    notice.hidden = true;
+    const body = el("div", "email-thread-body");
+    wrap.append(notice, body);
+
+    renderEmailBody(body, msg, {
+      viewMode,
+      loadRemoteImages: load,
+      onRemoteContent: ({ blockedCount }) => {
+        if (load || blockedCount === 0) return;
+
+        const label = blockedCount === 1 ? "1 remote image" : `${blockedCount} remote images`;
+        const text = el(
+          "span",
+          "email-remote-notice-text",
+          `${label} blocked to keep your address and read time private.`,
+        );
+
+        const loadOnce = el("button", "", "Load images") as HTMLButtonElement;
+        loadOnce.type = "button";
+        loadOnce.addEventListener("click", () => {
+          imagesLoadedFor.add(msg.id);
+          paint(true);
+        });
+
+        notice.replaceChildren(text, loadOnce);
+
+        if (sender) {
+          const always = el("button", "", "Always from this sender") as HTMLButtonElement;
+          always.type = "button";
+          always.addEventListener("click", async () => {
+            try {
+              imageAllowlist = await allowImagesFromSender(sender);
+              paint(true);
+            } catch (err) {
+              onStatus?.(
+                "err",
+                err instanceof Error ? err.message : "Could not update the image allowlist",
+              );
+            }
+          });
+          notice.appendChild(always);
+        }
+
+        notice.hidden = false;
+      },
+    });
+  };
+
+  const trusted = imagesLoadedFor.has(msg.id) || (imageAllowlist?.includes(sender) ?? false);
+  paint(trusted);
+
+  // Prime the allowlist once, then repaint if this sender turns out to be on it.
+  if (imageAllowlist === null) {
+    void fetchImageAllowlist()
+      .then((senders) => {
+        imageAllowlist = senders;
+        if (!trusted && senders.includes(sender)) paint(true);
+      })
+      .catch(() => {
+        imageAllowlist = [];
+      });
+  }
+
+  return wrap;
 }
 
 function formatWhen(iso?: string): string {
@@ -1065,11 +1166,9 @@ export async function renderEmailLayout(
           block.appendChild(attRow);
         }
 
-        const body = el("div", "email-thread-body");
-
-        renderEmailBody(body, msg, bodyViewMode);
-
-        block.appendChild(body);
+        block.appendChild(
+          renderBodyWithRemoteControls(msg, bodyViewMode, options.onStatus),
+        );
 
         bodyStack.appendChild(block);
       }

--- a/src/ui/email/email-undo-toast.ts
+++ b/src/ui/email/email-undo-toast.ts
@@ -1,0 +1,94 @@
+/**
+ * Undo affordance for queued sends.
+ *
+ * This is the replacement for the pre-send `window.confirm`. A modal asking
+ * "are you sure?" is answered reflexively after the third time and stops being
+ * a real check; a few seconds during which the send is visibly recallable
+ * catches the mistakes people actually make — wrong recipient, missing
+ * attachment, sent-too-soon — without gating the common case behind a click.
+ */
+
+import { cancelOutboxSend, type OutboxEntry } from '../../email/client';
+
+let activeToast: HTMLElement | null = null;
+
+function dismiss(): void {
+  activeToast?.remove();
+  activeToast = null;
+}
+
+export interface SendUndoToastOptions {
+  /** The send was recalled and the composer should reopen. */
+  onUndo?: (entry: OutboxEntry) => void;
+  onStatus?: (state: 'ok' | 'err', message: string) => void;
+}
+
+/**
+ * Show "Sending… / Undo" until the entry's undo window closes.
+ * @returns a function that dismisses the toast early
+ */
+export function showSendUndoToast(
+  entry: OutboxEntry,
+  options: SendUndoToastOptions = {},
+): () => void {
+  // Only one send is ever in flight from the composer; a second replaces the first.
+  dismiss();
+
+  const toast = document.createElement('div');
+  toast.className = 'email-undo-toast';
+  toast.setAttribute('role', 'status');
+
+  const label = document.createElement('span');
+  label.className = 'email-undo-toast-text';
+
+  const undoBtn = document.createElement('button');
+  undoBtn.type = 'button';
+  undoBtn.className = 'email-undo-toast-btn';
+  undoBtn.textContent = 'Undo';
+
+  toast.append(label, undoBtn);
+  document.body.appendChild(toast);
+  activeToast = toast;
+
+  const deadline = new Date(entry.sendAt).getTime();
+  let timer = 0;
+
+  const stop = (): void => {
+    window.clearInterval(timer);
+    if (activeToast === toast) dismiss();
+  };
+
+  const tick = (): void => {
+    const remaining = Math.max(0, Math.ceil((deadline - Date.now()) / 1000));
+    label.textContent = remaining > 0 ? `Sending to ${entry.to} in ${remaining}s` : 'Sending…';
+    if (remaining <= 0) {
+      window.clearInterval(timer);
+      undoBtn.disabled = true;
+      // Leave the toast up briefly so "Sending…" isn't a flash of nothing.
+      window.setTimeout(stop, 1500);
+    }
+  };
+
+  undoBtn.addEventListener('click', async () => {
+    undoBtn.disabled = true;
+    try {
+      await cancelOutboxSend(entry.id);
+      stop();
+      options.onStatus?.('ok', 'Send cancelled');
+      options.onUndo?.(entry);
+    } catch (err) {
+      // The window closed between the click and the request landing.
+      undoBtn.disabled = true;
+      options.onStatus?.(
+        'err',
+        err instanceof Error ? err.message : 'Too late to cancel — the message was sent',
+      );
+      stop();
+    }
+  });
+
+  tick();
+  timer = window.setInterval(tick, 250);
+
+  return stop;
+}

--- a/test/email/image-allowlist.test.mjs
+++ b/test/email/image-allowlist.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * Per-sender remote-image allowlist.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+
+let tempHome = '';
+const originalHome = process.env.MINNOW_HOME;
+
+const {
+  allowImagesFromSender,
+  blockImagesFromSender,
+  isSenderAllowed,
+  listImageAllowlist,
+  normalizeSender,
+} = await import('../../server/email/image-allowlist.js');
+
+describe('normalizeSender', () => {
+  test('reduces a From header to a bare comparable address', () => {
+    assert.equal(normalizeSender('"Acme News" <News@Acme.COM>'), 'news@acme.com');
+    assert.equal(normalizeSender('  Plain@Example.com '), 'plain@example.com');
+    assert.equal(normalizeSender(''), '');
+    assert.equal(normalizeSender(null), '');
+  });
+});
+
+describe('image allowlist', () => {
+  beforeEach(async () => {
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'minnow-allowlist-'));
+    process.env.MINNOW_HOME = tempHome;
+    await fs.mkdir(path.join(tempHome, 'email'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.MINNOW_HOME;
+    else process.env.MINNOW_HOME = originalHome;
+    await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  test('starts empty and blocks every sender', async () => {
+    assert.deepEqual(await listImageAllowlist(), []);
+    assert.equal(await isSenderAllowed('news@acme.com'), false);
+  });
+
+  test('allowing a sender persists and matches regardless of header form', async () => {
+    await allowImagesFromSender('"Acme News" <News@Acme.COM>');
+
+    assert.deepEqual(await listImageAllowlist(), ['news@acme.com']);
+    assert.equal(await isSenderAllowed('news@acme.com'), true);
+    // The same correspondent, written differently, is still trusted.
+    assert.equal(await isSenderAllowed('<NEWS@acme.com>'), true);
+  });
+
+  test('allowing twice does not duplicate the entry', async () => {
+    await allowImagesFromSender('news@acme.com');
+    await allowImagesFromSender('News@Acme.com');
+
+    assert.deepEqual(await listImageAllowlist(), ['news@acme.com']);
+  });
+
+  test('blocking removes the sender again', async () => {
+    await allowImagesFromSender('news@acme.com');
+    await blockImagesFromSender('news@acme.com');
+
+    assert.deepEqual(await listImageAllowlist(), []);
+    assert.equal(await isSenderAllowed('news@acme.com'), false);
+  });
+
+  test('an empty sender is rejected rather than stored', async () => {
+    await assert.rejects(() => allowImagesFromSender('   '), /sender is required/);
+    assert.deepEqual(await listImageAllowlist(), []);
+  });
+
+  test('trusting one sender does not trust another', async () => {
+    await allowImagesFromSender('news@acme.com');
+    assert.equal(await isSenderAllowed('tracker@evil.example'), false);
+  });
+});

--- a/test/email/image-proxy.test.mjs
+++ b/test/email/image-proxy.test.mjs
@@ -1,0 +1,48 @@
+/**
+ * Image proxy URL validation — the guard that keeps "load images" from
+ * becoming an SSRF hole into the user's own network.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { fetchRemoteImage } from '../../server/email/image-proxy.js';
+
+/** Assert the proxy refuses a URL before any request goes out. */
+async function assertRejects(url, pattern) {
+  await assert.rejects(() => fetchRemoteImage(url), pattern, `expected ${url} to be refused`);
+}
+
+describe('image proxy URL validation', () => {
+  test('refuses loopback and link-local addresses', async () => {
+    await assertRejects('http://127.0.0.1/pixel.png', /private\/internal/);
+    await assertRejects('http://[::1]/pixel.png', /private\/internal/);
+    // Cloud metadata endpoints are the classic SSRF prize.
+    await assertRejects('http://169.254.169.254/latest/meta-data/', /private\/internal/);
+  });
+
+  test('refuses RFC1918 ranges', async () => {
+    await assertRejects('http://10.0.0.5/a.png', /private\/internal/);
+    await assertRejects('http://192.168.1.1/a.png', /private\/internal/);
+    await assertRejects('http://172.16.0.9/a.png', /private\/internal/);
+  });
+
+  test('refuses non-http schemes', async () => {
+    await assertRejects('file:///etc/passwd', /must use http/);
+    await assertRejects('ftp://example.com/a.png', /must use http/);
+    // A javascript: URL should never reach the network stack at all.
+    await assertRejects('javascript:alert(1)', /must use http/);
+  });
+
+  test('refuses malformed and empty input', async () => {
+    await assertRejects('', /url is required/);
+    await assertRejects('not-a-url', /absolute http/);
+    await assertRejects(`https://example.com/${'a'.repeat(2100)}`, /too long/);
+  });
+
+  test('refuses hosts that do not resolve', async () => {
+    await assertRejects(
+      'https://this-host-should-not-exist.invalid/a.png',
+      /does not resolve|private\/internal/,
+    );
+  });
+});

--- a/test/email/outbox.test.mjs
+++ b/test/email/outbox.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * Outbox undo window and per-account send rate limiting.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, mock, test } from 'node:test';
+
+const sendCalls = [];
+/** Set by a test to make the next delivery fail at the SMTP layer. */
+let smtpError = null;
+
+mock.module('../../server/email/smtp.js', {
+  namedExports: {
+    sendEmail: async (input) => {
+      sendCalls.push(input);
+      if (smtpError) throw new Error(smtpError);
+      return { ok: true, messageId: `<generated-${sendCalls.length}>`, accepted: [], rejected: [] };
+    },
+    draftReply: async () => ({}),
+    resolveReplyVariantSend: async () => ({}),
+  },
+});
+
+const {
+  enqueueSend,
+  cancelSend,
+  listOutbox,
+  resetOutboxForTests,
+  setUndoWindowForTests,
+  getUndoWindowMs,
+} = await import('../../server/email/outbox.js');
+const { resetSendRateLimitForTests } = await import('../../server/email/send-rate-limit.js');
+
+/** Short enough to keep the suite fast, long enough to cancel within. */
+const TEST_UNDO_WINDOW_MS = 60;
+
+const draft = (overrides = {}) => ({
+  accountId: 'acct-1',
+  to: 'someone@example.com',
+  subject: 'Hello',
+  body: 'Body text',
+  ...overrides,
+});
+
+/** Let the undo window elapse and the delivery promise settle. */
+const waitForDelivery = async () => {
+  await new Promise((resolve) => setTimeout(resolve, getUndoWindowMs() + 60));
+};
+
+describe('outbox', () => {
+  beforeEach(() => {
+    sendCalls.length = 0;
+    smtpError = null;
+    resetOutboxForTests();
+    resetSendRateLimitForTests();
+    setUndoWindowForTests(TEST_UNDO_WINDOW_MS);
+  });
+
+  afterEach(() => {
+    resetOutboxForTests();
+  });
+
+  test('queues rather than sending immediately', () => {
+    const entry = enqueueSend(draft());
+
+    assert.equal(entry.status, 'queued');
+    assert.equal(sendCalls.length, 0, 'nothing may go out during the undo window');
+    assert.ok(new Date(entry.sendAt).getTime() > new Date(entry.queuedAt).getTime());
+  });
+
+  test('delivers once the undo window closes', async () => {
+    enqueueSend(draft({ subject: 'Delivered' }));
+    await waitForDelivery();
+
+    assert.equal(sendCalls.length, 1);
+    assert.equal(sendCalls[0].subject, 'Delivered');
+    assert.equal(listOutbox()[0].status, 'sent');
+  });
+
+  test('cancelling inside the window stops delivery for good', async () => {
+    const entry = enqueueSend(draft());
+    const cancelled = cancelSend(entry.id);
+
+    assert.equal(cancelled.status, 'cancelled');
+    await waitForDelivery();
+    assert.equal(sendCalls.length, 0, 'a cancelled send must never reach SMTP');
+  });
+
+  test('cannot cancel after the window has closed', async () => {
+    const entry = enqueueSend(draft());
+    await waitForDelivery();
+
+    assert.throws(() => cancelSend(entry.id), /already sent/);
+    assert.equal(sendCalls.length, 1);
+  });
+
+  test('cancelling an unknown id is an error, not a silent no-op', () => {
+    assert.throws(() => cancelSend('does-not-exist'), /not found/);
+  });
+
+  test('surfaces a failed send instead of losing it silently', async () => {
+    smtpError = 'SMTP host refused the connection';
+    enqueueSend(draft({ to: 'fails@example.com' }));
+    await waitForDelivery();
+
+    const [entry] = listOutbox();
+    assert.equal(entry.status, 'failed');
+    assert.match(entry.error, /refused the connection/);
+  });
+
+  test('requires the fields SMTP will need', () => {
+    assert.throws(() => enqueueSend(draft({ accountId: '' })), /accountId is required/);
+    assert.throws(() => enqueueSend(draft({ to: '' })), /to and subject are required/);
+    assert.throws(() => enqueueSend(draft({ subject: '' })), /to and subject are required/);
+  });
+});
+
+describe('send rate limit', () => {
+  beforeEach(() => {
+    sendCalls.length = 0;
+    smtpError = null;
+    resetOutboxForTests();
+    resetSendRateLimitForTests();
+    setUndoWindowForTests(TEST_UNDO_WINDOW_MS);
+  });
+
+  afterEach(() => {
+    resetOutboxForTests();
+  });
+
+  test('refuses a flood from one account and reports 429', () => {
+    for (let i = 0; i < 20; i += 1) {
+      enqueueSend(draft({ subject: `msg ${i}` }));
+    }
+
+    assert.throws(
+      () => enqueueSend(draft({ subject: 'over the line' })),
+      (err) => {
+        assert.match(err.message, /rate limit/i);
+        assert.equal(err.status, 429, 'middleware maps this to HTTP 429');
+        return true;
+      },
+    );
+  });
+
+  test('limits each account separately', () => {
+    for (let i = 0; i < 20; i += 1) {
+      enqueueSend(draft({ subject: `msg ${i}` }));
+    }
+
+    // A second account is unaffected by the first one's burst.
+    assert.doesNotThrow(() => enqueueSend(draft({ accountId: 'acct-2' })));
+  });
+
+  test('a refused send is not queued', () => {
+    for (let i = 0; i < 20; i += 1) {
+      enqueueSend(draft());
+    }
+    assert.throws(() => enqueueSend(draft()));
+
+    assert.equal(listOutbox().length, 20, 'the rejected send must leave no entry behind');
+  });
+});

--- a/test/email/sanitize-html.test.mjs
+++ b/test/email/sanitize-html.test.mjs
@@ -4,7 +4,8 @@
 
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { sanitizeEmailHtml } from '../../server/email/sanitize-html.js';
+import { sanitizeEmailHtml, sanitizeInboundEmailHtml } from '../../server/email/sanitize-html.js';
+import { countBlockedRemoteRefs } from '../../server/email/remote-content.js';
 
 describe('sanitizeEmailHtml', () => {
   test('strips script tags and keeps safe markup', () => {
@@ -28,5 +29,76 @@ describe('sanitizeEmailHtml', () => {
     const out = sanitizeEmailHtml('<a href="javascript:alert(1)">Click</a>');
     assert.ok(out);
     assert.doesNotMatch(out, /javascript:/i);
+  });
+
+  test('leaves remote images alone for outbound mail', () => {
+    const out = sanitizeEmailHtml('<img src="https://cdn.example.com/logo.png">');
+    assert.ok(out);
+    assert.match(out, /src="https:\/\/cdn\.example\.com\/logo\.png"/);
+    assert.equal(countBlockedRemoteRefs(out), 0);
+  });
+});
+
+describe('sanitizeInboundEmailHtml', () => {
+  /** Every URL a rendered body could dereference on its own. */
+  const TRACKING_FIXTURE = [
+    '<img src="https://tracker.example/pixel.gif" width="1" height="1">',
+    '<img srcset="https://tracker.example/a.png 1x, https://tracker.example/b.png 2x">',
+    '<table><tr><td background="https://tracker.example/bg.gif">cell</td></tr></table>',
+    '<video poster="https://tracker.example/poster.jpg"></video>',
+    '<div style="background: url(https://tracker.example/css.png); color: red">styled</div>',
+  ].join('');
+
+  test('parks every remote reference so the body cannot beacon', () => {
+    const out = sanitizeInboundEmailHtml(TRACKING_FIXTURE);
+    assert.ok(out);
+    assert.equal(countBlockedRemoteRefs(out), 5);
+
+    // The exit criterion: with the parked originals removed, nothing the
+    // renderer would dereference mentions the tracker at all.
+    const live = out.replace(/\sdata-minnow-remote-[a-z]+="[^"]*"/gi, '');
+    assert.doesNotMatch(live, /tracker\.example/);
+  });
+
+  test('keeps the original URLs recoverable for "load images"', () => {
+    const out = sanitizeInboundEmailHtml('<img src="https://tracker.example/pixel.gif">');
+    assert.ok(out);
+    assert.match(out, /data-minnow-remote-src="https:\/\/tracker\.example\/pixel\.gif"/);
+  });
+
+  test('preserves non-network cid: and data: sources', () => {
+    const out = sanitizeInboundEmailHtml(
+      '<img src="cid:logo@inline"><img src="data:image/gif;base64,R0lGOD">',
+    );
+    assert.ok(out);
+    assert.match(out, /src="cid:logo@inline"/);
+    assert.match(out, /src="data:image\/gif/);
+    assert.equal(countBlockedRemoteRefs(out), 0);
+  });
+
+  test('blocks protocol-relative URLs', () => {
+    const out = sanitizeInboundEmailHtml('<img src="//tracker.example/pixel.gif">');
+    assert.ok(out);
+    assert.doesNotMatch(out, /(?<!data-minnow-remote-)src="\/\//);
+    assert.equal(countBlockedRemoteRefs(out), 1);
+  });
+
+  test('keeps surviving style declarations when stripping a remote url()', () => {
+    const out = sanitizeInboundEmailHtml(
+      '<div style="background: url(https://t/x.png); color: red">hi</div>',
+    );
+    assert.ok(out);
+    // The live style keeps `color` but loses the fetch; the original is parked.
+    const live = /(?<!remote-)style="([^"]*)"/.exec(out)?.[1] ?? '';
+    assert.match(live, /color:\s*red/);
+    assert.doesNotMatch(live, /url\(/);
+    assert.match(out, /data-minnow-remote-style="[^"]*https:\/\/t\/x\.png/);
+  });
+
+  test('does not leak its hook into later outbound sanitizing', () => {
+    sanitizeInboundEmailHtml('<img src="https://tracker.example/pixel.gif">');
+    const outbound = sanitizeEmailHtml('<img src="https://cdn.example.com/logo.png">');
+    assert.ok(outbound);
+    assert.match(outbound, /src="https:\/\/cdn\.example\.com\/logo\.png"/);
   });
 });

--- a/test/test-config.mjs
+++ b/test/test-config.mjs
@@ -83,6 +83,8 @@ export const PATH_RUNNER_RULES = [
   { pattern: 'test/ui/orchestrate-finish-dashboard.test.mjs', runner: 'tsx-mocks-loader' },
   // Mocks server/email/{accounts,imap-session}.js to drive sync against a fake server.
   { pattern: 'test/email/incremental-sync.test.mjs', runner: 'tsx-mocks' },
+  // Mocks server/email/smtp.js so the undo window is exercised without SMTP.
+  { pattern: 'test/email/outbox.test.mjs', runner: 'tsx-mocks' },
   { pattern: 'test/server/**/*.test.mjs', runner: 'tsx-mocks' },
   { pattern: 'test/workspace/*.test.js', runner: 'tsx-mocks' },
   { pattern: 'test/terminal/shell-profiles.test.mjs', runner: 'tsx-mocks' },

--- a/test/ui/email-body.test.mts
+++ b/test/ui/email-body.test.mts
@@ -45,7 +45,11 @@ describe('email-body renderer', () => {
     );
   });
 
-  test('renders sanitized HTML by default', () => {
+  /** The srcdoc of the rendered body frame. */
+  const frameDoc = (mount: HTMLElement): string =>
+    mount.querySelector('iframe')?.getAttribute('srcdoc') ?? '';
+
+  test('renders sanitized HTML into an isolated frame', () => {
     const mount = document.createElement('div');
     emailBody.renderEmailBody(mount, {
       bodyHtml: '<p>Hello <strong>team</strong></p>',
@@ -53,8 +57,124 @@ describe('email-body renderer', () => {
     });
 
     assert.equal(mount.classList.contains('html-body'), true);
-    assert.match(mount.innerHTML, /<strong>team<\/strong>/);
-    assert.equal(mount.textContent, 'Hello team');
+    // Body content must never land in the app DOM, only inside the frame.
+    assert.equal(mount.querySelectorAll('strong').length, 0);
+    assert.match(frameDoc(mount), /<strong>team<\/strong>/);
+  });
+
+  test('frame is sandboxed without script execution', () => {
+    const mount = document.createElement('div');
+    emailBody.renderEmailBody(mount, { bodyHtml: '<p>Hi</p>' });
+
+    const sandbox = mount.querySelector('iframe')?.getAttribute('sandbox') ?? '';
+    // allow-same-origin is needed to measure height; combined with
+    // allow-scripts it would let the frame out of the sandbox entirely.
+    assert.match(sandbox, /allow-same-origin/);
+    assert.doesNotMatch(sandbox, /allow-scripts/);
+    assert.doesNotMatch(sandbox, /allow-top-navigation/);
+  });
+
+  test('frame CSP confines images to the local proxy', () => {
+    const mount = document.createElement('div');
+    emailBody.renderEmailBody(mount, { bodyHtml: '<p>Hi</p>' });
+
+    const doc = frameDoc(mount);
+    assert.match(doc, /default-src 'none'/);
+    assert.match(doc, /img-src 'self' data: cid:/);
+  });
+
+  /*
+   * The remote-content policy is exercised directly rather than through
+   * renderEmailBody: DOMPurify under happy-dom discards <img> and <div>
+   * outright (it keeps them in a real browser), so driving these cases through
+   * the full render path would assert on an empty document and prove nothing.
+   * Building the fragment here keeps the assertions about the policy itself.
+   */
+  const fragmentOf = (html: string): HTMLTemplateElement => {
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template;
+  };
+
+  test('withholds remote images and reports the count', () => {
+    const template = fragmentOf(
+      '<img src="https://tracker.example/a.gif"><img src="https://tracker.example/b.gif">',
+    );
+    const blocked = emailBody.applyRemoteContentPolicy(template.content, false);
+
+    assert.equal(blocked, 2);
+    // Nothing left that a renderer would dereference points at the sender.
+    const live = template.innerHTML.replace(/data-minnow-remote-[a-z]+="[^"]*"/g, '');
+    assert.doesNotMatch(live, /tracker\.example/);
+  });
+
+  test('blocks remote images still live in legacy cached bodies', () => {
+    // Bodies cached before server-side parking landed still carry a live src.
+    const template = fragmentOf('<img src="https://tracker.example/legacy.gif">');
+    const blocked = emailBody.applyRemoteContentPolicy(template.content, false);
+
+    assert.equal(blocked, 1);
+    assert.match(
+      template.innerHTML,
+      /data-minnow-remote-src="https:\/\/tracker\.example\/legacy\.gif"/,
+    );
+  });
+
+  test('routes images through the local proxy once loaded', () => {
+    const template = fragmentOf('<img data-minnow-remote-src="https://tracker.example/a.gif">');
+    emailBody.applyRemoteContentPolicy(template.content, true);
+
+    const html = template.innerHTML;
+    assert.match(html, /src="\/api\/email\/image-proxy\?url=/);
+    // The direct URL must never be reachable from the frame, even when loading.
+    assert.doesNotMatch(html, /src="https:\/\/tracker\.example/);
+  });
+
+  test('proxies every srcset candidate but keeps its descriptors', () => {
+    const template = fragmentOf(
+      '<img srcset="https://tracker.example/a.png 1x, https://tracker.example/b.png 2x">',
+    );
+    emailBody.applyRemoteContentPolicy(template.content, true);
+
+    const html = template.innerHTML;
+    assert.doesNotMatch(html, /srcset="https:\/\/tracker/);
+    assert.match(html, /2x/);
+  });
+
+  test('strips remote url() from style attributes', () => {
+    const template = fragmentOf(
+      '<div style="background: url(https://tracker.example/x.png); color: red">hi</div>',
+    );
+    const blocked = emailBody.applyRemoteContentPolicy(template.content, false);
+
+    assert.equal(blocked, 1);
+    // The live style keeps `color` but loses the fetch; the original is parked
+    // so "Load images" can restore it.
+    const live = template.innerHTML.replace(/data-minnow-remote-[a-z]+="[^"]*"/g, '');
+    assert.match(live, /color:\s*red/);
+    assert.doesNotMatch(live, /url\(\s*['"]?https:\/\/tracker/);
+    assert.match(template.innerHTML, /data-minnow-remote-style="[^"]*tracker\.example/);
+  });
+
+  test('leaves non-network cid: and data: sources alone', () => {
+    const template = fragmentOf(
+      '<img src="cid:logo@inline"><img src="data:image/gif;base64,R0lGOD">',
+    );
+    const blocked = emailBody.applyRemoteContentPolicy(template.content, false);
+
+    assert.equal(blocked, 0);
+    assert.match(template.innerHTML, /src="cid:logo@inline"/);
+  });
+
+  test('neutralises javascript: links and hardens the rest', () => {
+    const template = fragmentOf(
+      '<a href="javascript:alert(1)">x</a><a href="https://ok.example">y</a>',
+    );
+    emailBody.applyRemoteContentPolicy(template.content, false);
+
+    const html = template.innerHTML;
+    assert.doesNotMatch(html, /javascript:/i);
+    assert.match(html, /rel="noopener noreferrer"/);
   });
 
   test('plain mode shows only the text alternative', () => {
@@ -65,7 +185,7 @@ describe('email-body renderer', () => {
         bodyHtml: '<p>Hello <strong>team</strong></p>',
         bodyText: 'Hello team',
       },
-      'plain',
+      { viewMode: 'plain' },
     );
 
     assert.equal(mount.classList.contains('html-body'), false);


### PR DESCRIPTION
Phase 2 of the email security plan ([MIN-352](https://linear.app/minnowai/issue/MIN-352/phase-2-email-security-hardening)).

## The headline finding was already fixed

The issue led with `/api/email/*` setting `Access-Control-Allow-Origin: *` with zero auth. That is no longer true — [MIN-381](https://linear.app/minnowai/issue/MIN-381) has since landed a global `/api/*` gate (`server/runtime/auth-middleware.js`): per-boot token in `~/.minnow/session-token`, sent as `X-Minnow-Token`, plus Host validation, and no CORS header emitted anywhere. I verified this rather than reimplementing it.

Note it diverges from the spec, which asked for an email-specific `Authorization: Bearer` header. The global gate gives the same guarantee with one chokepoint for every API, so I left it and recorded the divergence in the spec doc.

The other four items were real and are implemented here.

## What changed

**Remote content blocking** (`server/email/remote-content.js`) — remote URLs are parked at sanitize time, *before* storage, so a cached body can't beacon however it's later rendered. Covers `src`/`srcset`/`background`/`poster` and `url()` in style attributes. Originals move to `data-minnow-remote-*` so "Load images" can restore them; `cid:`/`data:` are left alone since they never touch the network.

Worth a look during review: `sanitizeEmailHtml` is shared by inbound IMAP **and** outbound SMTP. Blocking indiscriminately would strip images from mail the user sends. Blocking is opt-in via `sanitizeInboundEmailHtml`, and a test asserts the DOMPurify hook doesn't leak into a later outbound call.

**Iframe isolation** (`src/ui/email/email-body.ts`) — bodies render in a sandboxed `srcdoc` frame with a mail-specific reset and `img-src 'self' data: cid:`, replacing `innerHTML` into the app DOM. Stops sender CSS restyling the app, keeps white-background newsletters readable under a dark theme, and gives a browser-enforced backstop if the parking above ever misses an attribute. Never `allow-scripts` — `allow-same-origin` is present only to measure content height, with a comment on why the two must not be combined.

**Image proxy + per-sender allowlist** (`server/email/image-proxy.js`, `image-allowlist.js`) — allowed images are fetched server-side with no referrer or cookies. The SSRF guard reuses the vetted primitives from `webhooks/ssrf.js` but deliberately not its `isPrivateUrl`, which is https-only and would reject legitimate http newsletter images. Every redirect hop is re-validated so a public host can't bounce the proxy onto the LAN.

**Outbox with undo window** (`server/email/outbox.js`) — `/send` returns `202` with a queued entry, recallable for 8s. The `confirmed: true` field is removed rather than kept as decoration: as the issue says, any caller that could reach the endpoint could set it. The undo window replaces `window.confirm` in both compose and the dashboard quick-replies; an undone send restores the draft rather than discarding it.

**Rate limit** (`server/email/send-rate-limit.js`) — 20 sends/min per account, charged at queue time so a flood is refused up front, returning `429` + `Retry-After`.

## Two things to know

- **The outbox is in-memory.** A send still inside its undo window when the app quits is dropped, not delivered — the same tradeoff Gmail's undo makes, but it *is* a behavior change from today's send-immediately. Durability would mean persisting message bodies to disk. Documented in the module and the spec; happy to change it if you'd rather it survive restarts.
- **A test-environment gap, worked around rather than papered over.** Under happy-dom, DOMPurify discards `<img>` and `<div>` outright (it keeps them in a real browser), so driving the blocking tests through the full render path asserted on an empty document and proved nothing. `applyRemoteContentPolicy` is extracted and tested directly, with a comment explaining why. That gap is precisely why I verified in a real browser rather than trusting the unit tests.

## Verification

All three exit criteria confirmed in a real browser against a fixture harness:

- **Zero external requests** from a tracking-pixel fixture — and I confirmed the network recorder wasn't simply blind by checking it captured other traffic, otherwise the check would have been vacuous.
- **CSP genuinely blocks** a remote image injected directly into the frame (`img-src` violation, image errors), while a same-origin image loads. I chased this specifically because the frame reports `origin: "null"`, which would have meant `'self'` blocked my own proxy URLs and broke "Load images" — it turned out to be a `srcdoc` reporting artifact, not an opaque origin.
- **Light/dark identical** inside the frame, while sender CSS (`body{background:#f0f!important}`, `.app-marker{display:none!important}`) failed to escape into the app.

Tests: 173 pass across the email, UI, and security suites (24 new). `tsc` clean; the one remaining error in `src/ui/context-usage-surface.ts` is pre-existing on `main` — confirmed by stashing — and untouched here.

Incidental fix caught by a test: the allowlist would have failed on first write on a fresh profile, since it assumed `ensureMinnowLayout()` had already run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
