### PR TITLE
✨ Improve AI git commit message quality (MIN-412)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -217,7 +217,7 @@ Invoke via **`/`** slash picker ([`src/ui/skill-picker.ts`](../src/ui/skill-pick
 
 API: `GET /api/skills`, `GET/PUT /api/skills/:id`, `GET/PUT /api/config/skills`.
 
-**Git commit messages (MIN-412):** The Code git panel and `/git-commit` skill share conventions — conventional commits with optional gitmoji (`config.json` → `gitCommitMessage.useGitmoji`, default on), imperative subject (≤72 chars), body explaining *why*, staged-vs-unstaged scope, and `BREAKING CHANGE:` footers. UI generation: [`src/ui/git-commit-message-client.ts`](../src/ui/git-commit-message-client.ts) (diff filtering, reasoning-chain extraction, prompt builder).
+**Git commit messages (MIN-412):** The Code git panel and `/git-commit` skill share conventions — conventional commits with optional gitmoji (`config.json` → `gitCommitMessage.useGitmoji`, default on), imperative subject (≤72 chars), body explaining *why*, staged-vs-unstaged scope, and `BREAKING CHANGE:` footers. UI generation: [`src/ui/git-commit-message-client.ts`](../src/ui/git-commit-message-client.ts) (diff filtering, reasoning-chain extraction, prompt builder). During streaming, only high-confidence conventional commit lines are shown in the input; heuristic/plain-text extraction and reasoning-channel fallback run on completion. Markdown diff walkthroughs (numbered steps, `Removed/Updated` bullets, `**Identify Key Changes**` headers) from local/LM Studio models are rejected as non-commit output.
 
 ---
 

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -217,6 +217,8 @@ Invoke via **`/`** slash picker ([`src/ui/skill-picker.ts`](../src/ui/skill-pick
 
 API: `GET /api/skills`, `GET/PUT /api/skills/:id`, `GET/PUT /api/config/skills`.
 
+**Git commit messages (MIN-412):** The Code git panel and `/git-commit` skill share conventions — conventional commits with optional gitmoji (`config.json` → `gitCommitMessage.useGitmoji`, default on), imperative subject (≤72 chars), body explaining *why*, staged-vs-unstaged scope, and `BREAKING CHANGE:` footers. UI generation: [`src/ui/git-commit-message-client.ts`](../src/ui/git-commit-message-client.ts) (diff filtering, reasoning-chain extraction, prompt builder).
+
 ---
 
 ## Memory and Brain

--- a/server/config/home.js
+++ b/server/config/home.js
@@ -289,6 +289,9 @@ const DEFAULT_META = {
     useNativeFim: true,
     enableCompletionCache: true,
   },
+  gitCommitMessage: {
+    useGitmoji: true,
+  },
   editorIntentMode: {
     enabledByDefault: false,
     autoRecheckDefault: false,

--- a/server/config/store.js
+++ b/server/config/store.js
@@ -274,6 +274,9 @@ export async function readResource(resource) {
     if (!data?.editorAiCompletion) {
       patch.editorAiCompletion = DEFAULT_META.editorAiCompletion;
     }
+    if (!data?.gitCommitMessage) {
+      patch.gitCommitMessage = DEFAULT_META.gitCommitMessage;
+    }
     if (!data?.editorIntentMode) {
       patch.editorIntentMode = DEFAULT_META.editorIntentMode;
     }

--- a/src/config/git-commit-message-meta.ts
+++ b/src/config/git-commit-message-meta.ts
@@ -1,0 +1,76 @@
+/**
+ * Git commit message generation preferences from config.json meta (MIN-412).
+ */
+
+import { detectConfigServer } from './storage-mode';
+
+export interface GitCommitMessageConfig {
+  /** Prefix subjects with gitmoji (✨ feat, 🐛 fix, …). */
+  useGitmoji: boolean;
+}
+
+const STORAGE_KEY = 'minnow.gitCommitMessage';
+
+export const DEFAULT_GIT_COMMIT_MESSAGE_CONFIG: GitCommitMessageConfig = {
+  useGitmoji: true,
+};
+
+let cached: GitCommitMessageConfig | null = null;
+
+/** Parse a partial meta block into a full config object. */
+export function parseGitCommitMessageBlock(raw: unknown): GitCommitMessageConfig {
+  if (!raw || typeof raw !== 'object') {
+    return { ...DEFAULT_GIT_COMMIT_MESSAGE_CONFIG };
+  }
+  const block = raw as Record<string, unknown>;
+  return {
+    useGitmoji: block.useGitmoji !== false,
+  };
+}
+
+function readLocal(): GitCommitMessageConfig {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_GIT_COMMIT_MESSAGE_CONFIG };
+    return parseGitCommitMessageBlock(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_GIT_COMMIT_MESSAGE_CONFIG };
+  }
+}
+
+function writeLocal(config: GitCommitMessageConfig): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+}
+
+async function fetchFromServer(): Promise<GitCommitMessageConfig> {
+  const res = await fetch('/api/config/meta', { cache: 'no-store' });
+  if (!res.ok) return readLocal();
+  const meta = (await res.json()) as Record<string, unknown>;
+  return parseGitCommitMessageBlock(meta.gitCommitMessage);
+}
+
+/** Load git commit message config (cached until reset). */
+export async function loadGitCommitMessageConfig(): Promise<GitCommitMessageConfig> {
+  if (cached) return cached;
+  const serverUp = await detectConfigServer();
+  cached = serverUp ? await fetchFromServer() : readLocal();
+  writeLocal(cached);
+  return cached;
+}
+
+/** Synchronous read of last loaded or local fallback. */
+export function getGitCommitMessageConfigSync(): GitCommitMessageConfig {
+  return cached ?? readLocal();
+}
+
+/** Clear cache (tests). */
+export function resetGitCommitMessageConfigCache(): void {
+  cached = null;
+}
+
+/** Override cache for tests. */
+export function setGitCommitMessageConfigForTests(
+  config: GitCommitMessageConfig,
+): void {
+  cached = config;
+}

--- a/src/skills/git-commit/SKILL.md
+++ b/src/skills/git-commit/SKILL.md
@@ -19,16 +19,38 @@ disable-model-invocation: true
 2. Run `git_diff` with `staged: true` (or equivalent args) — read the real patch.
 3. If nothing is staged, tell the user to stage files with `git_add` first; do not invent a message for unstaged work.
 4. Draft a **conventional commit** subject (≤72 chars) and optional body:
-   - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+   - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `build`, `ci`
    - Subject: imperative mood, no trailing period
-   - Body: explain *why*, not file lists
+   - Scope: primary module or area (e.g. `git`, `ui`, `api`)
+   - Body: explain **why** — motivation, user impact, trade-offs — not a file list
 5. If the user asked you to commit, run `git_commit` with the agreed message only after explicit approval unless they already said "commit it".
+
+## Gitmoji (when team uses them)
+
+Prefix the subject with one emoji when the project convention calls for it:
+
+| Emoji | Type |
+|-------|------|
+| ✨ | feat |
+| 🐛 | fix |
+| 📝 | docs |
+| 💄 | style |
+| ♻️ | refactor |
+| ✅ | test |
+| 🔧 | chore |
+| ⚡ | perf |
+| 👷 | build |
+| 🎨 | ui |
+
+Example: `✨ feat(git): add AI commit message generator`
 
 ## Quality checks
 
-- Message matches the diff (no unrelated scope)
+- Message matches **only** the staged diff scope (ignore unstaged paths)
+- Body explains *why*, not *what files changed*
 - No secrets, `.env`, or credentials in committed files — warn if diff shows them
-- Breaking changes called out in body with `BREAKING CHANGE:`
+- Breaking changes called out in body with `BREAKING CHANGE: description`
+- Use `git_log` for recent message style reference when unsure
 
 ## Tools
 

--- a/src/ui/git-commit-message-client.ts
+++ b/src/ui/git-commit-message-client.ts
@@ -10,13 +10,15 @@ import {
   type GenerationEndEvent,
 } from '../api/generations';
 import { modelCache } from '../app-state';
+import { splitThinkingSegments } from '../api/reasoning';
 import { thinkingToCompletionBody } from '../agents/thinking-to-body';
-import {
-  BenchmarkStreamReasoningAccumulator,
-  resolveBenchmarkCompletionText,
-} from '../benchmark/stream-text';
+import { BenchmarkStreamReasoningAccumulator } from '../benchmark/stream-text';
 import { StreamingContentAccumulator } from '../api/message-content';
 import { loadEditorAiCompletionConfig, type EditorAiCompletionConfig } from '../config/editor-ai-completion';
+import {
+  loadGitCommitMessageConfig,
+  type GitCommitMessageConfig,
+} from '../config/git-commit-message-meta';
 import { encodeModelSelectKey } from '../lib/model-select-key';
 import { catalogCapabilitiesFromRow } from '../providers/model-capabilities';
 import { resolveProvider } from '../providers/store';
@@ -29,17 +31,37 @@ import {
   type EditorAiBinding,
 } from './editor-ai-completion-client';
 
-const COMMIT_MSG_SYSTEM =
-  'You write git commit messages from git diffs. ' +
-  'Output ONLY the commit message — no markdown fences, explanations, or prefixes like "Commit message:". ' +
-  'Use conventional commits: type(scope): subject (≤72 chars on first line), optional blank line and body explaining why. ' +
-  'Types: feat, fix, docs, style, refactor, test, chore. Imperative mood, no trailing period on subject.';
+const COMMIT_TYPES = 'feat|fix|docs|style|refactor|test|chore|perf|build|ci';
+const COMMIT_TYPE = `(?:${COMMIT_TYPES})`;
+const GITMOJI_PREFIX = '[\\p{Extended_Pictographic}\\u200d\\ufe0f\\s]*';
+const CONVENTIONAL_COMMIT_LINE_RE = new RegExp(
+  `^${GITMOJI_PREFIX}${COMMIT_TYPE}(?:\\([^)]+\\))?:\\s+\\S`,
+  'iu',
+);
+
+/** Lines that are model reasoning / meta commentary, not commit body text. */
+const REASONING_LINE_RE =
+  /^\s*(?:the user |i need |i should |i will |let me |thinking(?:\s+process)?\s*:|looking at |based on |(?:okay|alright|hmm|right|so|well|first|next|now)[,.]?\s+(?:the|i|let|this|that)|looks good|that should|this looks|the diff |the changes |this diff |these changes |analy(?:s|z)(?:e|ing)|i(?:'ll| will) (?:use|write|draft|create|choose|pick|go with))/i;
 
 const MAX_PATCH_CHARS = 12_000;
+const MAX_FILE_HUNK_CHARS = 4_000;
 
-export interface GitCommitMessageRequest {
-  stagedPaths: string[];
+/** File patterns whose diffs are low-signal for commit message generation. */
+const LOW_SIGNAL_FILE_RE =
+  /(?:^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|Cargo\.lock|poetry\.lock|\.min\.(?:js|css)|dist\/|\.snap)$/i;
+
+export type GitCommitMessageScope = 'staged' | 'working-tree';
+
+export interface GitCommitMessagePromptInput {
+  changedPaths: string[];
   patch: string;
+  scope: GitCommitMessageScope;
+  /** Paths changed in the repo but excluded from this commit message. */
+  excludedPaths?: string[];
+  useGitmoji?: boolean;
+}
+
+export interface GitCommitMessageRequest extends GitCommitMessagePromptInput {
   signal: AbortSignal;
   onPartial?: (text: string) => void;
 }
@@ -49,6 +71,39 @@ export interface GitCommitMessageResult {
   error?: string;
 }
 
+function buildCommitMessageSystemPrompt(useGitmoji: boolean): string {
+  const lines = [
+    'You write high-quality git commit messages from git diffs.',
+    'Output ONLY the commit message — no markdown fences, explanations, or prefixes like "Commit message:".',
+    '',
+    'Subject line:',
+    '- Imperative mood, ≤72 characters, no trailing period',
+    '- Conventional commits: type(scope): subject',
+    `- Types: ${COMMIT_TYPES.replace(/\|/g, ', ')}`,
+    '- Derive scope from the primary module or area changed (e.g. git, ui, api)',
+    '',
+    'Body (optional, after a blank line):',
+    '- Explain WHY the change was made — motivation, user impact, trade-offs',
+    '- Do NOT list files or repeat the diff line-by-line',
+    '- If the change breaks public APIs or behavior, add a footer: BREAKING CHANGE: description',
+    '',
+    'Rules:',
+    '- Describe ONLY the files in the stated scope — never mention unrelated paths',
+    '- Never include secrets, credentials, or .env values',
+    '- Match the intent of the diff, not surface-level edits',
+  ];
+
+  if (useGitmoji) {
+    lines.push(
+      '',
+      'Prefix the subject with one gitmoji:',
+      '✨ feat, 🐛 fix, 📝 docs, 💄 style, ♻️ refactor, ✅ test, 🔧 chore, ⚡ perf, 👷 build, 🎨 ui',
+    );
+  }
+
+  return lines.join('\n');
+}
+
 /** Cap oversized staged diffs so prompts stay within model context. */
 export function truncateStagedPatch(patch: string, maxChars = MAX_PATCH_CHARS): string {
   const trimmed = patch.trimEnd();
@@ -56,27 +111,268 @@ export function truncateStagedPatch(patch: string, maxChars = MAX_PATCH_CHARS): 
   return `${trimmed.slice(0, maxChars)}\n\n... (diff truncated)`;
 }
 
+/** Collapse oversized per-file hunks and skip low-signal lock/generated files. */
+export function filterCommitMessagePatch(patch: string): string {
+  const trimmed = patch.trim();
+  if (!trimmed) return '';
+
+  const parts = trimmed.split(/\n(?=diff --git )/);
+  const kept: string[] = [];
+
+  for (const part of parts) {
+    const fileMatch = /^diff --git a\/(.+?) b\/(.+)$/m.exec(part);
+    const filePath = fileMatch?.[2] ?? fileMatch?.[1] ?? '';
+    if (filePath && LOW_SIGNAL_FILE_RE.test(filePath)) {
+      kept.push(`diff --git a/${filePath} b/${filePath}\n[lock/generated file — omitted from diff]`);
+      continue;
+    }
+    if (part.length > MAX_FILE_HUNK_CHARS) {
+      kept.push(`${part.slice(0, MAX_FILE_HUNK_CHARS)}\n... (file diff truncated)`);
+      continue;
+    }
+    kept.push(part);
+  }
+
+  return kept.join('\n').trim();
+}
+
 /** Build system + user messages for a staged-diff commit message request. */
 export function buildGitCommitMessagePrompt(
-  stagedPaths: string[],
-  patch: string,
+  input: GitCommitMessagePromptInput,
 ): ApiMessage[] {
-  const fileList = stagedPaths.length > 0 ? stagedPaths.join('\n') : '(see diff)';
-  const userBody = [
-    'Changed files:',
-    fileList,
+  const {
+    changedPaths,
+    patch,
+    scope,
+    excludedPaths = [],
+    useGitmoji = true,
+  } = input;
+
+  const scopeLine =
+    scope === 'staged'
+      ? 'Scope: staged changes only (git index). Describe ONLY what will be committed.'
+      : 'Scope: working tree (unstaged + untracked). Nothing is staged — describe these pending changes only.';
+
+  const fileList = changedPaths.length > 0 ? changedPaths.join('\n') : '(see diff)';
+  const userSections = [scopeLine, '', 'Changed files:', fileList];
+
+  if (excludedPaths.length > 0) {
+    userSections.push(
+      '',
+      'Excluded from this message (do not mention):',
+      excludedPaths.join('\n'),
+    );
+  }
+
+  const filteredPatch = filterCommitMessagePatch(patch);
+  userSections.push(
     '',
     'Diff:',
     '---',
-    truncateStagedPatch(patch),
+    truncateStagedPatch(filteredPatch),
     '---',
     'Write the commit message.',
-  ].join('\n');
+  );
 
   return [
-    { role: 'system', content: COMMIT_MSG_SYSTEM },
-    { role: 'user', content: userBody },
+    { role: 'system', content: buildCommitMessageSystemPrompt(useGitmoji) },
+    { role: 'user', content: userSections.join('\n') },
   ];
+}
+
+function looksLikeReasoningLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  return REASONING_LINE_RE.test(trimmed);
+}
+
+function hasUnclosedThinkingTag(text: string): boolean {
+  if (/<think(?:ing)?(?:\s+[^>]*)?>[\s\S]*$/i.test(text) && !/<\/think(?:ing)?>/i.test(text)) {
+    return true;
+  }
+  if (/<think>[\s\S]*$/i.test(text) && !/<\/redacted_thinking>/i.test(text)) {
+    return true;
+  }
+  return false;
+}
+
+/** Keep Gemma response-channel prose; drop thought-channel monologue when present. */
+function extractGemmaResponseChannel(text: string): string {
+  const responseMatch = /<\|channel>response\s*\n?([\s\S]*?)(?:<channel\|>|$)/i.exec(text);
+  if (responseMatch?.[1]?.trim()) return responseMatch[1].trim();
+  return text.replace(/<\|channel>thought\s*\n?[\s\S]*?(?:<channel\|>|$)/gi, '').trim();
+}
+
+/** Drop closed inline thinking tags only — avoid chat heuristics that split reasoning chains. */
+export function stripThinkingFromCommitOutput(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (hasUnclosedThinkingTag(trimmed)) return '';
+  const gemma = extractGemmaResponseChannel(trimmed);
+  const stripped = gemma
+    .replace(/<think(?:ing)?(?:\s+[^>]*)?>[\s\S]*?<\/think(?:ing)?>/gi, '')
+    .replace(/<think>[\s\S]*?<\/redacted_thinking>/gi, '')
+    .trim();
+  if (hasUnclosedThinkingTag(stripped)) return '';
+  return stripped;
+}
+
+/** Trim leading/trailing reasoning paragraphs while keeping the commit message body. */
+export function stripReasoningFraming(text: string): string {
+  const lines = text.split('\n');
+  let start = 0;
+  while (start < lines.length) {
+    const trimmed = lines[start].trim();
+    if (!trimmed) {
+      start += 1;
+      continue;
+    }
+    if (looksLikeReasoningLine(trimmed)) {
+      start += 1;
+      continue;
+    }
+    break;
+  }
+
+  let end = lines.length;
+  while (end > start) {
+    const trimmed = lines[end - 1].trim();
+    if (!trimmed) {
+      end -= 1;
+      continue;
+    }
+    if (
+      looksLikeReasoningLine(trimmed) ||
+      /^\s*(?:looks good|done|perfect|great)\.?\s*$/i.test(trimmed)
+    ) {
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+
+  return lines.slice(start, end).join('\n').trim();
+}
+
+function looksLikeCommitMessageSegment(segment: string): boolean {
+  const lines = segment.trim().split('\n').filter((line) => line.trim());
+  if (lines.length === 0) return false;
+  const firstLine = lines[0].trim();
+  if (looksLikeReasoningLine(firstLine)) return false;
+  if (CONVENTIONAL_COMMIT_LINE_RE.test(firstLine)) return true;
+  if (/\b(?:reasoning|mirrored|dumping|analy(?:s|z)(?:e|ing)|thinking)\b/i.test(segment)) {
+    return false;
+  }
+  if (firstLine.length <= 72 && !firstLine.endsWith('?')) {
+    const words = firstLine.split(/\s+/);
+    if (words.length >= 2 && words.length <= 12 && !/^(this|these|the|that|there|it|strip)\s/i.test(firstLine)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function extractExplicitCommitMessagePrefix(text: string): string {
+  for (const line of text.split('\n')) {
+    const match = /^(?:commit message|message):\s*(.+)$/i.exec(line.trim());
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+  return '';
+}
+
+function collectCommitBlockFromLine(lines: string[], subjectIdx: number): string {
+  const kept: string[] = [];
+  for (let i = subjectIdx; i < lines.length; i += 1) {
+    const trimmed = lines[i].trim();
+    if (i > subjectIdx && looksLikeReasoningLine(trimmed)) break;
+    if (i > subjectIdx && /^\s*(?:looks good|done|perfect|great)\.?\s*$/i.test(trimmed)) break;
+    kept.push(lines[i]);
+  }
+  return kept.join('\n').trim();
+}
+
+/**
+ * Pull the commit message out of a reasoning chain. Prefer the last conventional
+ * commit block; otherwise the last paragraph that looks like a commit message.
+ */
+export function extractCommitMessageFromChain(raw: string): string {
+  const stripped = stripThinkingFromCommitOutput(raw);
+  if (!stripped) return '';
+
+  const prefixed = extractExplicitCommitMessagePrefix(stripped);
+  if (prefixed) {
+    const candidate = sanitizeCommitMessage(stripReasoningFraming(prefixed));
+    if (candidate) return candidate;
+  }
+
+  const lines = stripped.split('\n');
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const trimmed = lines[i].trim();
+    if (!trimmed || looksLikeReasoningLine(trimmed)) continue;
+    if (CONVENTIONAL_COMMIT_LINE_RE.test(trimmed)) {
+      return sanitizeCommitMessage(collectCommitBlockFromLine(lines, i));
+    }
+  }
+
+  const segments = splitThinkingSegments(stripped);
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    if (!looksLikeCommitMessageSegment(segments[i])) continue;
+    const candidate = sanitizeCommitMessage(stripReasoningFraming(segments[i]));
+    if (candidate) return candidate;
+  }
+
+  const framed = stripReasoningFraming(stripped);
+  if (framed && looksLikeCommitMessageSegment(framed)) {
+    return sanitizeCommitMessage(framed);
+  }
+
+  return '';
+}
+
+/** Normalize stripped model text into a commit message. */
+export function normalizeCommitMessageOutput(raw: string): string {
+  return extractCommitMessageFromChain(raw);
+}
+
+/**
+ * Resolve display text from content/reasoning channels. Never surfaces a raw
+ * reasoning chain — providers often mirror reasoning into `content`.
+ */
+export function resolveCommitMessageDisplayText(
+  contentText: string,
+  reasoningText: string,
+  options?: { reasoningFallback?: boolean },
+): string {
+  const content = contentText.trim();
+  const reasoning = reasoningText.trim();
+  const mirrored = content.length > 0 && reasoning.length > 0 && content === reasoning;
+
+  if (content.length > 0) {
+    const fromContent = extractCommitMessageFromChain(contentText);
+    if (fromContent) return fromContent;
+
+    // Fast path: clean one-shot content with no reasoning markers.
+    if (!mirrored && content.split('\n').length <= 4) {
+      const firstLine = content.split('\n')[0]?.trim() ?? '';
+      if (firstLine && !looksLikeReasoningLine(firstLine)) {
+        const direct = sanitizeCommitMessage(content);
+        if (direct) return direct;
+      }
+    }
+  }
+
+  if (!options?.reasoningFallback) return '';
+
+  if (reasoning.length > 0 && !mirrored) {
+    const fromReasoning = extractCommitMessageFromChain(reasoningText);
+    if (fromReasoning) return fromReasoning;
+  }
+
+  if (content.length > 0) {
+    return extractCommitMessageFromChain(contentText);
+  }
+
+  return '';
 }
 
 /** Normalize model output into a plain commit message string. */
@@ -138,7 +434,10 @@ export async function resolveGitCommitMessageBinding(
 export async function fetchGitCommitMessage(
   input: GitCommitMessageRequest,
 ): Promise<GitCommitMessageResult> {
-  const config = await loadEditorAiCompletionConfig();
+  const [config, commitConfig] = await Promise.all([
+    loadEditorAiCompletionConfig(),
+    loadGitCommitMessageConfig(),
+  ]);
   const binding = await resolveGitCommitMessageBinding(config);
   const validation = validateEditorAiBinding(binding);
   if (validation.ok === false) {
@@ -146,12 +445,18 @@ export async function fetchGitCommitMessage(
   }
 
   const provider = await resolveProvider(binding.providerId);
-  const messages = buildGitCommitMessagePrompt(input.stagedPaths, input.patch);
+  const messages = buildGitCommitMessagePrompt({
+    changedPaths: input.changedPaths,
+    patch: input.patch,
+    scope: input.scope,
+    excludedPaths: input.excludedPaths,
+    useGitmoji: input.useGitmoji ?? commitConfig.useGitmoji,
+  });
   const body: Record<string, unknown> = {
     model: binding.modelId || undefined,
     messages,
     temperature: Math.min(config.temperature + 0.1, 0.7),
-    max_tokens: Math.max(config.maxTokens, 256),
+    max_tokens: Math.max(config.maxTokens, 384),
     stream: true,
   };
 
@@ -182,12 +487,12 @@ export async function fetchGitCommitMessage(
   const contentAcc = new StreamingContentAccumulator();
   const reasoningAcc = new BenchmarkStreamReasoningAccumulator();
 
-  const emit = (reasoningFallback = false): string => {
-    const raw = reasoningFallback
-      ? resolveBenchmarkCompletionText(contentAcc.getText(), reasoningAcc.getText())
-      : contentAcc.getText();
-    return sanitizeCommitMessage(raw.trim());
-  };
+  const emit = (reasoningFallback = false): string =>
+    resolveCommitMessageDisplayText(
+      contentAcc.getText(),
+      reasoningAcc.getText(),
+      { reasoningFallback },
+    );
 
   return new Promise<GitCommitMessageResult>((resolve) => {
     let settled = false;
@@ -208,6 +513,10 @@ export async function fetchGitCommitMessage(
         unsubscribe();
         if (event?.status === 'error') {
           finish(null, generationEndErrorMessage(event));
+          return;
+        }
+        if (event?.status === 'cancelled') {
+          finish(null);
           return;
         }
         const cleaned = emit(true);
@@ -235,3 +544,5 @@ export async function fetchGitCommitMessage(
     );
   });
 }
+
+export type { GitCommitMessageConfig };

--- a/src/ui/git-commit-message-client.ts
+++ b/src/ui/git-commit-message-client.ts
@@ -41,7 +41,19 @@ const CONVENTIONAL_COMMIT_LINE_RE = new RegExp(
 
 /** Lines that are model reasoning / meta commentary, not commit body text. */
 const REASONING_LINE_RE =
-  /^\s*(?:the user |i need |i should |i will |let me |thinking(?:\s+process)?\s*:|looking at |based on |(?:okay|alright|hmm|right|so|well|first|next|now)[,.]?\s+(?:the|i|let|this|that)|looks good|that should|this looks|the diff |the changes |this diff |these changes |analy(?:s|z)(?:e|ing)|i(?:'ll| will) (?:use|write|draft|create|choose|pick|go with))/i;
+  /^\s*(?:the user |they are |the question |i can |i need |i should |i will |i(?:'m| am) going |let me |thinking(?:\s+process)?\s*:|looking at |based on |(?:okay|alright|hmm|right|so|well|first|next|now)[,.]?\s+(?:the|i|let|this|that|so|now|here)|looks good|that should|this looks|the diff |the changes |this diff |these changes |analy(?:s|z)(?:e|ing)|i(?:'ll| will) (?:use|write|draft|create|choose|pick|go with)|need to |focus on |to draft |to write )/i;
+
+/** LM Studio / local models often emit markdown diff walkthroughs before (or instead of) a commit. */
+const DIFF_ANALYSIS_LINE_RE =
+  /^\s*(?:\d+\.\s+(?:\*\*)?|[-*]\s+(?:Removed|Updated|Added|Changed|Fixed|Deleted|Replaced|Modified|Introduced)\b|\*\*[^*]+:\*\*)/i;
+
+const DIFF_ANALYSIS_TEXT_RE =
+  /\bidentify key changes\b|\bkey changes\s*&\s*intent\b|\(likely\b|\(probably\b|\(possibly\b|ui\/ux cleanup\b/i;
+
+export interface CommitMessageExtractOptions {
+  /** When false, only explicit prefixes and conventional commit lines qualify. */
+  allowHeuristicFallback?: boolean;
+}
 
 const MAX_PATCH_CHARS = 12_000;
 const MAX_FILE_HUNK_CHARS = 4_000;
@@ -75,6 +87,7 @@ function buildCommitMessageSystemPrompt(useGitmoji: boolean): string {
   const lines = [
     'You write high-quality git commit messages from git diffs.',
     'Output ONLY the commit message — no markdown fences, explanations, or prefixes like "Commit message:".',
+    'Never output numbered steps, bullet analyses, diff walkthroughs, or markdown headers — go straight to the commit text.',
     '',
     'Subject line:',
     '- Imperative mood, ≤72 characters, no trailing period',
@@ -183,7 +196,25 @@ export function buildGitCommitMessagePrompt(
 function looksLikeReasoningLine(line: string): boolean {
   const trimmed = line.trim();
   if (!trimmed) return false;
+  if (DIFF_ANALYSIS_LINE_RE.test(trimmed)) return true;
   return REASONING_LINE_RE.test(trimmed);
+}
+
+/** True when text is a markdown diff analysis / thinking walkthrough, not a commit message. */
+export function looksLikeDiffAnalysisText(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (DIFF_ANALYSIS_TEXT_RE.test(trimmed)) return true;
+
+  const lines = trimmed.split('\n').map((line) => line.trim()).filter(Boolean);
+  if (lines.length === 0) return false;
+
+  const analysisLines = lines.filter(
+    (line) => DIFF_ANALYSIS_LINE_RE.test(line) || DIFF_ANALYSIS_TEXT_RE.test(line),
+  ).length;
+  if (analysisLines === 0) return false;
+  if (lines.some((line) => CONVENTIONAL_COMMIT_LINE_RE.test(line))) return false;
+  return analysisLines >= 1;
 }
 
 function hasUnclosedThinkingTag(text: string): boolean {
@@ -255,6 +286,7 @@ export function stripReasoningFraming(text: string): string {
 }
 
 function looksLikeCommitMessageSegment(segment: string): boolean {
+  if (looksLikeDiffAnalysisText(segment)) return false;
   const lines = segment.trim().split('\n').filter((line) => line.trim());
   if (lines.length === 0) return false;
   const firstLine = lines[0].trim();
@@ -265,11 +297,37 @@ function looksLikeCommitMessageSegment(segment: string): boolean {
   }
   if (firstLine.length <= 72 && !firstLine.endsWith('?')) {
     const words = firstLine.split(/\s+/);
-    if (words.length >= 2 && words.length <= 12 && !/^(this|these|the|that|there|it|strip)\s/i.test(firstLine)) {
+    if (
+      words.length >= 2 &&
+      words.length <= 12 &&
+      !/^(this|these|the|that|there|it|strip|need|focus|\d+\.)\s*/i.test(firstLine)
+    ) {
       return true;
     }
   }
   return false;
+}
+
+/** True when buffered text is mostly model reasoning with no commit subject yet. */
+function looksLikeReasoningChain(text: string): boolean {
+  if (looksLikeDiffAnalysisText(text)) return true;
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length < 2) return false;
+  if (lines.some((line) => CONVENTIONAL_COMMIT_LINE_RE.test(line))) return false;
+  const reasoningLines = lines.filter((line) => looksLikeReasoningLine(line)).length;
+  return reasoningLines > 0;
+}
+
+function rejectDiffAnalysis(candidate: string): string {
+  return looksLikeDiffAnalysisText(candidate) ? '' : candidate;
+}
+
+function isHighConfidenceCommitMessage(text: string): boolean {
+  const firstLine = text.split('\n')[0]?.trim() ?? '';
+  return CONVENTIONAL_COMMIT_LINE_RE.test(firstLine);
 }
 
 function extractExplicitCommitMessagePrefix(text: string): string {
@@ -291,17 +349,10 @@ function collectCommitBlockFromLine(lines: string[], subjectIdx: number): string
   return kept.join('\n').trim();
 }
 
-/**
- * Pull the commit message out of a reasoning chain. Prefer the last conventional
- * commit block; otherwise the last paragraph that looks like a commit message.
- */
-export function extractCommitMessageFromChain(raw: string): string {
-  const stripped = stripThinkingFromCommitOutput(raw);
-  if (!stripped) return '';
-
+function extractHighConfidenceCommitMessage(stripped: string): string {
   const prefixed = extractExplicitCommitMessagePrefix(stripped);
   if (prefixed) {
-    const candidate = sanitizeCommitMessage(stripReasoningFraming(prefixed));
+    const candidate = rejectDiffAnalysis(sanitizeCommitMessage(stripReasoningFraming(prefixed)));
     if (candidate) return candidate;
   }
 
@@ -310,20 +361,39 @@ export function extractCommitMessageFromChain(raw: string): string {
     const trimmed = lines[i].trim();
     if (!trimmed || looksLikeReasoningLine(trimmed)) continue;
     if (CONVENTIONAL_COMMIT_LINE_RE.test(trimmed)) {
-      return sanitizeCommitMessage(collectCommitBlockFromLine(lines, i));
+      return rejectDiffAnalysis(sanitizeCommitMessage(collectCommitBlockFromLine(lines, i)));
     }
   }
+
+  return '';
+}
+
+/**
+ * Pull the commit message out of a reasoning chain. Prefer the last conventional
+ * commit block; otherwise the last paragraph that looks like a commit message.
+ */
+export function extractCommitMessageFromChain(
+  raw: string,
+  options?: CommitMessageExtractOptions,
+): string {
+  const stripped = stripThinkingFromCommitOutput(raw);
+  if (!stripped) return '';
+
+  const highConfidence = extractHighConfidenceCommitMessage(stripped);
+  if (highConfidence) return highConfidence;
+
+  if (options?.allowHeuristicFallback === false) return '';
 
   const segments = splitThinkingSegments(stripped);
   for (let i = segments.length - 1; i >= 0; i -= 1) {
     if (!looksLikeCommitMessageSegment(segments[i])) continue;
-    const candidate = sanitizeCommitMessage(stripReasoningFraming(segments[i]));
+    const candidate = rejectDiffAnalysis(sanitizeCommitMessage(stripReasoningFraming(segments[i])));
     if (candidate) return candidate;
   }
 
   const framed = stripReasoningFraming(stripped);
   if (framed && looksLikeCommitMessageSegment(framed)) {
-    return sanitizeCommitMessage(framed);
+    return rejectDiffAnalysis(sanitizeCommitMessage(framed));
   }
 
   return '';
@@ -346,30 +416,45 @@ export function resolveCommitMessageDisplayText(
   const content = contentText.trim();
   const reasoning = reasoningText.trim();
   const mirrored = content.length > 0 && reasoning.length > 0 && content === reasoning;
+  const allowHeuristicFallback = options?.reasoningFallback === true;
+  const extractOpts: CommitMessageExtractOptions = { allowHeuristicFallback };
+
+  const tryExtract = (text: string): string => extractCommitMessageFromChain(text, extractOpts);
 
   if (content.length > 0) {
-    const fromContent = extractCommitMessageFromChain(contentText);
-    if (fromContent) return fromContent;
+    const fromContent = tryExtract(contentText);
+    if (fromContent) {
+      const reasoningChain = looksLikeReasoningChain(content);
+      if (!reasoningChain || isHighConfidenceCommitMessage(fromContent)) {
+        return fromContent;
+      }
+    }
 
-    // Fast path: clean one-shot content with no reasoning markers.
-    if (!mirrored && content.split('\n').length <= 4) {
+    // Fast path: clean one-shot content with no reasoning markers (final pass only).
+    if (
+      allowHeuristicFallback &&
+      !mirrored &&
+      !looksLikeReasoningChain(content) &&
+      !looksLikeDiffAnalysisText(content) &&
+      content.split('\n').length <= 4
+    ) {
       const firstLine = content.split('\n')[0]?.trim() ?? '';
       if (firstLine && !looksLikeReasoningLine(firstLine)) {
-        const direct = sanitizeCommitMessage(content);
+        const direct = rejectDiffAnalysis(sanitizeCommitMessage(content));
         if (direct) return direct;
       }
     }
   }
 
-  if (!options?.reasoningFallback) return '';
+  if (!allowHeuristicFallback) return '';
 
   if (reasoning.length > 0 && !mirrored) {
-    const fromReasoning = extractCommitMessageFromChain(reasoningText);
+    const fromReasoning = tryExtract(reasoningText);
     if (fromReasoning) return fromReasoning;
   }
 
   if (content.length > 0) {
-    return extractCommitMessageFromChain(contentText);
+    return tryExtract(contentText);
   }
 
   return '';
@@ -456,7 +541,7 @@ export async function fetchGitCommitMessage(
     model: binding.modelId || undefined,
     messages,
     temperature: Math.min(config.temperature + 0.1, 0.7),
-    max_tokens: Math.max(config.maxTokens, 384),
+    max_tokens: Math.max(config.maxTokens, 768),
     stream: true,
   };
 

--- a/src/ui/git-operations-panel.ts
+++ b/src/ui/git-operations-panel.ts
@@ -372,11 +372,17 @@ export function createGitOperationsPanel(
         setStatus(diffResult.error ?? 'Could not read diff', true);
         return;
       }
+      const changedPaths = useStagedOnly
+        ? staged.map((f) => f.path)
+        : allChanges.map((f) => f.path);
+      const excludedPaths = useStagedOnly
+        ? [...unstaged, ...untracked].map((f) => f.path)
+        : [];
       setStatus('Generating commit message…');
       const result = await fetchGitCommitMessage({
-        stagedPaths: useStagedOnly
-          ? staged.map((f) => f.path)
-          : allChanges.map((f) => f.path),
+        changedPaths,
+        excludedPaths,
+        scope: useStagedOnly ? 'staged' : 'working-tree',
         patch: diffResult.patch,
         signal: controller.signal,
         onPartial: (text) => {

--- a/src/ui/git-panel.ts
+++ b/src/ui/git-panel.ts
@@ -1056,23 +1056,24 @@ async function handleGenerateCommitMessage(): Promise<void> {
       return;
     }
 
+    const changedPaths = useStagedOnly
+      ? staged.map((file) => file.path)
+      : allChanges.map((file) => file.path);
+    const excludedPaths = useStagedOnly
+      ? [...unstaged, ...untracked].map((file) => file.path)
+      : [];
+
     setStatus('Generating commit message…');
 
     const result = await fetchGitCommitMessage({
-      stagedPaths: useStagedOnly
-        ? staged.map((file) => file.path)
-        : allChanges.map((file) => file.path),
-
+      changedPaths,
+      excludedPaths,
+      scope: useStagedOnly ? 'staged' : 'working-tree',
       patch: diffResult.patch,
-
       signal: controller.signal,
-
       onPartial: (text) => {
-
         commitInput!.value = text;
-
       },
-
     });
 
     if (controller.signal.aborted) return;

--- a/test/ui/git-commit-message-client.test.mts
+++ b/test/ui/git-commit-message-client.test.mts
@@ -6,8 +6,14 @@ import { DEFAULT_EDITOR_AI_COMPLETION } from '../../src/config/editor-ai-complet
 import { createEmptyChatObject, setSessionStateForTests } from '../../src/state/sessions.ts';
 import {
   buildGitCommitMessagePrompt,
+  extractCommitMessageFromChain,
+  filterCommitMessagePatch,
+  normalizeCommitMessageOutput,
+  resolveCommitMessageDisplayText,
   resolveGitCommitMessageBinding,
   sanitizeCommitMessage,
+  stripReasoningFraming,
+  stripThinkingFromCommitOutput,
   truncateStagedPatch,
 } from '../../src/ui/git-commit-message-client.ts';
 
@@ -15,6 +21,10 @@ describe('truncateStagedPatch', () => {
   test('returns patch unchanged when under limit', () => {
     const patch = 'diff --git a/foo.ts b/foo.ts\n+hello';
     assert.equal(truncateStagedPatch(patch, 100), patch);
+  });
+
+  test('returns empty patch unchanged', () => {
+    assert.equal(truncateStagedPatch(''), '');
   });
 
   test('appends truncation marker when over limit', () => {
@@ -25,16 +35,87 @@ describe('truncateStagedPatch', () => {
   });
 });
 
+describe('filterCommitMessagePatch', () => {
+  test('collapses oversized per-file hunks', () => {
+    const hunk = `diff --git a/src/big.ts b/src/big.ts\n${'+line\n'.repeat(900)}`;
+    const out = filterCommitMessagePatch(hunk);
+    assert.match(out, /file diff truncated/);
+  });
+
+  test('summarizes lock files instead of full diff', () => {
+    const patch = 'diff --git a/package-lock.json b/package-lock.json\n+  "version": "2.0.0"';
+    const out = filterCommitMessagePatch(patch);
+    assert.match(out, /lock\/generated file/);
+    assert.doesNotMatch(out, /"version": "2.0.0"/);
+  });
+
+  test('returns empty string for empty patch', () => {
+    assert.equal(filterCommitMessagePatch(''), '');
+  });
+});
+
 describe('buildGitCommitMessagePrompt', () => {
-  test('includes changed file list and diff in user message', () => {
-    const messages = buildGitCommitMessagePrompt(['src/a.ts', 'src/b.ts'], '+added line');
+  test('includes changed file list, scope, and diff in user message', () => {
+    const messages = buildGitCommitMessagePrompt({
+      changedPaths: ['src/a.ts', 'src/b.ts'],
+      patch: '+added line',
+      scope: 'staged',
+    });
     assert.equal(messages.length, 2);
     assert.equal(messages[0].role, 'system');
     assert.equal(messages[1].role, 'user');
+    const system = String(messages[0].content);
     const user = String(messages[1].content);
+    assert.match(system, /WHY the change was made/);
+    assert.match(system, /gitmoji/);
+    assert.match(user, /staged changes only/);
     assert.match(user, /src\/a\.ts/);
     assert.match(user, /src\/b\.ts/);
     assert.match(user, /\+added line/);
+  });
+
+  test('notes working-tree scope when nothing is staged', () => {
+    const messages = buildGitCommitMessagePrompt({
+      changedPaths: ['src/a.ts'],
+      patch: '+change',
+      scope: 'working-tree',
+    });
+    const user = String(messages[1].content);
+    assert.match(user, /working tree/);
+    assert.match(user, /Nothing is staged/);
+  });
+
+  test('lists excluded paths for staged-only generation', () => {
+    const messages = buildGitCommitMessagePrompt({
+      changedPaths: ['src/a.ts'],
+      excludedPaths: ['src/b.ts'],
+      patch: '+change',
+      scope: 'staged',
+    });
+    const user = String(messages[1].content);
+    assert.match(user, /Excluded from this message/);
+    assert.match(user, /src\/b\.ts/);
+  });
+
+  test('omits gitmoji guidance when disabled', () => {
+    const messages = buildGitCommitMessagePrompt({
+      changedPaths: ['src/a.ts'],
+      patch: '+change',
+      scope: 'staged',
+      useGitmoji: false,
+    });
+    const system = String(messages[0].content);
+    assert.doesNotMatch(system, /gitmoji/);
+    assert.doesNotMatch(system, /✨/);
+  });
+
+  test('includes breaking change guidance in system prompt', () => {
+    const messages = buildGitCommitMessagePrompt({
+      changedPaths: ['src/a.ts'],
+      patch: '+change',
+      scope: 'staged',
+    });
+    assert.match(String(messages[0].content), /BREAKING CHANGE/);
   });
 });
 
@@ -54,6 +135,143 @@ describe('sanitizeCommitMessage', () => {
   test('preserves multiline body', () => {
     const raw = 'feat: add panel\n\nExplain why this matters.';
     assert.equal(sanitizeCommitMessage(raw), raw);
+  });
+
+  test('preserves gitmoji prefix', () => {
+    const raw = '✨ feat(ui): add commit generator';
+    assert.equal(sanitizeCommitMessage(raw), raw);
+  });
+});
+
+describe('stripThinkingFromCommitOutput', () => {
+  test('returns reply after inline thinking tags', () => {
+    const raw = '<thinking>analyze diff</thinking>feat: add widget';
+    assert.equal(stripThinkingFromCommitOutput(raw), 'feat: add widget');
+  });
+
+  test('returns empty while thinking block is still open', () => {
+    const raw = '<thinking>still analyzing the diff';
+    assert.equal(stripThinkingFromCommitOutput(raw), '');
+  });
+});
+
+describe('extractCommitMessageFromChain', () => {
+  test('extracts the last conventional commit block from a reasoning chain', () => {
+    const chain = [
+      'The user wants a commit message for these git changes.',
+      'I need to analyze the diff carefully.',
+      'The diff shows changes to git-commit-message-client.ts.',
+      "I'll use a fix type since this is a bug fix.",
+      '',
+      'fix(git): extract commit message from reasoning chain',
+      '',
+      'Strip mirrored reasoning instead of dumping the full chain.',
+    ].join('\n');
+
+    const result = extractCommitMessageFromChain(chain);
+    assert.match(result, /^fix\(git\):/);
+    assert.match(result, /Strip mirrored reasoning/);
+  });
+
+  test('extracts gitmoji-prefixed conventional commit', () => {
+    const chain = [
+      'Let me analyze the diff.',
+      '',
+      '✨ feat(git): improve commit message prompts',
+      '',
+      'Body explains why the change matters.',
+    ].join('\n');
+
+    const result = extractCommitMessageFromChain(chain);
+    assert.match(result, /^✨ feat\(git\):/);
+    assert.match(result, /Body explains why/);
+  });
+
+  test('extracts plain commit text from trailing paragraph', () => {
+    const chain = [
+      'Let me read the diff.',
+      'The changes update git panel behavior.',
+      '',
+      'Fix git auto commit message generation',
+    ].join('\n');
+
+    assert.equal(extractCommitMessageFromChain(chain), 'Fix git auto commit message generation');
+  });
+
+  test('returns empty for reasoning-only output', () => {
+    assert.equal(
+      extractCommitMessageFromChain('Let me analyze the staged diff carefully.'),
+      '',
+    );
+  });
+});
+
+describe('resolveCommitMessageDisplayText', () => {
+  test('prefers content channel over reasoning', () => {
+    assert.equal(
+      resolveCommitMessageDisplayText('feat: from content', 'fix: from reasoning', {
+        reasoningFallback: true,
+      }),
+      'feat: from content',
+    );
+  });
+
+  test('does not surface mirrored reasoning chains in content', () => {
+    const chain = [
+      'The user wants a commit message.',
+      'I need to analyze the diff.',
+      '',
+      'feat(git): add commit generator',
+    ].join('\n');
+
+    assert.equal(
+      resolveCommitMessageDisplayText(chain, chain, { reasoningFallback: true }),
+      'feat(git): add commit generator',
+    );
+  });
+
+  test('does not stream partial reasoning while the chain is still growing', () => {
+    const partial = 'The user wants a commit message.\nI need to analyze the diff.';
+    assert.equal(
+      resolveCommitMessageDisplayText(partial, partial, { reasoningFallback: false }),
+      '',
+    );
+  });
+
+  test('falls back to reasoning channel when content is empty', () => {
+    const reasoning = [
+      'Analyzing patch.',
+      '',
+      'fix(ui): handle empty diff',
+    ].join('\n');
+
+    assert.equal(
+      resolveCommitMessageDisplayText('', reasoning, { reasoningFallback: true }),
+      'fix(ui): handle empty diff',
+    );
+  });
+
+  test('matches clean content fast path', () => {
+    assert.equal(
+      resolveCommitMessageDisplayText('✨ feat: ship it', '', { reasoningFallback: true }),
+      '✨ feat: ship it',
+    );
+  });
+});
+
+describe('normalizeCommitMessageOutput', () => {
+  test('accepts plain commit text without conventional prefix', () => {
+    assert.equal(
+      normalizeCommitMessageOutput('Fix git auto commit message generation'),
+      'Fix git auto commit message generation',
+    );
+  });
+});
+
+describe('stripReasoningFraming', () => {
+  test('removes trailing meta commentary', () => {
+    const raw = 'feat(ui): add generator\n\nLooks good.';
+    assert.equal(stripReasoningFraming(raw), 'feat(ui): add generator');
   });
 });
 

--- a/test/ui/git-commit-message-client.test.mts
+++ b/test/ui/git-commit-message-client.test.mts
@@ -8,6 +8,7 @@ import {
   buildGitCommitMessagePrompt,
   extractCommitMessageFromChain,
   filterCommitMessagePatch,
+  looksLikeDiffAnalysisText,
   normalizeCommitMessageOutput,
   resolveCommitMessageDisplayText,
   resolveGitCommitMessageBinding,
@@ -204,6 +205,55 @@ describe('extractCommitMessageFromChain', () => {
       '',
     );
   });
+
+  test('skips heuristic fallback in strict mode', () => {
+    assert.equal(
+      extractCommitMessageFromChain('Fix git auto commit message generation', {
+        allowHeuristicFallback: false,
+      }),
+      '',
+    );
+  });
+
+  test('rejects markdown diff analysis without a conventional subject', () => {
+    const analysis = [
+      '2.  **Identify Key Changes & Intent:**',
+      '   - Removed the "Not sure which to pick?" auto-detection note from the download page (UI/UX cleanup).',
+      '   - Updated platform icons to official logos (Windows, macOS, Linux) for better visual fidelity.',
+      '   - Removed "Continue.dev" from the comparison table on features page (likely no longer relevant).',
+      '   - Removed `<base>` tag from index.html (likely fixing a',
+    ].join('\n');
+
+    assert.equal(extractCommitMessageFromChain(analysis), '');
+    assert.equal(
+      resolveCommitMessageDisplayText(analysis, '', { reasoningFallback: true }),
+      '',
+    );
+    assert.equal(
+      resolveCommitMessageDisplayText(analysis, '', { reasoningFallback: false }),
+      '',
+    );
+  });
+
+  test('extracts conventional commit after markdown diff analysis', () => {
+    const mixed = [
+      '2. **Identify Key Changes & Intent:**',
+      '- Removed stale copy from the download page.',
+      '',
+      'feat(site): refresh download page icons and copy',
+      '',
+      'Align platform branding with current marketing assets.',
+    ].join('\n');
+
+    assert.match(extractCommitMessageFromChain(mixed), /^feat\(site\):/);
+  });
+});
+
+describe('looksLikeDiffAnalysisText', () => {
+  test('detects numbered markdown diff walkthroughs', () => {
+    const sample = '2. **Identify Key Changes & Intent:**\n- Removed stale copy.';
+    assert.equal(looksLikeDiffAnalysisText(sample), true);
+  });
 });
 
 describe('resolveCommitMessageDisplayText', () => {
@@ -235,6 +285,45 @@ describe('resolveCommitMessageDisplayText', () => {
     assert.equal(
       resolveCommitMessageDisplayText(partial, partial, { reasoningFallback: false }),
       '',
+    );
+  });
+
+  test('does not stream heuristic reasoning paragraphs before a conventional subject', () => {
+    const partial = [
+      'Need to focus on the git module changes.',
+      'The diff updates commit message extraction.',
+    ].join('\n');
+    assert.equal(
+      resolveCommitMessageDisplayText(partial, '', { reasoningFallback: false }),
+      '',
+    );
+  });
+
+  test('streams partial conventional commit subjects while generation is in flight', () => {
+    const partial = [
+      'The user wants a commit message.',
+      'fix(git): extract commit message from reasoning',
+    ].join('\n');
+    assert.equal(
+      resolveCommitMessageDisplayText(partial, '', { reasoningFallback: false }),
+      'fix(git): extract commit message from reasoning',
+    );
+  });
+
+  test('prefers reasoning channel over heuristic content false positives', () => {
+    const content = [
+      'Need to focus on the git module changes.',
+      'The diff updates commit message extraction.',
+    ].join('\n');
+    const reasoning = [
+      'Let me analyze the diff.',
+      '',
+      'fix(git): ignore reasoning paragraphs during streaming',
+    ].join('\n');
+
+    assert.equal(
+      resolveCommitMessageDisplayText(content, reasoning, { reasoningFallback: true }),
+      'fix(git): ignore reasoning paragraphs during streaming',
     );
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves AI-generated git commit messages in the Code git panel and aligns the `/git-commit` skill with team conventions.

## Changes

- **Prompt quality:** System prompt now asks for *why* (motivation, impact, trade-offs), conventional `type(scope): subject`, optional body, and `BREAKING CHANGE:` footers when relevant.
- **Gitmoji support:** New `gitCommitMessage.useGitmoji` config (default `true` in `config.json` meta). Prompt includes gitmoji guidance when enabled; extraction/sanitization preserves emoji prefixes.
- **Staged vs unstaged scope:** Git panels pass `scope: 'staged' | 'working-tree'`, changed paths, and excluded unstaged paths so messages match what will actually be committed.
- **Diff filtering:** Lock/generated files are summarized; oversized per-file hunks are truncated before prompting (global cap unchanged).
- **Reasoning-chain extraction:** Models that mirror reasoning into content no longer dump monologue into the commit field — extracts the last conventional commit block instead (builds on MIN-347 work).
- **Skill update:** `/git-commit` SKILL.md documents gitmoji table, scope rules, and quality checks.

## Acceptance

- [x] Sample staged diff → structured prompt with subject + body guidance
- [x] Messages match gitmoji convention when `useGitmoji` is enabled
- [x] No regression on empty/large diffs (tests cover truncation, empty patch, lock-file filtering)

## Test plan

- [x] `npx tsx --import ./test/test-loader.mjs --test test/ui/git-commit-message-client.test.mts` — 29 tests pass
- [ ] Manual: stage changes in Code git panel → sparkles button → verify subject + body quality
- [ ] Manual: invoke `/git-commit` in chat with staged diff

Closes MIN-412
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-412](https://linear.app/minnowai/issue/MIN-412/improve-git-commit-messages)

<div><a href="https://cursor.com/agents/bc-73f964a6-4b82-4844-a5e7-218d0e524956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73f964a6-4b82-4844-a5e7-218d0e524956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

