### PR TITLE
MIN-356 Phase 5 — Automations v2 (conditions, mail-op actions, audit log)

### DIFF
--- a/documentation/plans/email-world-class-spec.md
+++ b/documentation/plans/email-world-class-spec.md
@@ -350,8 +350,37 @@ As built:
   update path now also preserves `signature`, which previously blanked on
   every account edit.
 
-### Phase 5 — Automations v2
+### Phase 5 — Automations v2 ✅ shipped (MIN-356)
 Condition builder, mail-op actions through review queue, real OS notifications, dry-run, audit log + Runs UI.
+
+As built:
+
+- **Rule schema** (`server/email/automations.js`): a rule is now
+  `{ trigger, conditions: [{ field, op, value }], actions: [...], trusted }`.
+  `normalizeRule` migrates v1 rules (bare `action` + `config`) forward on
+  read, so old files keep working and the old `notify` maps onto `os_notify`.
+- **Conditions** AND-combine over `sender`/`domain`/`subject`/`category`/
+  `urgency` (text ops) and `has_attachment` (boolean); an empty list matches
+  everything. Matching is pure and case-insensitive.
+- **Actions**: `triage`, `generate_variants`, `mark_read`, `flag`, `archive`,
+  `move_to_folder`, `forward_to`, `os_notify`, `run_scheduler_job`. Mail-ops
+  route through the Phase 4 review queue by default; a rule the user marks
+  **trusted** applies them directly. `delete` is intentionally not an action.
+- **Guardrail** (Part 7, absolute): automations never send mail. `forward_to`
+  writes a *forward draft* (`drafts` store) for the user to send by hand — it
+  never reaches SMTP, trusted or not. This is the "confirm-queue".
+- **os_notify** fixes the D9 dead-end `notify`: it enqueues a real
+  `enqueueSchedulerNotification` (the same path follow-ups use for OS
+  notifications) and still emits the in-app `automation_notify` SSE.
+- **Audit log**: every action execution writes an `automation_runs` row
+  (rule, message row, action, outcome, detail). `GET /automations/:id/runs`
+  backs a Runs view per rule; the account is resolved from the rule itself.
+- **Dry-run**: `POST /automations/dry-run` evaluates a (possibly unsaved) rule
+  against messages stored in the last N days (default 7) and returns
+  "matched M of N" plus a small sample — no actions run.
+- **UI** (`src/ui/email/email-automations.ts`): full builder with add/remove
+  condition and action rows, contextual param inputs, trusted checkbox, a
+  dry-run button, and a per-rule Runs view — replacing the two-dropdown form.
 
 ### Phase 6 — Design polish pass
 Everything remaining from Part 5: quick-reply preview cards, dashboard visual refresh, states/feedback, a11y audit (axe pass, full keyboard traversal, focus management on pane switches), responsive ≤900px two-step flow re-check.

--- a/server/email/automations.js
+++ b/server/email/automations.js
@@ -1,5 +1,19 @@
 /**
- * Email automation rules — persisted in ~/.minnow/email/automations.json.
+ * Email automation rules v2 (spec Part 4 / Phase 5).
+ *
+ * A rule is `{ conditions: [{ field, op, value }], trigger, actions: [...] }`:
+ * a trigger picks the moment (new mail, high urgency, tag), the conditions
+ * AND-narrow which messages qualify, and one or more actions run against each
+ * match. Rules persist in ~/.minnow/email/automations.json; every execution is
+ * recorded in the per-account `automation_runs` table (the audit log, surfaced
+ * as the Runs tab).
+ *
+ * Guardrails (Part 7, absolute):
+ *  - Automations never send mail. `forward_to` writes a *draft* for the user to
+ *    review and send by hand — it never reaches SMTP on its own.
+ *  - Mail-op actions (archive/move/read/flag) route through the Phase 4 review
+ *    queue by default; only a rule the user explicitly marks `trusted` executes
+ *    them directly. `delete` is not an automation action at all.
  */
 
 import fs from 'node:fs/promises';
@@ -7,6 +21,58 @@ import { randomUUID } from 'node:crypto';
 import { emailAutomationsPath } from './paths.js';
 import { triageMessage } from './triage.js';
 import { emitEmailEvent } from './events.js';
+import { getMailDb, hydrateAttachments } from './store.js';
+import { splitAddressHeader } from './contacts.js';
+import { bulkMessageAction } from './mail-actions.js';
+import { enqueuePendingAction } from './pending-actions.js';
+import { enqueueSchedulerNotification } from '../scheduler/delivery.js';
+
+/** Fields a condition may test against a message. */
+export const CONDITION_FIELDS = ['sender', 'domain', 'subject', 'has_attachment', 'category', 'urgency'];
+
+/** Comparison operators a condition may use. */
+export const CONDITION_OPS = ['contains', 'not_contains', 'equals', 'not_equals', 'is_true', 'is_false'];
+
+/** Triggers that pick the moment a rule is considered. */
+export const AUTOMATION_TRIGGERS = ['on_new_message', 'on_high_urgency', 'on_tag_match'];
+
+/** Every action type a rule may carry. */
+export const ACTION_TYPES = [
+  'triage',
+  'generate_variants',
+  'mark_read',
+  'flag',
+  'archive',
+  'move_to_folder',
+  'forward_to',
+  'os_notify',
+  'run_scheduler_job',
+];
+
+/** Mail-op actions that collapse onto the review-queue / bulk pipeline. */
+const MAIL_OP_ACTIONS = {
+  mark_read: 'read',
+  flag: 'flag',
+  archive: 'archive',
+  move_to_folder: 'move',
+};
+
+/**
+ * @typedef {object} AutomationCondition
+ * @property {string} field
+ * @property {string} op
+ * @property {string} value
+ */
+
+/**
+ * @typedef {object} AutomationAction
+ * @property {string} type
+ * @property {string} [folder]
+ * @property {string} [to]
+ * @property {string} [title]
+ * @property {string} [body]
+ * @property {string} [jobId]
+ */
 
 /**
  * @typedef {object} EmailAutomation
@@ -15,16 +81,103 @@ import { emitEmailEvent } from './events.js';
  * @property {boolean} enabled
  * @property {string} accountId
  * @property {string} trigger
- * @property {string} action
+ * @property {AutomationCondition[]} conditions
+ * @property {AutomationAction[]} actions
+ * @property {boolean} trusted
  * @property {Record<string, unknown>} [config]
  * @property {string} createdAt
  * @property {string} updatedAt
  */
 
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/** @param {unknown} raw */
+function normalizeCondition(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const field = String(/** @type {any} */ (raw).field ?? '').trim();
+  const op = String(/** @type {any} */ (raw).op ?? '').trim();
+  if (!CONDITION_FIELDS.includes(field) || !CONDITION_OPS.includes(op)) {
+    return null;
+  }
+  return { field, op, value: String(/** @type {any} */ (raw).value ?? '') };
+}
+
 /**
- * @returns {Promise<EmailAutomation[]>}
+ * Coerce a stored/legacy action into the v2 shape. A legacy rule stored a bare
+ * `action` string plus a `config`; the old `notify` maps onto `os_notify`.
+ * @param {unknown} raw
+ * @param {Record<string, unknown>} [legacyConfig]
  */
-export async function listAutomations() {
+function normalizeAction(raw, legacyConfig) {
+  const isString = typeof raw === 'string';
+  const source = isString ? {} : /** @type {Record<string, any>} */ (raw ?? {});
+  const rawType = isString ? String(raw) : String(source.type ?? '').trim();
+  const type = rawType === 'notify' ? 'os_notify' : rawType;
+  if (!ACTION_TYPES.includes(type)) {
+    return null;
+  }
+
+  /** @type {AutomationAction} */
+  const action = { type };
+  const cfg = legacyConfig && typeof legacyConfig === 'object' ? legacyConfig : {};
+  if (type === 'move_to_folder') {
+    action.folder = String(source.folder ?? cfg.folder ?? '').trim();
+  }
+  if (type === 'forward_to') {
+    action.to = String(source.to ?? cfg.to ?? '').trim();
+  }
+  if (type === 'os_notify') {
+    action.title = String(source.title ?? cfg.title ?? '').trim();
+    action.body = String(source.body ?? cfg.body ?? '').trim();
+  }
+  if (type === 'run_scheduler_job') {
+    action.jobId = String(source.jobId ?? cfg.jobId ?? '').trim();
+  }
+  return action;
+}
+
+/**
+ * Migrate any stored rule (v1 single-action or v2) to the v2 shape.
+ * @param {Record<string, any>} rule
+ * @returns {EmailAutomation}
+ */
+export function normalizeRule(rule) {
+  const conditions = Array.isArray(rule.conditions)
+    ? rule.conditions.map(normalizeCondition).filter(Boolean)
+    : [];
+
+  let actions = [];
+  if (Array.isArray(rule.actions) && rule.actions.length > 0) {
+    actions = rule.actions.map((action) => normalizeAction(action)).filter(Boolean);
+  } else if (rule.action) {
+    // v1 rule: one action string plus a loose config bag.
+    const legacy = normalizeAction(rule.action, rule.config);
+    if (legacy) actions = [legacy];
+  }
+
+  const trigger = AUTOMATION_TRIGGERS.includes(String(rule.trigger))
+    ? String(rule.trigger)
+    : 'on_new_message';
+
+  return {
+    id: String(rule.id ?? ''),
+    name: String(rule.name ?? 'Untitled rule').trim() || 'Untitled rule',
+    enabled: rule.enabled !== false,
+    accountId: String(rule.accountId ?? '').trim(),
+    trigger,
+    conditions,
+    actions,
+    trusted: rule.trusted === true,
+    config: rule.config && typeof rule.config === 'object' ? rule.config : {},
+    createdAt: String(rule.createdAt ?? ''),
+    updatedAt: String(rule.updatedAt ?? ''),
+  };
+}
+
+/** Read the raw rules array exactly as stored. */
+async function readRulesFromDisk() {
   const filePath = emailAutomationsPath();
   try {
     const raw = await fs.readFile(filePath, 'utf8');
@@ -39,6 +192,14 @@ export async function listAutomations() {
 }
 
 /**
+ * @returns {Promise<EmailAutomation[]>}
+ */
+export async function listAutomations() {
+  const rules = await readRulesFromDisk();
+  return rules.map(normalizeRule);
+}
+
+/**
  * @param {EmailAutomation[]} rules
  */
 async function writeAutomations(rules) {
@@ -46,7 +207,7 @@ async function writeAutomations(rules) {
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   await fs.writeFile(
     tmp,
-    `${JSON.stringify({ version: 1, rules, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+    `${JSON.stringify({ version: 2, rules, updatedAt: nowIso() }, null, 2)}\n`,
     'utf8',
   );
   await fs.rename(tmp, filePath);
@@ -56,24 +217,22 @@ async function writeAutomations(rules) {
  * @param {Record<string, unknown>} input
  */
 export async function createAutomation(input) {
-  const rules = await listAutomations();
-  const now = new Date().toISOString();
-  const rule = {
+  const rules = await readRulesFromDisk();
+  const now = nowIso();
+  const rule = normalizeRule({
+    ...input,
     id: randomUUID(),
-    name: String(input.name ?? 'Untitled rule').trim(),
-    enabled: input.enabled !== false,
-    accountId: String(input.accountId ?? '').trim(),
-    trigger: String(input.trigger ?? 'on_new_message').trim(),
-    action: String(input.action ?? 'triage').trim(),
-    config: input.config && typeof input.config === 'object' ? input.config : {},
     createdAt: now,
     updatedAt: now,
-  };
+  });
   if (!rule.accountId) {
     throw new Error('accountId is required');
   }
+  if (rule.actions.length === 0) {
+    throw new Error('At least one action is required');
+  }
   rules.push(rule);
-  await writeAutomations(rules);
+  await writeAutomations(rules.map(normalizeRule));
   return rule;
 }
 
@@ -82,32 +241,35 @@ export async function createAutomation(input) {
  * @param {Record<string, unknown>} patch
  */
 export async function updateAutomation(id, patch) {
-  const rules = await listAutomations();
+  const rules = await readRulesFromDisk();
   const index = rules.findIndex((row) => row.id === id);
   if (index < 0) {
     throw new Error('Automation not found');
   }
-  const prev = rules[index];
-  rules[index] = {
+  const prev = normalizeRule(rules[index]);
+  const merged = normalizeRule({
     ...prev,
     ...patch,
     id: prev.id,
-    updatedAt: new Date().toISOString(),
-  };
-  await writeAutomations(rules);
-  return rules[index];
+    accountId: prev.accountId,
+    createdAt: prev.createdAt,
+    updatedAt: nowIso(),
+  });
+  rules[index] = merged;
+  await writeAutomations(rules.map(normalizeRule));
+  return merged;
 }
 
 /**
  * @param {string} id
  */
 export async function deleteAutomation(id) {
-  const rules = await listAutomations();
+  const rules = await readRulesFromDisk();
   const next = rules.filter((row) => row.id !== id);
   if (next.length === rules.length) {
     throw new Error('Automation not found');
   }
-  await writeAutomations(next);
+  await writeAutomations(next.map(normalizeRule));
   return { deleted: true };
 }
 
@@ -116,21 +278,90 @@ export async function deleteAutomation(id) {
  * @param {string} accountId
  */
 export async function deleteAutomationsForAccount(accountId) {
-  const rules = await listAutomations();
+  const rules = await readRulesFromDisk();
   const next = rules.filter((row) => row.accountId !== accountId);
   if (next.length === rules.length) {
     return { removed: 0 };
   }
-  await writeAutomations(next);
+  await writeAutomations(next.map(normalizeRule));
   return { removed: rules.length - next.length };
 }
 
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
 /**
- * Match automation trigger against a message.
- * @param {EmailAutomation} rule
- * @param {Record<string, unknown>} message
+ * The lowercased value a condition field reads off a message.
+ * @param {string} field
+ * @param {Record<string, any>} message
  */
-function triggerMatches(rule, message) {
+function fieldValue(field, message) {
+  const from = String(message.from ?? '');
+  switch (field) {
+    case 'sender':
+      return from.toLowerCase();
+    case 'domain': {
+      const address = splitAddressHeader(from).address.toLowerCase();
+      const at = address.lastIndexOf('@');
+      return at >= 0 ? address.slice(at + 1) : '';
+    }
+    case 'subject':
+      return String(message.subject ?? '').toLowerCase();
+    case 'category':
+      return String(message.triage?.category ?? '').toLowerCase();
+    case 'urgency':
+      return String(message.triage?.urgency ?? '').toLowerCase();
+    case 'has_attachment':
+      return message.hasAttachments ? 'true' : 'false';
+    default:
+      return '';
+  }
+}
+
+/**
+ * @param {AutomationCondition} cond
+ * @param {Record<string, any>} message
+ */
+export function matchCondition(cond, message) {
+  const value = String(cond?.value ?? '').trim().toLowerCase();
+  const actual = fieldValue(String(cond?.field ?? ''), message);
+  switch (cond?.op) {
+    case 'contains':
+      return value.length > 0 && actual.includes(value);
+    case 'not_contains':
+      return value.length === 0 || !actual.includes(value);
+    case 'equals':
+      return actual === value;
+    case 'not_equals':
+      return actual !== value;
+    case 'is_true':
+      return actual === 'true';
+    case 'is_false':
+      return actual === 'false';
+    default:
+      return false;
+  }
+}
+
+/**
+ * All conditions must hold (AND). An empty condition list matches everything.
+ * @param {AutomationCondition[]} conditions
+ * @param {Record<string, any>} message
+ */
+export function matchesConditions(conditions, message) {
+  if (!Array.isArray(conditions) || conditions.length === 0) {
+    return true;
+  }
+  return conditions.every((cond) => matchCondition(cond, message));
+}
+
+/**
+ * Whether the rule's trigger fires for this message.
+ * @param {EmailAutomation} rule
+ * @param {Record<string, any>} message
+ */
+export function triggerMatches(rule, message) {
   if (!rule.enabled) {
     return false;
   }
@@ -138,28 +369,259 @@ function triggerMatches(rule, message) {
     return false;
   }
 
-  const trigger = rule.trigger;
-  if (trigger === 'on_new_message') {
-    return true;
-  }
-  if (trigger === 'on_high_urgency') {
-    return String(message.triage?.urgency ?? '').toLowerCase() === 'high';
-  }
-  if (trigger === 'on_tag_match') {
-    const needle = String(rule.config?.tag ?? '').trim().toLowerCase();
-    if (!needle) {
-      return false;
+  switch (rule.trigger) {
+    case 'on_new_message':
+      return true;
+    case 'on_high_urgency':
+      return String(message.triage?.urgency ?? '').toLowerCase() === 'high';
+    case 'on_tag_match': {
+      const needle = String(rule.config?.tag ?? '').trim().toLowerCase();
+      if (!needle) return false;
+      const tags = Array.isArray(message.triage?.tags) ? message.triage.tags : [];
+      return tags.some((tag) => String(tag).toLowerCase() === needle);
     }
-    const tags = Array.isArray(message.triage?.tags) ? message.triage.tags : [];
-    return tags.some((tag) => String(tag).toLowerCase() === needle);
+    default:
+      return false;
   }
-  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+/** @param {Record<string, any>} row */
+function rowToRun(row) {
+  return {
+    id: row.id,
+    ruleId: row.rule_id,
+    messageRowId: row.message_row_id ?? null,
+    action: row.action,
+    outcome: row.outcome,
+    detail: row.detail || '',
+    ranAt: row.ran_at || '',
+  };
+}
+
+/**
+ * @param {import('better-sqlite3').Database} db
+ * @param {{ ruleId: string, messageRowId?: number | null, action: string, outcome: string, detail?: string }} input
+ */
+export function recordAutomationRun(db, input) {
+  db.prepare(
+    `INSERT INTO automation_runs (rule_id, message_row_id, action, outcome, detail, ran_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    String(input.ruleId ?? ''),
+    Number.isFinite(input.messageRowId) ? Number(input.messageRowId) : null,
+    String(input.action ?? ''),
+    String(input.outcome ?? ''),
+    String(input.detail ?? ''),
+    nowIso(),
+  );
+}
+
+/**
+ * @param {string} accountId
+ * @param {string} ruleId
+ * @param {{ limit?: number }} [options]
+ */
+export async function listAutomationRuns(accountId, ruleId, options = {}) {
+  const db = getMailDb(accountId);
+  const limit = Math.min(200, Math.max(1, Number(options.limit) || 50));
+  const rows = db
+    .prepare('SELECT * FROM automation_runs WHERE rule_id = ? ORDER BY id DESC LIMIT ?')
+    .all(String(ruleId ?? ''), limit);
+  return rows.map(rowToRun);
+}
+
+/**
+ * Runs for a rule, resolving the owning account from the rule itself so the
+ * route does not need the account id in the URL.
+ * @param {string} ruleId
+ * @param {{ limit?: number }} [options]
+ */
+export async function listAutomationRunsForRule(ruleId, options = {}) {
+  const rules = await listAutomations();
+  const rule = rules.find((row) => row.id === ruleId);
+  if (!rule) {
+    throw new Error('Automation not found');
+  }
+  return listAutomationRuns(rule.accountId, ruleId, options);
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a forward draft. Never sends — the draft is the "confirm queue" the
+ * guardrail requires: the user opens it and clicks Send themselves.
+ * @param {string} accountId
+ * @param {string} to
+ * @param {Record<string, any>} message
+ */
+async function createForwardDraft(accountId, to, message) {
+  const { saveDraft } = await import('./drafts.js');
+  const subjectRaw = String(message.subject ?? '');
+  const subject = /^\s*fwd?:/i.test(subjectRaw) ? subjectRaw : `Fwd: ${subjectRaw}`.trim();
+  const original = String(message.bodyText ?? message.bodyPreview ?? '');
+  const header =
+    '\n\n---------- Forwarded message ----------\n' +
+    `From: ${String(message.from ?? '')}\n` +
+    `Subject: ${subjectRaw}\n` +
+    `Date: ${String(message.date ?? '')}\n\n`;
+  return saveDraft(accountId, {
+    threadId: String(message.threadId ?? ''),
+    mode: 'forward',
+    to,
+    subject,
+    body: `${header}${original}`,
+  });
+}
+
+/**
+ * Run one action against one message and record the outcome. Never throws:
+ * a failing action is logged to the audit table, not propagated.
+ * @param {string} accountId
+ * @param {EmailAutomation} rule
+ * @param {AutomationAction} action
+ * @param {Record<string, any>} message
+ * @param {string} messageKey
+ */
+async function runAutomationAction(accountId, rule, action, message, messageKey) {
+  const db = getMailDb(accountId);
+  const messageRowId = Number.isFinite(message.messageRowId) ? Number(message.messageRowId) : null;
+  let outcome = 'applied';
+  let detail = '';
+
+  try {
+    switch (action.type) {
+      case 'triage':
+        await triageMessage(accountId, messageKey);
+        break;
+
+      case 'generate_variants':
+        if (message.threadId) {
+          const { generateReplyVariants } = await import('./agent.js');
+          await generateReplyVariants(accountId, String(message.threadId), { messageKey });
+        } else {
+          outcome = 'skipped';
+          detail = 'no thread';
+        }
+        break;
+
+      case 'mark_read':
+      case 'flag':
+      case 'archive':
+      case 'move_to_folder': {
+        const mailAction = MAIL_OP_ACTIONS[action.type];
+        const destFolder = action.type === 'move_to_folder' ? String(action.folder ?? '').trim() : undefined;
+        if (action.type === 'move_to_folder' && !destFolder) {
+          outcome = 'failed';
+          detail = 'destination folder required';
+          break;
+        }
+        if (rule.trusted) {
+          // Explicitly trusted: apply the mail-op straight away.
+          const result = await bulkMessageAction(accountId, {
+            ids: [messageKey],
+            action: mailAction,
+            destFolder,
+          });
+          if (result.failed > 0) {
+            outcome = 'failed';
+            detail = `${result.failed} of 1 failed`;
+          }
+        } else {
+          // Default: route through the Phase 4 review queue for the user to
+          // Apply / Dismiss. The pending row is the second audit trail.
+          await enqueuePendingAction(accountId, {
+            source: `automation:${rule.id}`,
+            label: `${rule.name}: ${action.type.replace(/_/g, ' ')}`,
+            action: mailAction,
+            messageIds: [messageKey],
+            destFolder,
+            detail: `Automation "${rule.name}"`,
+          });
+          outcome = 'queued';
+        }
+        break;
+      }
+
+      case 'forward_to': {
+        const to = String(action.to ?? '').trim();
+        if (!to) {
+          outcome = 'failed';
+          detail = 'recipient required';
+          break;
+        }
+        // Absolute guardrail: never send. A forward becomes a draft to review.
+        const draft = await createForwardDraft(accountId, to, message);
+        outcome = 'drafted';
+        detail = `Forward draft to ${to} (${draft.id})`;
+        break;
+      }
+
+      case 'os_notify': {
+        const title = String(action.title ?? '').trim() || rule.name;
+        const bodyText = String(action.body ?? '').trim() || String(message.subject ?? 'New mail');
+        await enqueueSchedulerNotification({
+          jobId: `email-automation:${rule.id}:${messageKey}`,
+          label: title,
+          message: bodyText,
+        });
+        // Keep the in-app SSE too, so an open dashboard can flash the toast.
+        emitEmailEvent('automation_notify', {
+          accountId,
+          messageId: messageKey,
+          ruleId: rule.id,
+          title,
+          body: bodyText,
+        });
+        outcome = 'notified';
+        break;
+      }
+
+      case 'run_scheduler_job': {
+        const jobId = String(action.jobId ?? '').trim();
+        if (!jobId) {
+          outcome = 'failed';
+          detail = 'jobId required';
+          break;
+        }
+        const { runJobNow } = await import('../scheduler/runner.js');
+        await runJobNow(jobId, { trigger: 'email-automation' });
+        outcome = 'ran';
+        detail = `job ${jobId}`;
+        break;
+      }
+
+      default:
+        outcome = 'skipped';
+        detail = `unknown action ${action.type}`;
+    }
+  } catch (err) {
+    outcome = 'failed';
+    detail = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[email/automations] rule ${rule.id} action ${action.type} failed:`,
+      detail,
+    );
+  }
+
+  recordAutomationRun(db, {
+    ruleId: rule.id,
+    messageRowId,
+    action: action.type,
+    outcome,
+    detail,
+  });
 }
 
 /**
  * Run matching automations for one new message.
  * @param {string} accountId
- * @param {Record<string, unknown>} message
+ * @param {Record<string, any>} message
  */
 export async function evaluateAutomationsForMessage(accountId, message) {
   const rules = await listAutomations();
@@ -172,27 +634,53 @@ export async function evaluateAutomationsForMessage(accountId, message) {
     if (!triggerMatches(rule, { ...message, accountId })) {
       continue;
     }
-
-    try {
-      if (rule.action === 'triage') {
-        await triageMessage(accountId, messageKey);
-      } else if (rule.action === 'generate_variants' && message.threadId) {
-        const { generateReplyVariants } = await import('./agent.js');
-        await generateReplyVariants(accountId, String(message.threadId), { messageKey });
-      } else if (rule.action === 'notify') {
-        emitEmailEvent('automation_notify', {
-          accountId,
-          messageId: messageKey,
-          ruleId: rule.id,
-          title: String(rule.config?.title ?? rule.name),
-          body: String(rule.config?.body ?? message.subject ?? 'New mail'),
-        });
-      }
-    } catch (err) {
-      console.warn(
-        `[email/automations] rule ${rule.id} failed:`,
-        err instanceof Error ? err.message : err,
-      );
+    if (!matchesConditions(rule.conditions, message)) {
+      continue;
+    }
+    for (const action of rule.actions) {
+      // Each action records its own run and swallows its own errors, so one
+      // bad action never aborts the rest of the rule.
+      // eslint-disable-next-line no-await-in-loop
+      await runAutomationAction(accountId, rule, action, message, messageKey);
     }
   }
+}
+
+/**
+ * Preview how many recently stored messages a (possibly unsaved) rule would
+ * have matched — trigger + conditions, no actions run.
+ * @param {string} accountId
+ * @param {Record<string, unknown>} ruleInput
+ * @param {{ days?: number }} [options]
+ */
+export async function dryRunAutomation(accountId, ruleInput, options = {}) {
+  const days = Math.min(90, Math.max(1, Number(options.days) || 7));
+  const since = Date.now() - days * 86_400_000;
+  const db = getMailDb(accountId);
+  const rows = db
+    .prepare('SELECT * FROM messages WHERE date_ms >= ? ORDER BY date_ms DESC LIMIT 2000')
+    .all(since);
+  const messages = hydrateAttachments(db, rows).filter(Boolean);
+
+  // Force enabled so a disabled draft still previews; scope to this account.
+  const rule = normalizeRule({ ...ruleInput, accountId, enabled: true });
+
+  const matched = [];
+  for (const message of messages) {
+    if (!triggerMatches(rule, { ...message, accountId })) continue;
+    if (!matchesConditions(rule.conditions, message)) continue;
+    matched.push(message);
+  }
+
+  return {
+    days,
+    total: messages.length,
+    matched: matched.length,
+    sample: matched.slice(0, 8).map((message) => ({
+      id: message.id,
+      from: message.from,
+      subject: message.subject,
+      date: message.date,
+    })),
+  };
 }

--- a/server/email/middleware.js
+++ b/server/email/middleware.js
@@ -75,6 +75,8 @@ import {
   createAutomation,
   updateAutomation,
   deleteAutomation,
+  dryRunAutomation,
+  listAutomationRunsForRule,
 } from './automations.js';
 import { getFolderUnreadCounts } from './cache.js';
 
@@ -196,6 +198,33 @@ export function createEmailMiddleware() {
         const body = await readJsonBody(req);
         const rule = await createAutomation(body);
         sendJson(res, 201, { rule });
+        return;
+      }
+
+      // Dry-run previews an unsaved rule against the store; must be matched
+      // before the `/automations/:id` catch so "dry-run" is not read as an id.
+      if (url === '/api/email/automations/dry-run' && req.method === 'POST') {
+        const body = await readJsonBody(req);
+        const accountId = String(body.accountId ?? body.rule?.accountId ?? '').trim();
+        if (!accountId) {
+          sendJson(res, 400, { error: 'accountId is required' });
+          return;
+        }
+        const preview = await dryRunAutomation(accountId, body.rule ?? body, {
+          days: Number(body.days) || undefined,
+        });
+        sendJson(res, 200, preview);
+        return;
+      }
+
+      const automationRunsMatch = url.match(/^\/api\/email\/automations\/([^/]+)\/runs$/);
+      if (automationRunsMatch && req.method === 'GET') {
+        const ruleId = decodeURIComponent(automationRunsMatch[1]);
+        const params = parseQuery(req.url ?? '');
+        const runs = await listAutomationRunsForRule(ruleId, {
+          limit: Number(params.get('limit')) || undefined,
+        });
+        sendJson(res, 200, { runs });
         return;
       }
 

--- a/src/email/client-ext.ts
+++ b/src/email/client-ext.ts
@@ -5,6 +5,8 @@
 import type {
   EmailAccount,
   EmailAutomation,
+  EmailAutomationDryRun,
+  EmailAutomationRun,
   EmailDraft,
   EmailFollowup,
   EmailInboxSummary,
@@ -19,6 +21,8 @@ import { withSessionToken } from '../api/session-token.ts';
 
 export type {
   EmailAutomation,
+  EmailAutomationDryRun,
+  EmailAutomationRun,
   EmailFollowup,
   EmailInboxSummary,
   EmailNarrativeDigest,
@@ -293,6 +297,24 @@ export async function deleteAutomationRule(id: string): Promise<void> {
     method: 'DELETE',
   });
   await parseJson(res);
+}
+
+export async function fetchAutomationRuns(id: string): Promise<EmailAutomationRun[]> {
+  const res = await fetch(`/api/email/automations/${encodeURIComponent(id)}/runs`);
+  const data = await parseJson<{ runs: EmailAutomationRun[] }>(res);
+  return data.runs;
+}
+
+export async function dryRunAutomation(
+  rule: Partial<EmailAutomation> & { accountId: string },
+  days?: number,
+): Promise<EmailAutomationDryRun> {
+  const res = await fetch('/api/email/automations/dry-run', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accountId: rule.accountId, rule, days }),
+  });
+  return parseJson<EmailAutomationDryRun>(res);
 }
 
 /**

--- a/src/email/client.ts
+++ b/src/email/client.ts
@@ -157,16 +157,79 @@ export interface EmailCatchupSummary {
   messageCount: number;
 }
 
+export type EmailAutomationTrigger = 'on_new_message' | 'on_high_urgency' | 'on_tag_match';
+
+export type EmailAutomationConditionField =
+  | 'sender'
+  | 'domain'
+  | 'subject'
+  | 'has_attachment'
+  | 'category'
+  | 'urgency';
+
+export type EmailAutomationConditionOp =
+  | 'contains'
+  | 'not_contains'
+  | 'equals'
+  | 'not_equals'
+  | 'is_true'
+  | 'is_false';
+
+export interface EmailAutomationCondition {
+  field: EmailAutomationConditionField;
+  op: EmailAutomationConditionOp;
+  value: string;
+}
+
+export type EmailAutomationActionType =
+  | 'triage'
+  | 'generate_variants'
+  | 'mark_read'
+  | 'flag'
+  | 'archive'
+  | 'move_to_folder'
+  | 'forward_to'
+  | 'os_notify'
+  | 'run_scheduler_job';
+
+export interface EmailAutomationAction {
+  type: EmailAutomationActionType;
+  folder?: string;
+  to?: string;
+  title?: string;
+  body?: string;
+  jobId?: string;
+}
+
 export interface EmailAutomation {
   id: string;
   name: string;
   enabled: boolean;
   accountId: string;
-  trigger: 'on_new_message' | 'on_high_urgency' | 'on_tag_match';
-  action: 'triage' | 'generate_variants' | 'notify' | 'run_scheduler_job';
+  trigger: EmailAutomationTrigger;
+  conditions: EmailAutomationCondition[];
+  actions: EmailAutomationAction[];
+  trusted: boolean;
   config?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface EmailAutomationRun {
+  id: number;
+  ruleId: string;
+  messageRowId: number | null;
+  action: string;
+  outcome: string;
+  detail: string;
+  ranAt: string;
+}
+
+export interface EmailAutomationDryRun {
+  days: number;
+  total: number;
+  matched: number;
+  sample: Array<{ id: string; from: string; subject: string; date: string }>;
 }
 
 export interface EmailDraft {

--- a/src/styles/email.css
+++ b/src/styles/email.css
@@ -2044,6 +2044,133 @@
   color: var(--mn-fg-muted);
 }
 
+.email-automation-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.email-automation-title h4 {
+  margin: 0;
+}
+
+.email-chip {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border: 1px solid var(--mn-border);
+  border-radius: 6px;
+  color: var(--mn-fg-muted);
+}
+
+.email-chip-trusted {
+  color: var(--mn-accent);
+  border-color: color-mix(in srgb, var(--mn-accent) 40%, var(--mn-border));
+}
+
+.email-automation-subhead {
+  margin: 14px 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--mn-fg-muted);
+}
+
+.email-automation-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.email-automation-label {
+  min-width: 64px;
+  font-size: 12px;
+  color: var(--mn-fg-muted);
+}
+
+.email-automation-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--mn-fg-muted);
+}
+
+.email-automation-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.email-automation-row-edit {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.email-automation-row-edit .email-select {
+  flex: 0 0 auto;
+}
+
+.email-automation-row-edit .email-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.email-btn-icon {
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+.email-automation-dryrun {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+
+.email-automation-dryrun-result {
+  font-size: 12px;
+  color: var(--mn-fg-muted);
+}
+
+.email-automation-runs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.email-automation-run {
+  padding: 8px 12px;
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-md, 10px);
+}
+
+.email-automation-run-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.email-automation-run-action {
+  font-family: var(--mn-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+}
+
+.email-run-outcome.outcome-failed {
+  color: var(--mn-danger, #c45);
+  border-color: color-mix(in srgb, var(--mn-danger, #c45) 35%, var(--mn-border));
+}
+
+.email-run-outcome.outcome-queued,
+.email-run-outcome.outcome-drafted {
+  color: var(--mn-accent);
+  border-color: color-mix(in srgb, var(--mn-accent) 35%, var(--mn-border));
+}
+
 @media (max-width: 900px) {
   .email-layout-grid {
     grid-template-columns: 1fr;

--- a/src/ui/email/email-automations.ts
+++ b/src/ui/email/email-automations.ts
@@ -1,11 +1,24 @@
-import { appAlert, appConfirm, appPrompt } from '../app-dialog';
+import { appConfirm } from '../app-dialog';
 /**
- * Email automation rules list and simple builder.
+ * Email automation rules — condition builder, multi-action rules, dry-run
+ * preview, and a per-rule Runs (audit) view. Spec Part 4 / Phase 5.
  */
 
-import type { EmailAccount, EmailAutomation } from '../../email/client';
+import type {
+  EmailAccount,
+  EmailAutomation,
+  EmailAutomationAction,
+  EmailAutomationActionType,
+  EmailAutomationCondition,
+  EmailAutomationConditionField,
+  EmailAutomationConditionOp,
+  EmailAutomationRun,
+  EmailAutomationTrigger,
+} from '../../email/client';
 import {
   deleteAutomationRule,
+  dryRunAutomation,
+  fetchAutomationRuns,
   fetchAutomations,
   saveAutomation,
   updateAutomationRule,
@@ -16,6 +29,45 @@ export interface EmailAutomationsOptions {
   onStatus?: (state: 'ok' | 'err', message: string) => void;
   onClose: () => void;
 }
+
+const TRIGGERS: Array<{ value: EmailAutomationTrigger; label: string }> = [
+  { value: 'on_new_message', label: 'On new message' },
+  { value: 'on_high_urgency', label: 'On high urgency' },
+  { value: 'on_tag_match', label: 'On tag match' },
+];
+
+const CONDITION_FIELDS: Array<{ value: EmailAutomationConditionField; label: string; boolean?: boolean }> = [
+  { value: 'sender', label: 'Sender' },
+  { value: 'domain', label: 'Domain' },
+  { value: 'subject', label: 'Subject' },
+  { value: 'category', label: 'Category' },
+  { value: 'urgency', label: 'Urgency' },
+  { value: 'has_attachment', label: 'Has attachment', boolean: true },
+];
+
+const TEXT_OPS: Array<{ value: EmailAutomationConditionOp; label: string }> = [
+  { value: 'contains', label: 'contains' },
+  { value: 'not_contains', label: "doesn't contain" },
+  { value: 'equals', label: 'equals' },
+  { value: 'not_equals', label: "doesn't equal" },
+];
+
+const BOOL_OPS: Array<{ value: EmailAutomationConditionOp; label: string }> = [
+  { value: 'is_true', label: 'is true' },
+  { value: 'is_false', label: 'is false' },
+];
+
+const ACTIONS: Array<{ value: EmailAutomationActionType; label: string }> = [
+  { value: 'triage', label: 'Triage' },
+  { value: 'generate_variants', label: 'Draft reply variants' },
+  { value: 'mark_read', label: 'Mark read' },
+  { value: 'flag', label: 'Flag' },
+  { value: 'archive', label: 'Archive' },
+  { value: 'move_to_folder', label: 'Move to folder' },
+  { value: 'forward_to', label: 'Forward (draft)' },
+  { value: 'os_notify', label: 'Notify' },
+  { value: 'run_scheduler_job', label: 'Run scheduler job' },
+];
 
 function el<K extends keyof HTMLElementTagNameMap>(
   tag: K,
@@ -28,6 +80,31 @@ function el<K extends keyof HTMLElementTagNameMap>(
   return node;
 }
 
+function option(select: HTMLSelectElement, value: string, label: string): void {
+  const opt = el('option') as HTMLOptionElement;
+  opt.value = value;
+  opt.textContent = label;
+  select.appendChild(opt);
+}
+
+/** Human-readable one-liner for a condition. */
+function conditionText(cond: EmailAutomationCondition): string {
+  const field = CONDITION_FIELDS.find((f) => f.value === cond.field)?.label ?? cond.field;
+  const op = [...TEXT_OPS, ...BOOL_OPS].find((o) => o.value === cond.op)?.label ?? cond.op;
+  return cond.op === 'is_true' || cond.op === 'is_false'
+    ? `${field} ${op}`
+    : `${field} ${op} "${cond.value}"`;
+}
+
+/** Human-readable one-liner for an action. */
+function actionText(action: EmailAutomationAction): string {
+  const label = ACTIONS.find((a) => a.value === action.type)?.label ?? action.type;
+  if (action.type === 'move_to_folder') return `${label} → ${action.folder || '?'}`;
+  if (action.type === 'forward_to') return `${label} → ${action.to || '?'}`;
+  if (action.type === 'run_scheduler_job') return `${label} (${action.jobId || '?'})`;
+  return label;
+}
+
 /**
  * Render automation drawer content.
  */
@@ -37,13 +114,6 @@ export async function renderEmailAutomations(
 ): Promise<void> {
   mount.replaceChildren(el('p', 'email-loading', 'Loading automations…'));
   mount.className = 'email-automations';
-
-  const header = el('div', 'email-automations-head');
-  header.appendChild(el('h3', '', 'Email automations'));
-  const closeBtn = el('button', 'email-btn', 'Close') as HTMLButtonElement;
-  closeBtn.type = 'button';
-  closeBtn.addEventListener('click', options.onClose);
-  header.appendChild(closeBtn);
 
   let rules: EmailAutomation[] = [];
   try {
@@ -56,43 +126,156 @@ export async function renderEmailAutomations(
   }
 
   const accountRules = rules.filter((row) => row.accountId === options.account.id);
+
+  const header = el('div', 'email-automations-head');
+  header.appendChild(el('h3', '', 'Email automations'));
+  const closeBtn = el('button', 'email-btn', 'Close') as HTMLButtonElement;
+  closeBtn.type = 'button';
+  closeBtn.addEventListener('click', options.onClose);
+  header.appendChild(closeBtn);
+
   mount.replaceChildren(header);
 
   const list = el('div', 'email-automations-list');
   if (accountRules.length === 0) {
-    list.appendChild(el('p', 'email-empty', 'No rules yet. Add one to triage or draft on new mail.'));
+    list.appendChild(
+      el('p', 'email-empty', 'No rules yet. Build one below to act on new mail.'),
+    );
   }
 
   for (const rule of accountRules) {
-    const row = el('article', 'email-automation-row');
-    row.appendChild(el('h4', '', rule.name));
-    row.appendChild(el('p', 'email-automation-meta', `${rule.trigger} → ${rule.action}`));
+    list.appendChild(renderRuleRow(mount, options, rule));
+  }
+  mount.appendChild(list);
 
-    const toggle = el('button', 'email-btn', rule.enabled ? 'Disable' : 'Enable') as HTMLButtonElement;
-    toggle.type = 'button';
-    toggle.addEventListener('click', async () => {
+  mount.appendChild(renderBuilder(mount, options));
+}
+
+/** One saved rule: summary + enable/runs/delete controls. */
+function renderRuleRow(
+  mount: HTMLElement,
+  options: EmailAutomationsOptions,
+  rule: EmailAutomation,
+): HTMLElement {
+  const row = el('article', 'email-automation-row');
+
+  const title = el('div', 'email-automation-title');
+  const name = el('h4', '', rule.name);
+  title.appendChild(name);
+  if (rule.trusted) {
+    title.appendChild(el('span', 'email-chip email-chip-trusted', 'trusted'));
+  }
+  if (!rule.enabled) {
+    title.appendChild(el('span', 'email-chip', 'disabled'));
+  }
+  row.appendChild(title);
+
+  const triggerLabel = TRIGGERS.find((t) => t.value === rule.trigger)?.label ?? rule.trigger;
+  row.appendChild(el('p', 'email-automation-meta', `Trigger: ${triggerLabel}`));
+
+  if (rule.conditions.length > 0) {
+    row.appendChild(
+      el('p', 'email-automation-meta', `When: ${rule.conditions.map(conditionText).join(' AND ')}`),
+    );
+  }
+  row.appendChild(
+    el(
+      'p',
+      'email-automation-meta',
+      `Do: ${rule.actions.map(actionText).join(', ') || '(none)'}`,
+    ),
+  );
+
+  const toggle = el('button', 'email-btn', rule.enabled ? 'Disable' : 'Enable') as HTMLButtonElement;
+  toggle.type = 'button';
+  toggle.addEventListener('click', async () => {
+    try {
       await updateAutomationRule(rule.id, { enabled: !rule.enabled });
       options.onStatus?.('ok', 'Rule updated');
       void renderEmailAutomations(mount, options);
-    });
+    } catch (err) {
+      options.onStatus?.('err', err instanceof Error ? err.message : 'Update failed');
+    }
+  });
 
-    const remove = el('button', 'email-btn email-btn-danger', 'Delete') as HTMLButtonElement;
-    remove.type = 'button';
-    remove.addEventListener('click', async () => {
-      if (!await appConfirm(`Delete rule "${rule.name}"?`)) return;
+  const runsBtn = el('button', 'email-btn', 'Runs') as HTMLButtonElement;
+  runsBtn.type = 'button';
+  runsBtn.addEventListener('click', () => {
+    void renderRuns(mount, options, rule);
+  });
+
+  const remove = el('button', 'email-btn email-btn-danger', 'Delete') as HTMLButtonElement;
+  remove.type = 'button';
+  remove.addEventListener('click', async () => {
+    if (!(await appConfirm(`Delete rule "${rule.name}"?`))) return;
+    try {
       await deleteAutomationRule(rule.id);
       options.onStatus?.('ok', 'Rule deleted');
       void renderEmailAutomations(mount, options);
-    });
+    } catch (err) {
+      options.onStatus?.('err', err instanceof Error ? err.message : 'Delete failed');
+    }
+  });
 
-    const actions = el('div', 'email-actions');
-    actions.appendChild(toggle);
-    actions.appendChild(remove);
-    row.appendChild(actions);
-    list.appendChild(row);
+  const actions = el('div', 'email-actions');
+  actions.appendChild(toggle);
+  actions.appendChild(runsBtn);
+  actions.appendChild(remove);
+  row.appendChild(actions);
+  return row;
+}
+
+/** Per-rule audit log view. */
+async function renderRuns(
+  mount: HTMLElement,
+  options: EmailAutomationsOptions,
+  rule: EmailAutomation,
+): Promise<void> {
+  const header = el('div', 'email-automations-head');
+  header.appendChild(el('h3', '', `Runs — ${rule.name}`));
+  const backBtn = el('button', 'email-btn', 'Back') as HTMLButtonElement;
+  backBtn.type = 'button';
+  backBtn.addEventListener('click', () => {
+    void renderEmailAutomations(mount, options);
+  });
+  header.appendChild(backBtn);
+  mount.replaceChildren(header);
+
+  let runs: EmailAutomationRun[] = [];
+  try {
+    runs = await fetchAutomationRuns(rule.id);
+  } catch (err) {
+    mount.appendChild(
+      el('p', 'email-empty is-err', err instanceof Error ? err.message : 'Load failed'),
+    );
+    return;
   }
 
-  mount.appendChild(list);
+  if (runs.length === 0) {
+    mount.appendChild(el('p', 'email-empty', 'No runs recorded yet.'));
+    return;
+  }
+
+  const table = el('div', 'email-automation-runs');
+  for (const run of runs) {
+    const item = el('div', 'email-automation-run');
+    const line = el('div', 'email-automation-run-line');
+    line.appendChild(el('span', 'email-automation-run-action', run.action));
+    line.appendChild(
+      el('span', `email-chip email-run-outcome outcome-${run.outcome}`, run.outcome),
+    );
+    item.appendChild(line);
+    const when = run.ranAt ? new Date(run.ranAt).toLocaleString() : '';
+    item.appendChild(el('p', 'email-automation-meta', [when, run.detail].filter(Boolean).join(' · ')));
+    table.appendChild(item);
+  }
+  mount.appendChild(table);
+}
+
+/** The new-rule builder form. */
+function renderBuilder(mount: HTMLElement, options: EmailAutomationsOptions): HTMLElement {
+  const conditions: EmailAutomationCondition[] = [];
+  const actions: EmailAutomationAction[] = [{ type: 'triage' }];
 
   const form = el('form', 'email-automation-form');
   form.appendChild(el('h4', '', 'New rule'));
@@ -103,23 +286,96 @@ export async function renderEmailAutomations(
   nameInput.required = true;
   form.appendChild(nameInput);
 
+  // Trigger
+  const triggerRow = el('label', 'email-automation-field');
+  triggerRow.appendChild(el('span', 'email-automation-label', 'Trigger'));
   const triggerSelect = el('select', 'email-select') as HTMLSelectElement;
-  for (const value of ['on_new_message', 'on_high_urgency', 'on_tag_match']) {
-    const opt = el('option') as HTMLOptionElement;
-    opt.value = value;
-    opt.textContent = value.replace(/_/g, ' ');
-    triggerSelect.appendChild(opt);
-  }
-  form.appendChild(triggerSelect);
+  for (const t of TRIGGERS) option(triggerSelect, t.value, t.label);
+  triggerRow.appendChild(triggerSelect);
+  form.appendChild(triggerRow);
 
-  const actionSelect = el('select', 'email-select') as HTMLSelectElement;
-  for (const value of ['triage', 'generate_variants', 'notify']) {
-    const opt = el('option') as HTMLOptionElement;
-    opt.value = value;
-    opt.textContent = value.replace(/_/g, ' ');
-    actionSelect.appendChild(opt);
-  }
-  form.appendChild(actionSelect);
+  // Tag value shown only for on_tag_match
+  const tagRow = el('label', 'email-automation-field');
+  tagRow.appendChild(el('span', 'email-automation-label', 'Tag'));
+  const tagInput = el('input', 'email-input') as HTMLInputElement;
+  tagInput.placeholder = 'tag to match';
+  tagRow.appendChild(tagInput);
+  tagRow.hidden = true;
+  form.appendChild(tagRow);
+  triggerSelect.addEventListener('change', () => {
+    tagRow.hidden = triggerSelect.value !== 'on_tag_match';
+  });
+
+  // Conditions
+  form.appendChild(el('h5', 'email-automation-subhead', 'Conditions (all must match)'));
+  const condList = el('div', 'email-automation-rows');
+  form.appendChild(condList);
+
+  const addCond = el('button', 'email-btn', '+ Add condition') as HTMLButtonElement;
+  addCond.type = 'button';
+  addCond.addEventListener('click', () => {
+    const cond: EmailAutomationCondition = { field: 'sender', op: 'contains', value: '' };
+    conditions.push(cond);
+    condList.appendChild(buildConditionRow(cond, conditions, condList));
+  });
+  form.appendChild(addCond);
+
+  // Actions
+  form.appendChild(el('h5', 'email-automation-subhead', 'Actions'));
+  const actionList = el('div', 'email-automation-rows');
+  form.appendChild(actionList);
+  actionList.appendChild(buildActionRow(actions[0], actions, actionList));
+
+  const addAction = el('button', 'email-btn', '+ Add action') as HTMLButtonElement;
+  addAction.type = 'button';
+  addAction.addEventListener('click', () => {
+    const action: EmailAutomationAction = { type: 'triage' };
+    actions.push(action);
+    actionList.appendChild(buildActionRow(action, actions, actionList));
+  });
+  form.appendChild(addAction);
+
+  // Trusted
+  const trustedRow = el('label', 'email-automation-check');
+  const trustedInput = el('input') as HTMLInputElement;
+  trustedInput.type = 'checkbox';
+  trustedRow.appendChild(trustedInput);
+  trustedRow.appendChild(
+    el(
+      'span',
+      '',
+      'Trusted — apply mail-op actions directly (otherwise they wait in the review queue). Forwards are always drafted, never sent.',
+    ),
+  );
+  form.appendChild(trustedRow);
+
+  const collectRule = () => ({
+    name: nameInput.value.trim(),
+    accountId: options.account.id,
+    trigger: triggerSelect.value as EmailAutomationTrigger,
+    conditions,
+    actions,
+    trusted: trustedInput.checked,
+    config: triggerSelect.value === 'on_tag_match' ? { tag: tagInput.value.trim() } : {},
+  });
+
+  // Dry-run
+  const dryRow = el('div', 'email-automation-dryrun');
+  const dryBtn = el('button', 'email-btn', 'Dry-run (last 7 days)') as HTMLButtonElement;
+  dryBtn.type = 'button';
+  const dryResult = el('span', 'email-automation-dryrun-result', '');
+  dryBtn.addEventListener('click', async () => {
+    dryResult.textContent = 'Checking…';
+    try {
+      const preview = await dryRunAutomation(collectRule(), 7);
+      dryResult.textContent = `Would have matched ${preview.matched} of ${preview.total} messages this week.`;
+    } catch (err) {
+      dryResult.textContent = err instanceof Error ? err.message : 'Dry-run failed';
+    }
+  });
+  dryRow.appendChild(dryBtn);
+  dryRow.appendChild(dryResult);
+  form.appendChild(dryRow);
 
   const submit = el('button', 'email-btn email-btn-primary', 'Add rule') as HTMLButtonElement;
   submit.type = 'submit';
@@ -127,14 +383,12 @@ export async function renderEmailAutomations(
 
   form.addEventListener('submit', async (event) => {
     event.preventDefault();
+    if (actions.length === 0) {
+      options.onStatus?.('err', 'Add at least one action');
+      return;
+    }
     try {
-      await saveAutomation({
-        name: nameInput.value.trim(),
-        accountId: options.account.id,
-        trigger: triggerSelect.value as EmailAutomation['trigger'],
-        action: actionSelect.value as EmailAutomation['action'],
-        enabled: true,
-      });
+      await saveAutomation({ ...collectRule(), enabled: true });
       options.onStatus?.('ok', 'Rule created');
       void renderEmailAutomations(mount, options);
     } catch (err) {
@@ -142,5 +396,143 @@ export async function renderEmailAutomations(
     }
   });
 
-  mount.appendChild(form);
+  return form;
+}
+
+/** One editable condition row bound to `cond`. */
+function buildConditionRow(
+  cond: EmailAutomationCondition,
+  conditions: EmailAutomationCondition[],
+  container: HTMLElement,
+): HTMLElement {
+  const rowEl = el('div', 'email-automation-row-edit');
+
+  const fieldSelect = el('select', 'email-select') as HTMLSelectElement;
+  for (const f of CONDITION_FIELDS) option(fieldSelect, f.value, f.label);
+  fieldSelect.value = cond.field;
+
+  const opSelect = el('select', 'email-select') as HTMLSelectElement;
+  const valueInput = el('input', 'email-input') as HTMLInputElement;
+  valueInput.placeholder = 'value';
+  valueInput.value = cond.value;
+
+  const syncOps = () => {
+    const field = CONDITION_FIELDS.find((f) => f.value === fieldSelect.value);
+    const ops = field?.boolean ? BOOL_OPS : TEXT_OPS;
+    opSelect.replaceChildren();
+    for (const o of ops) option(opSelect, o.value, o.label);
+    if (!ops.some((o) => o.value === cond.op)) {
+      cond.op = ops[0].value;
+    }
+    opSelect.value = cond.op;
+    valueInput.hidden = Boolean(field?.boolean);
+  };
+
+  fieldSelect.addEventListener('change', () => {
+    cond.field = fieldSelect.value as EmailAutomationConditionField;
+    syncOps();
+  });
+  opSelect.addEventListener('change', () => {
+    cond.op = opSelect.value as EmailAutomationConditionOp;
+  });
+  valueInput.addEventListener('input', () => {
+    cond.value = valueInput.value;
+  });
+
+  const remove = el('button', 'email-btn email-btn-icon', '×') as HTMLButtonElement;
+  remove.type = 'button';
+  remove.setAttribute('aria-label', 'Remove condition');
+  remove.addEventListener('click', () => {
+    const idx = conditions.indexOf(cond);
+    if (idx >= 0) conditions.splice(idx, 1);
+    rowEl.remove();
+  });
+
+  syncOps();
+  rowEl.appendChild(fieldSelect);
+  rowEl.appendChild(opSelect);
+  rowEl.appendChild(valueInput);
+  rowEl.appendChild(remove);
+  void container;
+  return rowEl;
+}
+
+/** One editable action row bound to `action`. */
+function buildActionRow(
+  action: EmailAutomationAction,
+  actions: EmailAutomationAction[],
+  container: HTMLElement,
+): HTMLElement {
+  const rowEl = el('div', 'email-automation-row-edit');
+
+  const typeSelect = el('select', 'email-select') as HTMLSelectElement;
+  for (const a of ACTIONS) option(typeSelect, a.value, a.label);
+  typeSelect.value = action.type;
+
+  const paramInput = el('input', 'email-input') as HTMLInputElement;
+
+  const syncParam = () => {
+    switch (action.type) {
+      case 'move_to_folder':
+        paramInput.hidden = false;
+        paramInput.placeholder = 'folder name';
+        paramInput.value = action.folder ?? '';
+        break;
+      case 'forward_to':
+        paramInput.hidden = false;
+        paramInput.placeholder = 'forward to (email)';
+        paramInput.value = action.to ?? '';
+        break;
+      case 'os_notify':
+        paramInput.hidden = false;
+        paramInput.placeholder = 'notification text (optional)';
+        paramInput.value = action.body ?? '';
+        break;
+      case 'run_scheduler_job':
+        paramInput.hidden = false;
+        paramInput.placeholder = 'scheduler job id';
+        paramInput.value = action.jobId ?? '';
+        break;
+      default:
+        paramInput.hidden = true;
+        paramInput.value = '';
+    }
+  };
+
+  const writeParam = () => {
+    const v = paramInput.value.trim();
+    if (action.type === 'move_to_folder') action.folder = v;
+    else if (action.type === 'forward_to') action.to = v;
+    else if (action.type === 'os_notify') action.body = v;
+    else if (action.type === 'run_scheduler_job') action.jobId = v;
+  };
+
+  typeSelect.addEventListener('change', () => {
+    // Reset params when the type changes so a stale folder/email can't leak.
+    delete action.folder;
+    delete action.to;
+    delete action.body;
+    delete action.title;
+    delete action.jobId;
+    action.type = typeSelect.value as EmailAutomationActionType;
+    syncParam();
+  });
+  paramInput.addEventListener('input', writeParam);
+
+  const remove = el('button', 'email-btn email-btn-icon', '×') as HTMLButtonElement;
+  remove.type = 'button';
+  remove.setAttribute('aria-label', 'Remove action');
+  remove.addEventListener('click', () => {
+    if (actions.length <= 1) return;
+    const idx = actions.indexOf(action);
+    if (idx >= 0) actions.splice(idx, 1);
+    rowEl.remove();
+  });
+
+  syncParam();
+  rowEl.appendChild(typeSelect);
+  rowEl.appendChild(paramInput);
+  rowEl.appendChild(remove);
+  void container;
+  return rowEl;
 }

--- a/test/email/phase5-automations.test.mjs
+++ b/test/email/phase5-automations.test.mjs
@@ -1,0 +1,366 @@
+/**
+ * Phase 5 Automations v2 (MIN-356) — store-backed behavior with no network
+ * and no LLM: rule normalization, condition matching, dry-run, the audit log,
+ * and the action router's routing decisions (review queue vs direct, forward
+ * always drafts, os_notify reaches the scheduler queue).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, beforeEach, describe, test } from 'node:test';
+
+import { closeMailDbs, getMailDb } from '../../server/email/store.js';
+import {
+  createAutomation,
+  deleteAutomationsForAccount,
+  dryRunAutomation,
+  evaluateAutomationsForMessage,
+  listAutomationRuns,
+  matchCondition,
+  matchesConditions,
+  normalizeRule,
+  recordAutomationRun,
+  triggerMatches,
+} from '../../server/email/automations.js';
+import { listPendingActions } from '../../server/email/pending-actions.js';
+import { listUnackedNotifications } from '../../server/scheduler/delivery.js';
+
+const ACCOUNT_ID = 'acct-phase5-test';
+
+let tempHome;
+let savedHome;
+
+before(async () => {
+  savedHome = process.env.MINNOW_HOME;
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'minnow-phase5-'));
+  process.env.MINNOW_HOME = tempHome;
+});
+
+after(async () => {
+  closeMailDbs();
+  if (savedHome === undefined) {
+    delete process.env.MINNOW_HOME;
+  } else {
+    process.env.MINNOW_HOME = savedHome;
+  }
+  await fs.rm(tempHome, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  const db = getMailDb(ACCOUNT_ID);
+  db.exec('DELETE FROM messages; DELETE FROM automation_runs; DELETE FROM pending_actions; DELETE FROM drafts;');
+  await deleteAutomationsForAccount(ACCOUNT_ID);
+});
+
+function insertMessage(overrides = {}) {
+  const db = getMailDb(ACCOUNT_ID);
+  const row = {
+    id: overrides.id ?? `msg-${Math.random().toString(36).slice(2)}`,
+    folder: overrides.folder ?? 'INBOX',
+    uid: overrides.uid ?? String(Math.floor(Math.random() * 1e9)),
+    thread_id: overrides.thread_id ?? '',
+    from_addr: overrides.from_addr ?? 'Ada <ada@example.com>',
+    subject: overrides.subject ?? 'Hello there',
+    date: overrides.date ?? new Date().toISOString(),
+    date_ms: overrides.date_ms ?? Date.now(),
+    has_attachments: overrides.has_attachments ?? 0,
+    triage_json: overrides.triage_json ?? null,
+  };
+  db.prepare(
+    `INSERT INTO messages (id, folder, uid, thread_id, from_addr, subject, date, date_ms, has_attachments, triage_json)
+     VALUES (@id, @folder, @uid, @thread_id, @from_addr, @subject, @date, @date_ms, @has_attachments, @triage_json)`,
+  ).run(row);
+  return row;
+}
+
+describe('normalizeRule', () => {
+  test('migrates a v1 single-action rule to the v2 shape', () => {
+    const rule = normalizeRule({
+      id: 'r1',
+      name: 'Legacy',
+      accountId: ACCOUNT_ID,
+      trigger: 'on_new_message',
+      action: 'triage',
+      config: { tag: 'x' },
+    });
+    assert.deepEqual(rule.actions, [{ type: 'triage' }]);
+    assert.deepEqual(rule.conditions, []);
+    assert.equal(rule.trusted, false);
+  });
+
+  test('maps legacy notify to os_notify and carries its config', () => {
+    const rule = normalizeRule({
+      id: 'r2',
+      name: 'Ping',
+      accountId: ACCOUNT_ID,
+      action: 'notify',
+      config: { title: 'Hi', body: 'Body' },
+    });
+    assert.equal(rule.actions[0].type, 'os_notify');
+    assert.equal(rule.actions[0].title, 'Hi');
+    assert.equal(rule.actions[0].body, 'Body');
+  });
+
+  test('drops unknown conditions and actions', () => {
+    const rule = normalizeRule({
+      id: 'r3',
+      name: 'Mixed',
+      accountId: ACCOUNT_ID,
+      conditions: [
+        { field: 'sender', op: 'contains', value: 'a' },
+        { field: 'bogus', op: 'contains', value: 'x' },
+        { field: 'subject', op: 'nope', value: 'y' },
+      ],
+      actions: [{ type: 'archive' }, { type: 'delete' }, { type: 'nonsense' }],
+    });
+    assert.equal(rule.conditions.length, 1);
+    assert.equal(rule.conditions[0].field, 'sender');
+    assert.deepEqual(rule.actions, [{ type: 'archive' }]);
+  });
+});
+
+describe('matchCondition', () => {
+  const message = {
+    from: 'Ada Lovelace <ada@math.example.com>',
+    subject: 'Invoice #42 due Friday',
+    hasAttachments: true,
+    triage: { category: 'receipt', urgency: 'high' },
+  };
+
+  test('sender contains / not_contains', () => {
+    assert.equal(matchCondition({ field: 'sender', op: 'contains', value: 'ada' }, message), true);
+    assert.equal(matchCondition({ field: 'sender', op: 'not_contains', value: 'bob' }, message), true);
+  });
+
+  test('domain equals', () => {
+    assert.equal(
+      matchCondition({ field: 'domain', op: 'equals', value: 'math.example.com' }, message),
+      true,
+    );
+    assert.equal(matchCondition({ field: 'domain', op: 'equals', value: 'example.com' }, message), false);
+  });
+
+  test('subject contains is case-insensitive', () => {
+    assert.equal(matchCondition({ field: 'subject', op: 'contains', value: 'INVOICE' }, message), true);
+  });
+
+  test('category / urgency equals', () => {
+    assert.equal(matchCondition({ field: 'category', op: 'equals', value: 'receipt' }, message), true);
+    assert.equal(matchCondition({ field: 'urgency', op: 'not_equals', value: 'low' }, message), true);
+  });
+
+  test('has_attachment boolean ops', () => {
+    assert.equal(matchCondition({ field: 'has_attachment', op: 'is_true', value: '' }, message), true);
+    assert.equal(matchCondition({ field: 'has_attachment', op: 'is_false', value: '' }, message), false);
+  });
+
+  test('empty condition list matches everything', () => {
+    assert.equal(matchesConditions([], message), true);
+  });
+
+  test('conditions are AND-combined', () => {
+    assert.equal(
+      matchesConditions(
+        [
+          { field: 'domain', op: 'equals', value: 'math.example.com' },
+          { field: 'urgency', op: 'equals', value: 'high' },
+        ],
+        message,
+      ),
+      true,
+    );
+    assert.equal(
+      matchesConditions(
+        [
+          { field: 'domain', op: 'equals', value: 'math.example.com' },
+          { field: 'urgency', op: 'equals', value: 'low' },
+        ],
+        message,
+      ),
+      false,
+    );
+  });
+});
+
+describe('triggerMatches', () => {
+  const base = { enabled: true, accountId: ACCOUNT_ID, trigger: 'on_new_message', config: {} };
+
+  test('on_high_urgency needs high triage', () => {
+    const rule = { ...base, trigger: 'on_high_urgency' };
+    assert.equal(triggerMatches(rule, { accountId: ACCOUNT_ID, triage: { urgency: 'high' } }), true);
+    assert.equal(triggerMatches(rule, { accountId: ACCOUNT_ID, triage: { urgency: 'low' } }), false);
+  });
+
+  test('disabled rule never fires', () => {
+    assert.equal(triggerMatches({ ...base, enabled: false }, { accountId: ACCOUNT_ID }), false);
+  });
+});
+
+describe('dryRunAutomation', () => {
+  test('counts messages the rule would match this week', async () => {
+    insertMessage({ from_addr: 'a@acme.com', subject: 'Q1 report' });
+    insertMessage({ from_addr: 'b@acme.com', subject: 'Q2 report' });
+    insertMessage({ from_addr: 'c@other.com', subject: 'Spam' });
+    // Old message outside the window should not count.
+    insertMessage({ from_addr: 'd@acme.com', date_ms: Date.now() - 40 * 86_400_000 });
+
+    const preview = await dryRunAutomation(
+      ACCOUNT_ID,
+      {
+        accountId: ACCOUNT_ID,
+        trigger: 'on_new_message',
+        conditions: [{ field: 'domain', op: 'equals', value: 'acme.com' }],
+        actions: [{ type: 'archive' }],
+      },
+      { days: 7 },
+    );
+
+    assert.equal(preview.total, 3);
+    assert.equal(preview.matched, 2);
+    assert.equal(preview.sample.length, 2);
+  });
+});
+
+describe('audit log', () => {
+  test('records and lists runs newest first', async () => {
+    const db = getMailDb(ACCOUNT_ID);
+    recordAutomationRun(db, { ruleId: 'ruleX', action: 'archive', outcome: 'queued' });
+    recordAutomationRun(db, { ruleId: 'ruleX', action: 'os_notify', outcome: 'notified' });
+    recordAutomationRun(db, { ruleId: 'ruleY', action: 'flag', outcome: 'applied' });
+
+    const runs = await listAutomationRuns(ACCOUNT_ID, 'ruleX');
+    assert.equal(runs.length, 2);
+    assert.equal(runs[0].action, 'os_notify');
+    assert.equal(runs[1].action, 'archive');
+  });
+});
+
+describe('evaluateAutomationsForMessage', () => {
+  test('untrusted mail-op routes to the review queue and records queued', async () => {
+    const rule = await createAutomation({
+      name: 'Archive acme',
+      accountId: ACCOUNT_ID,
+      trigger: 'on_new_message',
+      conditions: [{ field: 'domain', op: 'equals', value: 'acme.com' }],
+      actions: [{ type: 'archive' }],
+    });
+
+    await evaluateAutomationsForMessage(ACCOUNT_ID, {
+      id: 'm1',
+      messageRowId: 1,
+      folder: 'INBOX',
+      from: 'sales@acme.com',
+      subject: 'Deal',
+    });
+
+    const pending = await listPendingActions(ACCOUNT_ID);
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].action, 'archive');
+    assert.equal(pending[0].source, `automation:${rule.id}`);
+
+    const runs = await listAutomationRuns(ACCOUNT_ID, rule.id);
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].outcome, 'queued');
+  });
+
+  test('trusted mail-op skips the review queue (direct path)', async () => {
+    const rule = await createAutomation({
+      name: 'Trusted archive',
+      accountId: ACCOUNT_ID,
+      trigger: 'on_new_message',
+      trusted: true,
+      actions: [{ type: 'archive' }],
+    });
+
+    await evaluateAutomationsForMessage(ACCOUNT_ID, {
+      id: 'm2',
+      messageRowId: 2,
+      folder: 'INBOX',
+      from: 'x@y.com',
+      subject: 'Anything',
+    });
+
+    // No IMAP in tests, so the direct apply fails — but crucially it never
+    // enqueued a review item, proving the trusted path took the direct branch.
+    const pending = await listPendingActions(ACCOUNT_ID);
+    assert.equal(pending.length, 0);
+    const runs = await listAutomationRuns(ACCOUNT_ID, rule.id);
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].action, 'archive');
+  });
+
+  test('forward_to writes a draft and never sends', async () => {
+    const rule = await createAutomation({
+      name: 'Forward to boss',
+      accountId: ACCOUNT_ID,
+      trigger: 'on_new_message',
+      actions: [{ type: 'forward_to', to: 'boss@example.com' }],
+    });
+
+    await evaluateAutomationsForMessage(ACCOUNT_ID, {
+      id: 'm3',
+      messageRowId: 3,
+      folder: 'INBOX',
+      from: 'client@example.com',
+      subject: 'Proposal',
+      bodyPreview: 'Please review.',
+    });
+
+    const db = getMailDb(ACCOUNT_ID);
+    const drafts = db.prepare('SELECT * FROM drafts').all();
+    assert.equal(drafts.length, 1);
+    assert.equal(drafts[0].to_addr, 'boss@example.com');
+    assert.match(drafts[0].subject, /^Fwd:/);
+
+    const runs = await listAutomationRuns(ACCOUNT_ID, rule.id);
+    assert.equal(runs[0].outcome, 'drafted');
+  });
+
+  test('os_notify reaches the scheduler notification queue', async () => {
+    const rule = await createAutomation({
+      name: 'Ping me',
+      accountId: ACCOUNT_ID,
+      trigger: 'on_new_message',
+      actions: [{ type: 'os_notify', title: 'New mail', body: 'You got mail' }],
+    });
+
+    const before = (await listUnackedNotifications()).length;
+    await evaluateAutomationsForMessage(ACCOUNT_ID, {
+      id: 'm4',
+      messageRowId: 4,
+      folder: 'INBOX',
+      from: 'a@b.com',
+      subject: 'Hi',
+    });
+
+    const notifications = await listUnackedNotifications();
+    assert.equal(notifications.length, before + 1);
+    assert.ok(notifications.some((n) => n.jobId.startsWith(`email-automation:${rule.id}`)));
+
+    const runs = await listAutomationRuns(ACCOUNT_ID, rule.id);
+    assert.equal(runs[0].outcome, 'notified');
+  });
+
+  test('conditions gate the actions', async () => {
+    const rule = await createAutomation({
+      name: 'Only acme',
+      accountId: ACCOUNT_ID,
+      trigger: 'on_new_message',
+      conditions: [{ field: 'domain', op: 'equals', value: 'acme.com' }],
+      actions: [{ type: 'os_notify' }],
+    });
+
+    await evaluateAutomationsForMessage(ACCOUNT_ID, {
+      id: 'm5',
+      messageRowId: 5,
+      folder: 'INBOX',
+      from: 'nope@other.com',
+      subject: 'Skip me',
+    });
+
+    const runs = await listAutomationRuns(ACCOUNT_ID, rule.id);
+    assert.equal(runs.length, 0);
+  });
+});


### PR DESCRIPTION
## Overview

Phase 5 of the email world-class spec (MIN-356). Rewrites the automations engine from a name + two-dropdown form into a real rule builder, and fixes the dead-end `notify` action (D9). Follows Phase 4 (#648).

## What changed

**Rule engine** (`server/email/automations.js`)
- New schema: `{ trigger, conditions: [{field, op, value}], actions: [...], trusted }`.
- `normalizeRule` migrates v1 rules on read **and** write (bare `action` + `config`; `notify` → `os_notify`), so existing `automations.json` files keep working.
- Conditions AND-combine over `sender` / `domain` / `subject` / `category` / `urgency` (text ops) + a boolean `has_attachment`; empty list matches everything; matching is case-insensitive and pure.
- Actions: `triage`, `generate_variants`, `mark_read`, `flag`, `archive`, `move_to_folder`, `forward_to`, `os_notify`, `run_scheduler_job`.
- **Audit log**: every action execution writes an `automation_runs` row (rule, message, action, outcome, detail).

**Routes** (`server/email/middleware.js`)
- `POST /api/email/automations/dry-run` — "matched M of N messages this week" against the store (no actions run).
- `GET /api/email/automations/:id/runs` — the audit log for a rule (account resolved from the rule itself).

**UI** (`src/ui/email/email-automations.ts`, `client.ts`, `client-ext.ts`, `email.css`)
- Full builder: add/remove condition and action rows, contextual param inputs, trusted checkbox, a dry-run button, and a per-rule Runs view. v2 types + `fetchAutomationRuns` / `dryRunAutomation` client calls.

## Guardrails (deliberate, safety-critical)

- **Automations never send mail.** `forward_to` writes a forward *draft* for the user to send by hand — never SMTP, **even for a trusted rule**. Part 7's no-auto-send is absolute, so the spec's "trusted forward auto-sends" was intentionally not implemented; the draft *is* the confirm-queue.
- **`trusted` only affects mail-op routing** (mark_read/flag/archive/move): default routes through the Phase 4 review queue (`enqueuePendingAction`, source `automation:<ruleId>`); trusted applies directly via `bulkMessageAction`. It does not affect forward/notify/triage.
- **`delete` is not an automation action.**
- `os_notify` fixes the old dead-end `notify` (unused SSE): now enqueues a real scheduler notification (same OS-notify path follow-ups use) and still emits the in-app `automation_notify` SSE.

## Testing

- New `test/email/phase5-automations.test.mjs` (19 tests, no LLM/IMAP): normalize/migrate, condition matching, dry-run counting, audit log ordering, and the action router's routing decisions — review-queue vs trusted-direct, forward-drafts-never-sends, os_notify reaches the scheduler queue, conditions gate actions.
- **220/220 email tests pass** (`npm run test:email`); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
