### PR TITLE
MIN-358 — Email IA rethink: spine rail + single-stream inbox (Direction A)

### DIFF
--- a/src/styles/email.css
+++ b/src/styles/email.css
@@ -3125,3 +3125,697 @@
     color: var(--mn-accent);
   }
 }
+
+/* ===========================================================================
+   Direction A — "One Stream" shell (MIN-358 IA rethink)
+
+   One navigation spine on the left, one workspace on the right. The old top
+   tabs and the three-pane folder rail both collapse into `.email-rail`; the
+   Dashboard and Mail surfaces merge into one `.email-stream`. Reader docks
+   in from the right rather than living as a permanent third pane.
+   =========================================================================== */
+
+.email-shell-a {
+  flex-direction: row;
+  gap: 0;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ---- The spine rail ---------------------------------------------------- */
+.email-rail {
+  flex: 0 0 244px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 0;
+  padding: 16px 12px 14px;
+  border-right: 1px solid var(--mn-border);
+  background: var(--mn-surface-0, color-mix(in oklch, var(--mn-fg) 2%, var(--mn-bg)));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.email-rail-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 4px;
+}
+
+.email-rail-mark {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  background: var(--mn-accent);
+  color: var(--mn-fg-on-accent, #0b1410);
+  font-weight: 700;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.email-rail-word {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* Account switcher — a real button that opens the account menu. The colour
+   dots mirror the unified-inbox legend so a mailbox reads the same here. */
+.email-rail-account {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-md, 10px);
+  background: var(--mn-bg);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s var(--ease-out, ease-out);
+}
+
+.email-rail-account:focus-visible {
+  outline: 2px solid var(--mn-accent);
+  outline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .email-rail-account:hover {
+    border-color: var(--mn-border-strong, var(--mn-border));
+  }
+}
+
+.email-rail-account-dots {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.email-rail-account-text {
+  min-width: 0;
+}
+
+.email-rail-account-name {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.email-rail-account-hint {
+  display: block;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  color: var(--mn-fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.email-rail-account-caret {
+  color: var(--mn-fg-subtle);
+  flex-shrink: 0;
+}
+
+.email-rail-account-caret .icon-svg,
+.email-rail-account-caret .email-icon {
+  width: 14px;
+  height: 14px;
+}
+
+/* The account menu (accounts + "All inboxes") — a popover, not a native select,
+   so the dots render inside it. */
+.email-rail-account-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin: -8px 0 0;
+  padding: 5px;
+  border: 1px solid var(--mn-border-strong, var(--mn-border));
+  border-radius: var(--radius-md, 10px);
+  background: var(--mn-surface-1, var(--mn-bg));
+  box-shadow: var(--mn-shadow, 0 8px 24px rgba(0, 0, 0, 0.35));
+  animation: email-pop-in 0.14s var(--ease-out-quart, cubic-bezier(0.25, 1, 0.5, 1));
+}
+
+.email-rail-account-menu[hidden] {
+  display: none;
+}
+
+.email-rail-account-opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 9px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.email-rail-account-opt .email-account-dot {
+  flex-shrink: 0;
+}
+
+.email-rail-account-opt.is-active {
+  background: var(--mn-accent-soft, color-mix(in srgb, var(--mn-accent) 14%, transparent));
+  color: var(--mn-fg);
+  font-weight: 600;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .email-rail-account-opt:hover {
+    background: var(--mn-surface-elevated, color-mix(in oklch, var(--mn-fg) 8%, transparent));
+  }
+}
+
+@keyframes email-pop-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Compose — the one accent-filled action in the rail. */
+.email-rail-compose {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 40px;
+  padding: 0 14px;
+  border: 1px solid var(--mn-accent);
+  border-radius: var(--radius-md, 10px);
+  background: var(--mn-accent);
+  color: var(--mn-fg-on-accent, #0b1410);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s var(--ease-out, ease-out);
+}
+
+.email-rail-compose .icon-svg,
+.email-rail-compose .email-icon {
+  width: 16px;
+  height: 16px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .email-rail-compose:hover {
+    filter: brightness(1.06);
+  }
+}
+
+.email-rail-compose:focus-visible {
+  outline: 2px solid var(--mn-accent);
+  outline-offset: 2px;
+}
+
+/* Navigation groups: Views, then Folders. */
+.email-rail-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.email-rail-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.email-rail-group-label {
+  margin: 0 0 4px;
+  padding: 0 8px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mn-fg-subtle, var(--mn-fg-muted));
+}
+
+.email-rail-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 7px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--mn-fg-muted);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.14s var(--ease-out, ease-out),
+    color 0.14s var(--ease-out, ease-out);
+}
+
+.email-rail-item-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* A leading tick carries the view's tone (danger for "Needs attention"). */
+.email-rail-item-tick {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--mn-fg-subtle, var(--mn-fg-muted));
+}
+
+.email-rail-item-tick.is-attn { background: var(--mn-danger, #e07a6f); }
+.email-rail-item-tick.is-wait { background: var(--mn-warning, #d4a574); }
+
+.email-rail-item-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--mn-fg-subtle, var(--mn-fg-muted));
+}
+
+.email-rail-item-icon .icon-svg,
+.email-rail-item-icon .email-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.email-rail-item-count {
+  margin-left: auto;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--mn-fg-subtle, var(--mn-fg-muted));
+  flex-shrink: 0;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .email-rail-item:hover {
+    background: var(--mn-surface-elevated, color-mix(in oklch, var(--mn-fg) 5%, transparent));
+    color: var(--mn-fg);
+  }
+}
+
+.email-rail-item.is-active {
+  background: var(--mn-accent-soft, color-mix(in srgb, var(--mn-accent) 14%, transparent));
+  color: var(--mn-fg);
+  font-weight: 600;
+}
+
+.email-rail-item.is-active .email-rail-item-count {
+  color: var(--mn-accent);
+}
+
+.email-rail-item.is-active .email-rail-item-icon {
+  color: var(--mn-accent);
+}
+
+.email-rail-item:focus-visible {
+  outline: 2px solid var(--mn-accent);
+  outline-offset: 1px;
+}
+
+.email-rail-foot {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 12px;
+  border-top: 1px solid var(--mn-border);
+}
+
+/* ---- The workspace ----------------------------------------------------- */
+.email-workspace {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.email-surface {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Scroll wrapper for the non-stream surfaces (Automations, account settings)
+   so they scroll inside the workspace rather than pushing the shell. */
+.email-surface-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 22px 24px;
+}
+
+/* ---- The single stream ------------------------------------------------- */
+.email-stream {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.email-stream-col {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 22px 28px 48px;
+}
+
+@media (max-width: 720px) {
+  .email-stream-col { padding: 16px 16px 40px; }
+}
+
+/* The quiet mono readout that replaces the boxed 4-cell KPI strip. */
+.email-readout {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--mn-border);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  color: var(--mn-fg-muted);
+}
+
+.email-readout-metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.email-readout-metric b {
+  font-size: 14px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--mn-fg);
+}
+
+.email-readout-metric.is-attn b { color: var(--mn-danger, #e07a6f); }
+.email-readout-metric.is-wait b { color: var(--mn-fg); }
+.email-readout-metric.is-unread b { color: var(--mn-warning, #d4a574); }
+
+.email-readout-synced {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--mn-fg-subtle, var(--mn-fg-muted));
+}
+
+.email-readout-synced::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--mn-accent);
+}
+
+/* The agent's read of the inbox. Narrative gets a hair more presence. */
+.email-stream-brief {
+  margin: 0;
+  padding: 18px 0 20px;
+  max-width: 68ch;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--mn-fg);
+  border-bottom: 1px solid var(--mn-border);
+}
+
+.email-stream-brief.is-narrative {
+  color: var(--mn-fg);
+}
+
+/* Section markers inside the stream ("Needs attention", "Everything else"). */
+.email-stream-marker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 22px 0 6px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mn-fg-muted);
+}
+
+.email-stream-marker::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--mn-border);
+}
+
+/* A slim toolbar tucked beside the "Everything else" marker. */
+.email-stream-marker .email-stream-tools {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+/* Raw conversation rows — purpose-built for the stream, reusing the list's
+   inner text classes so type and colour stay consistent with the reader. */
+.email-stream-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.email-stream-row {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) auto;
+  gap: 11px;
+  align-items: center;
+  width: 100%;
+  padding: 11px 6px;
+  border: none;
+  border-bottom: 1px solid var(--mn-border);
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.email-stream-row:last-child {
+  border-bottom: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .email-stream-row:hover {
+    background: var(--mn-surface-elevated, color-mix(in oklch, var(--mn-fg) 4%, transparent));
+  }
+}
+
+.email-stream-row.is-selected {
+  background: var(--mn-accent-soft, color-mix(in srgb, var(--mn-accent) 8%, transparent));
+}
+
+.email-stream-row-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.email-stream-row-from {
+  font-size: 12px;
+  color: var(--mn-fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.email-stream-row.is-unread .email-stream-row-from,
+.email-stream-row.is-unread .email-stream-row-subject {
+  color: var(--mn-fg);
+  font-weight: 600;
+}
+
+.email-stream-row-subject {
+  font-size: 13.5px;
+  color: var(--mn-fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.email-stream-row-snippet {
+  font-weight: 400;
+  color: var(--mn-fg-subtle, var(--mn-fg-muted));
+}
+
+.email-stream-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.email-stream-row-date {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--mn-fg-subtle, var(--mn-fg-muted));
+  white-space: nowrap;
+}
+
+.email-stream-row-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--mn-accent);
+  flex-shrink: 0;
+}
+
+.email-stream-row-attach {
+  color: var(--mn-fg-subtle, var(--mn-fg-muted));
+  display: inline-flex;
+}
+
+.email-stream-row-attach .icon-svg,
+.email-stream-row-attach .email-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.email-stream-empty,
+.email-stream-loading {
+  padding: 28px 4px;
+  color: var(--mn-fg-muted);
+  font-size: 13px;
+}
+
+.email-stream-more {
+  display: flex;
+  justify-content: center;
+  padding: 16px 0 4px;
+}
+
+/* Slim search/sync controls beside the "Everything else" marker. */
+.email-stream-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--mn-bg);
+}
+
+.email-stream-search .icon-svg,
+.email-stream-search .email-icon {
+  width: 13px;
+  height: 13px;
+  color: var(--mn-fg-muted);
+  flex-shrink: 0;
+}
+
+.email-stream-search input {
+  border: none;
+  background: transparent;
+  color: var(--mn-fg);
+  font: inherit;
+  font-size: 12px;
+  padding: 3px 0;
+  width: 130px;
+  min-width: 0;
+}
+
+.email-stream-search input:focus {
+  outline: none;
+}
+
+/* The reader dock's own header/actions reuse .email-reader-* from the mail
+   client; only the dock chrome differs. */
+.email-reader-dock .email-reader-head {
+  padding-right: 40px;
+}
+
+/* ---- The reader dock --------------------------------------------------- */
+.email-reader-dock {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(600px, 88%);
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--mn-border-strong, var(--mn-border));
+  background: var(--mn-bg);
+  box-shadow: -18px 0 40px -24px rgba(0, 0, 0, 0.55);
+  transform: translateX(100%);
+  transition: transform 0.28s var(--ease-out-quart, cubic-bezier(0.25, 1, 0.5, 1));
+  z-index: 3;
+  overflow: hidden;
+}
+
+.email-surface.has-reader .email-reader-dock {
+  transform: translateX(0);
+}
+
+/* A dim scrim over the stream while the dock is open, so focus lands on the
+   reader without the stream disappearing. */
+.email-reader-scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background: var(--mn-overlay, rgba(0, 0, 0, 0.35));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.24s var(--ease-out, ease-out);
+}
+
+.email-surface.has-reader .email-reader-scrim {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.email-reader-dock-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 22px 28px;
+}
+
+.email-reader-dock-close {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  z-index: 1;
+}
+
+@media (max-width: 640px) {
+  .email-reader-dock { width: 100%; }
+  .email-rail { flex-basis: 208px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .email-reader-dock { transition: none; }
+  .email-rail-account-menu { animation: none; }
+}
+

--- a/src/ui/email/email-dashboard.ts
+++ b/src/ui/email/email-dashboard.ts
@@ -484,7 +484,7 @@ function renderPriorityFeedback(
 }
 
 /** One attention-queue row for a triaged highlight thread. */
-function renderHighlightRow(
+export function renderHighlightRow(
   list: HTMLElement,
   highlight: EmailInboxSummary['highlights'][0],
   account: EmailAccount,

--- a/src/ui/email/email-inbox.ts
+++ b/src/ui/email/email-inbox.ts
@@ -1,0 +1,723 @@
+/**
+ * The unified inbox stream (MIN-358 Direction A).
+ *
+ * One surface where the agent's read of the inbox (a quiet instrument readout,
+ * the narrative digest, and the "Needs attention" queue) is the head of the
+ * same column the raw conversation stream flows into. The old Dashboard and
+ * Mail tabs collapse into this. The reader docks in from the right rather than
+ * occupying a permanent third pane.
+ *
+ * It reuses the mail client's proven pieces: `renderHighlightRow` for the
+ * triage queue, `renderBodyWithRemoteControls` for message bodies, and
+ * `mountEmailCompose` for replies — so this is a re-composition of the IA, not
+ * a re-implementation of mail behaviour.
+ */
+
+import type {
+  EmailAccount,
+  EmailFollowup,
+  EmailInboxSummary,
+  EmailMessage,
+  EmailThreadSummary,
+} from '../../email/client';
+import {
+  downloadEmailAttachment,
+  fetchEmailThread,
+  fetchEmailThreads,
+  saveBlobAs,
+  syncEmailFolder,
+} from '../../email/client';
+import {
+  archiveEmailMessage,
+  deleteEmailMessage,
+  fetchInboxSummary,
+  moveEmailMessage,
+  requestThreadSummary,
+  setEmailMessageFlags,
+} from '../../email/client-ext';
+import { mountEmailCompose, type ComposeMode } from './email-compose';
+import { renderHighlightRow, type EmailDashboardOptions } from './email-dashboard';
+import {
+  folderLabel,
+  formatBytes,
+  formatWhen,
+  parseSender,
+  previewKind,
+  renderBodyWithRemoteControls,
+  senderInitials,
+} from './email-layout';
+import { toConversationRow } from './email-conversation-row';
+import { EMAIL_ICONS } from './email-icons';
+import { showActionUndoToast } from './email-undo-toast';
+
+/** What the stream is scoped to, driven by the rail's Views and Folders. */
+export type InboxScope =
+  | { kind: 'triage' }
+  | { kind: 'waiting' }
+  | { kind: 'filter'; filter: 'unread' | 'flagged' | 'snoozed' }
+  | { kind: 'folder'; path: string };
+
+export interface EmailInboxOptions {
+  account: EmailAccount;
+  scope: InboxScope;
+  onStatus?: (state: 'ok' | 'err', message: string) => void;
+  /** Toggle the chrome sync bar (ref-counted by the panel). */
+  onSyncActivity?: (active: boolean) => void;
+  /** Report inbox counts so the rail can badge its Views and Folders. */
+  onCounts?: (counts: Record<string, number | undefined>) => void;
+  /** Open a fresh "new message" compose in the dock on first render. */
+  openComposeNew?: boolean;
+  /** Open straight into a thread (e.g. from a digest deep-link). */
+  initialThreadId?: string;
+}
+
+const PAGE = 40;
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function iconBtn(svg: string, label: string, className = 'email-icon-btn'): HTMLButtonElement {
+  const btn = el('button', className) as HTMLButtonElement;
+  btn.type = 'button';
+  btn.title = label;
+  btn.setAttribute('aria-label', label);
+  btn.innerHTML = svg;
+  return btn;
+}
+
+/** IMAP folder the scope reads from; INBOX for the agent Views. */
+function scopeFolder(scope: InboxScope): string {
+  return scope.kind === 'folder' ? scope.path : 'INBOX';
+}
+
+/** Server-side filter for the scope, if any. */
+function scopeFilter(scope: InboxScope): 'unread' | 'flagged' | 'snoozed' | undefined {
+  return scope.kind === 'filter' ? scope.filter : undefined;
+}
+
+/** Only the default triage view leads with the agent's read of the inbox. */
+function scopeShowsHead(scope: InboxScope): boolean {
+  return scope.kind === 'triage';
+}
+
+/** Human title for the current scope, shown as the "everything else" marker. */
+function scopeMarker(scope: InboxScope): string {
+  switch (scope.kind) {
+    case 'triage':
+      return 'Everything else';
+    case 'waiting':
+      return 'Waiting on';
+    case 'filter':
+      return scope.filter === 'unread' ? 'Unread' : scope.filter === 'flagged' ? 'Flagged' : 'Snoozed';
+    case 'folder':
+      return folderLabel(scope.path);
+  }
+}
+
+export async function renderEmailInbox(mount: HTMLElement, options: EmailInboxOptions): Promise<void> {
+  const surface = mount;
+  const { account, scope } = options;
+
+  surface.classList.remove('has-reader');
+  surface.replaceChildren();
+
+  const stream = el('div', 'email-stream');
+  const streamCol = el('div', 'email-stream-col');
+  stream.appendChild(streamCol);
+
+  const scrim = el('div', 'email-reader-scrim');
+  const dock = el('div', 'email-reader-dock');
+  dock.setAttribute('role', 'dialog');
+  dock.setAttribute('aria-modal', 'false');
+  dock.setAttribute('aria-label', 'Message');
+
+  surface.append(stream, scrim, dock);
+  scrim.addEventListener('click', () => closeReader());
+
+  // ---- State -----------------------------------------------------------
+  let offset = 0;
+  let search = '';
+  let threads: EmailThreadSummary[] = [];
+  let total = 0;
+  let summary: EmailInboxSummary | null = null;
+  let followups: EmailFollowup[] = [];
+  let selectedThreadId: string | null = null;
+  let composeMode: ComposeMode | null = null;
+
+  const dashOptions: EmailDashboardOptions = {
+    account,
+    onStatus: options.onStatus,
+    onSyncActivity: options.onSyncActivity,
+    onOpenThread: (threadId) => void openThread(threadId),
+    onOpenMail: () => {
+      // Already on the inbox surface; nothing to route to.
+    },
+    onRefresh: () => void reload({ showLoading: false }),
+  };
+
+  // ---- Data ------------------------------------------------------------
+  const reportCounts = (payload: {
+    summary: EmailInboxSummary;
+    unreadByFolder: Record<string, number>;
+    followups: EmailFollowup[];
+  }): void => {
+    const counts: Record<string, number | undefined> = {
+      attn: payload.summary.highlights.length,
+      waiting: payload.followups.length,
+      unread: payload.summary.unread,
+    };
+    for (const [path, n] of Object.entries(payload.unreadByFolder ?? {})) {
+      counts[`folder:${path}`] = n;
+    }
+    options.onCounts?.(counts);
+  };
+
+  const loadData = async (): Promise<void> => {
+    // The summary feeds both the triage head and the rail counts; it is cached
+    // server-side, so fetching it for every scope is cheap.
+    try {
+      const payload = await fetchInboxSummary(account.id);
+      summary = payload.summary;
+      followups = payload.followups ?? [];
+      reportCounts(payload);
+
+      // Cold cache: sync once so triage and the stream have something to show.
+      if (scope.kind === 'triage' && payload.summary.text.includes('Sync to fetch new mail')) {
+        options.onSyncActivity?.(true);
+        try {
+          await syncEmailFolder(account.id, 'INBOX');
+          const fresh = await fetchInboxSummary(account.id);
+          summary = fresh.summary;
+          followups = fresh.followups ?? [];
+          reportCounts(fresh);
+        } catch (err) {
+          options.onStatus?.('err', err instanceof Error ? err.message : 'Inbox sync failed');
+        } finally {
+          options.onSyncActivity?.(false);
+        }
+      }
+    } catch {
+      summary = null;
+    }
+
+    // "Waiting on" is followup-only; it has no conversation stream of its own.
+    if (scope.kind === 'waiting') {
+      threads = [];
+      total = 0;
+      return;
+    }
+
+    const result = await fetchEmailThreads(account.id, {
+      folder: scopeFolder(scope),
+      offset,
+      limit: PAGE,
+      filter: scopeFilter(scope),
+      query: search || undefined,
+    });
+    threads = result.threads;
+    total = result.total;
+  };
+
+  // ---- Stream rendering ------------------------------------------------
+  const renderReadout = (): HTMLElement | null => {
+    if (!summary) return null;
+    const readout = el('div', 'email-readout');
+    readout.setAttribute('role', 'group');
+    readout.setAttribute('aria-label', 'Inbox status');
+
+    const metric = (cls: string, value: number, label: string): void => {
+      const cell = el('span', `email-readout-metric ${cls}`);
+      cell.append(el('b', '', String(value)), document.createTextNode(label));
+      readout.appendChild(cell);
+    };
+    metric('is-attn', summary.highlights.length, ' need you');
+    metric('is-wait', followups.length, ' waiting');
+    metric('is-unread', summary.unread, ' unread');
+
+    const synced = el('span', 'email-readout-synced', relativeTime(summary.generatedAt));
+    readout.appendChild(synced);
+    return readout;
+  };
+
+  const renderStreamRow = (thread: EmailThreadSummary): HTMLElement => {
+    const model = toConversationRow(thread);
+    const row = el('button', 'email-stream-row') as HTMLButtonElement;
+    row.type = 'button';
+    row.classList.toggle('is-unread', model.unread);
+    row.classList.toggle('is-selected', thread.threadId === selectedThreadId);
+
+    row.appendChild(
+      el('span', 'email-list-avatar', senderInitials(thread.participants?.[0] ?? '')),
+    );
+
+    const main = el('div', 'email-stream-row-main');
+    const from = el('span', 'email-stream-row-from');
+    from.textContent = model.participants + (model.countLabel ? `  ${model.countLabel}` : '');
+    main.appendChild(from);
+    const subject = el('span', 'email-stream-row-subject');
+    subject.textContent = model.subject;
+    if (model.snippet) {
+      const snip = el('span', 'email-stream-row-snippet', `  ${model.snippet}`);
+      subject.appendChild(snip);
+    }
+    main.appendChild(subject);
+    row.appendChild(main);
+
+    const meta = el('div', 'email-stream-row-meta');
+    if (model.unread) meta.appendChild(el('span', 'email-stream-row-dot'));
+    if (model.hasAttachments) {
+      const attach = el('span', 'email-stream-row-attach');
+      attach.innerHTML = EMAIL_ICONS.attach;
+      attach.title = 'Has attachments';
+      meta.appendChild(attach);
+    }
+    meta.appendChild(el('span', 'email-stream-row-date', formatWhen(model.date)));
+    row.appendChild(meta);
+
+    row.addEventListener('click', () => void openThread(thread.threadId));
+    return row;
+  };
+
+  const renderStream = (): void => {
+    streamCol.replaceChildren();
+
+    // --- Triage head (default view only) ---
+    if (scopeShowsHead(scope) && summary) {
+      const readout = renderReadout();
+      if (readout) streamCol.appendChild(readout);
+
+      const brief = (summary.text ?? '').trim();
+      if (brief) {
+        streamCol.appendChild(el('p', 'email-stream-brief', brief));
+      }
+
+      if (summary.highlights.length > 0) {
+        const marker = el('div', 'email-stream-marker', 'Needs attention');
+        streamCol.appendChild(marker);
+        const attn = el('div', 'email-dash-rows');
+        for (const highlight of summary.highlights.slice(0, 5)) {
+          renderHighlightRow(attn, highlight, account, dashOptions);
+        }
+        streamCol.appendChild(attn);
+      }
+    }
+
+    // --- Waiting on (followups) ---
+    if (scope.kind === 'waiting') {
+      streamCol.appendChild(buildScopeMarker());
+      streamCol.appendChild(renderFollowups());
+      return;
+    }
+
+    // --- The conversation stream ---
+    streamCol.appendChild(buildScopeMarker());
+
+    const rows = el('div', 'email-stream-rows');
+    if (threads.length === 0) {
+      const empty = el('div', 'email-stream-empty');
+      empty.appendChild(el('p', 'email-empty-title', emptyTitle()));
+      empty.appendChild(el('p', 'email-empty-copy', emptyCopy()));
+      rows.appendChild(empty);
+    } else {
+      for (const thread of threads) rows.appendChild(renderStreamRow(thread));
+    }
+    streamCol.appendChild(rows);
+
+    if (total > offset + PAGE || offset > 0) {
+      const pager = el('div', 'email-stream-more');
+      if (offset > 0) {
+        const prev = el('button', 'email-btn', 'Newer') as HTMLButtonElement;
+        prev.type = 'button';
+        prev.addEventListener('click', () => {
+          offset = Math.max(0, offset - PAGE);
+          void reload({ showLoading: true });
+        });
+        pager.appendChild(prev);
+      }
+      if (total > offset + PAGE) {
+        const next = el('button', 'email-btn', 'Older') as HTMLButtonElement;
+        next.type = 'button';
+        next.addEventListener('click', () => {
+          offset += PAGE;
+          void reload({ showLoading: true });
+        });
+        pager.appendChild(next);
+      }
+      streamCol.appendChild(pager);
+    }
+  };
+
+  const buildScopeMarker = (): HTMLElement => {
+    const marker = el('div', 'email-stream-marker', scopeMarker(scope));
+    // A slim inline search sits with the "everything else" marker.
+    const tools = el('div', 'email-stream-tools');
+    const searchWrap = el('label', 'email-stream-search');
+    searchWrap.innerHTML = EMAIL_ICONS.search;
+    const input = el('input') as HTMLInputElement;
+    input.type = 'search';
+    input.value = search;
+    input.placeholder = 'Search';
+    input.setAttribute('aria-label', 'Search mail');
+    let timer: number | undefined;
+    input.addEventListener('input', () => {
+      if (timer) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        search = input.value.trim();
+        offset = 0;
+        void reload({ showLoading: true, keepFocus: 'search' });
+      }, 300);
+    });
+    searchWrap.appendChild(input);
+    tools.appendChild(searchWrap);
+    marker.appendChild(tools);
+    return marker;
+  };
+
+  const renderFollowups = (): HTMLElement => {
+    const wrap = el('div', 'email-dash-rows');
+    if (followups.length === 0) {
+      const empty = el('div', 'email-stream-empty');
+      empty.appendChild(el('p', 'email-empty-title', 'Nothing outstanding'));
+      empty.appendChild(
+        el('p', 'email-empty-copy', 'Sent mail that expects a reply will show up here.'),
+      );
+      wrap.appendChild(empty);
+      return wrap;
+    }
+    for (const followup of followups) {
+      const row = el('article', 'email-dash-row');
+      const main = el('div', 'email-dash-row-main');
+      const title = el('div', 'email-dash-row-title');
+      title.appendChild(el('span', 'email-dash-row-subject', followup.subject || '(no subject)'));
+      main.appendChild(title);
+      const meta = el('div', 'email-dash-row-meta');
+      meta.appendChild(el('span', 'email-dash-row-from', `to ${followup.to}`));
+      const overdue = new Date(followup.expectedBy).getTime() < Date.now();
+      const when = el(
+        'span',
+        `email-urgency-badge ${overdue ? 'email-urgency-high' : 'email-urgency-normal'}`,
+        overdue ? 'overdue' : `by ${new Date(followup.expectedBy).toLocaleDateString()}`,
+      );
+      meta.appendChild(when);
+      main.appendChild(meta);
+      row.appendChild(main);
+      if (followup.threadId) {
+        const open = el('button', 'email-btn', 'Open') as HTMLButtonElement;
+        open.type = 'button';
+        open.addEventListener('click', () => void openThread(followup.threadId));
+        row.appendChild(open);
+      }
+      wrap.appendChild(row);
+    }
+    return wrap;
+  };
+
+  const emptyTitle = (): string => {
+    if (search) return 'No matches';
+    if (scope.kind === 'filter' && scope.filter === 'unread') return "You're all caught up";
+    return 'Nothing here';
+  };
+  const emptyCopy = (): string => {
+    if (search) return 'No conversations match that search. Try fewer words.';
+    if (scope.kind === 'filter') return 'Nothing matches this view right now.';
+    return 'Sync this mailbox or pick another view.';
+  };
+
+  // ---- Reader dock -----------------------------------------------------
+  const closeReader = (): void => {
+    selectedThreadId = null;
+    composeMode = null;
+    surface.classList.remove('has-reader');
+    // Reflect the cleared selection in the stream rows.
+    for (const row of streamCol.querySelectorAll('.email-stream-row.is-selected')) {
+      row.classList.remove('is-selected');
+    }
+  };
+
+  const openCompose = (mode: ComposeMode, thread: EmailMessage[], selected: EmailMessage): void => {
+    composeMode = mode;
+    const mountEl = dock.querySelector<HTMLElement>('.email-reader-compose-mount');
+    if (!mountEl) return;
+    mountEmailCompose(mountEl, {
+      account,
+      mode,
+      threadId: selected.threadId,
+      messages: thread,
+      selectedMessage: selected,
+      onStatus: options.onStatus,
+      onRefresh: () => void reload({ showLoading: false }),
+      onSent: () => {
+        composeMode = null;
+        closeReader();
+        void reload({ showLoading: false });
+      },
+    });
+    mountEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  };
+
+  const removeOpen = async (
+    message: EmailMessage,
+    action: 'archive' | 'delete',
+    label: string,
+  ): Promise<void> => {
+    const subject = message.subject || 'message';
+    const origin = message.folder;
+    closeReader();
+    const undo = async (): Promise<void> => {
+      await moveEmailMessage(account.id, message.id, origin);
+      await reload({ showLoading: false });
+    };
+    try {
+      await (action === 'archive'
+        ? archiveEmailMessage(account.id, message.id)
+        : deleteEmailMessage(account.id, message.id));
+      showActionUndoToast(`${label} "${subject}"`, { onUndo: undo, onStatus: options.onStatus });
+      await reload({ showLoading: false });
+    } catch (err) {
+      options.onStatus?.('err', err instanceof Error ? err.message : `Couldn't ${action}`);
+    }
+  };
+
+  const openThread = async (threadId: string): Promise<void> => {
+    selectedThreadId = threadId;
+    composeMode = null;
+    // Reflect selection in the stream immediately.
+    for (const row of streamCol.querySelectorAll('.email-stream-row')) {
+      row.classList.remove('is-selected');
+    }
+
+    let thread: EmailMessage[];
+    try {
+      ({ messages: thread } = await fetchEmailThread(account.id, threadId));
+    } catch (err) {
+      options.onStatus?.('err', err instanceof Error ? err.message : 'Could not open the conversation');
+      return;
+    }
+    const selected = thread[thread.length - 1];
+    if (!selected) return;
+
+    if (!selected.flags?.seen) {
+      void setEmailMessageFlags(account.id, selected.id, { seen: true }).then(
+        () => reportCountsAfterSeen(),
+        () => undefined,
+      );
+    }
+
+    dock.replaceChildren();
+    const close = iconBtn(EMAIL_ICONS.back, 'Close', 'email-icon-btn email-reader-dock-close');
+    close.addEventListener('click', () => closeReader());
+    dock.appendChild(close);
+
+    const scrollArea = el('div', 'email-reader-dock-scroll');
+    dock.appendChild(scrollArea);
+
+    // --- Header ---
+    const header = el('header', 'email-reader-head');
+    header.appendChild(el('h2', 'email-reader-subject', selected.subject || '(no subject)'));
+    const sender = parseSender(selected.from);
+    const metaRow = el('div', 'email-reader-meta-row');
+    metaRow.appendChild(el('span', 'email-sender-avatar', senderInitials(selected.from)));
+    const metaText = el('div', 'email-reader-meta-text');
+    metaText.appendChild(el('p', 'email-reader-from', sender.name));
+    if (sender.email) metaText.appendChild(el('p', 'email-reader-email', sender.email));
+    metaText.appendChild(el('p', 'email-reader-date', formatWhen(selected.date)));
+    metaRow.appendChild(metaText);
+    header.appendChild(metaRow);
+
+    const primary = el('div', 'email-reader-primary-actions');
+    const mkPrimary = (icon: string, label: string, mode: ComposeMode, isPrimary = false): void => {
+      const btn = iconBtn(
+        icon,
+        label,
+        `email-btn ${isPrimary ? 'email-btn-primary ' : ''}email-btn-icon`,
+      );
+      btn.appendChild(el('span', 'email-btn-label', label));
+      btn.addEventListener('click', () => openCompose(mode, thread, selected));
+      primary.appendChild(btn);
+    };
+    mkPrimary(EMAIL_ICONS.reply, 'Reply', 'reply', true);
+    mkPrimary(EMAIL_ICONS.replyAll, 'Reply all', 'replyAll');
+    mkPrimary(EMAIL_ICONS.forward, 'Forward', 'forward');
+    header.appendChild(primary);
+
+    const secondary = el('div', 'email-reader-actions');
+    const flagBtn = iconBtn(
+      selected.flags?.flagged ? EMAIL_ICONS.starFilled : EMAIL_ICONS.star,
+      selected.flags?.flagged ? 'Remove flag' : 'Flag',
+    );
+    flagBtn.classList.toggle('is-active', Boolean(selected.flags?.flagged));
+    flagBtn.addEventListener('click', async () => {
+      const next = !selected.flags?.flagged;
+      try {
+        await setEmailMessageFlags(account.id, selected.id, { flagged: next });
+        flagBtn.classList.toggle('is-active', next);
+        flagBtn.innerHTML = next ? EMAIL_ICONS.starFilled : EMAIL_ICONS.star;
+      } catch (err) {
+        options.onStatus?.('err', err instanceof Error ? err.message : 'Flag failed');
+      }
+    });
+    const archiveBtn = iconBtn(EMAIL_ICONS.archive, 'Archive');
+    archiveBtn.addEventListener('click', () => void removeOpen(selected, 'archive', 'Archived'));
+    const deleteBtn = iconBtn(EMAIL_ICONS.trash, 'Delete');
+    deleteBtn.classList.add('email-icon-btn--danger');
+    deleteBtn.addEventListener('click', () => void removeOpen(selected, 'delete', 'Trashed'));
+    secondary.append(flagBtn, archiveBtn, deleteBtn);
+    header.appendChild(secondary);
+    scrollArea.appendChild(header);
+
+    // --- Catch-up on long threads ---
+    if (thread.length > 3 || thread.some((m) => (m.bodyText?.length ?? 0) > 8000)) {
+      const catchup = el('details', 'email-reader-catchup');
+      catchup.open = true;
+      const label = el('summary', 'email-reader-catchup-label', 'Catch up');
+      catchup.appendChild(label);
+      const busy = el('p', 'email-reader-catchup-text', 'Summarizing…');
+      catchup.appendChild(busy);
+      scrollArea.appendChild(catchup);
+      void requestThreadSummary(account.id, threadId)
+        .then(({ eligible, summary: s }) => {
+          if (eligible && s?.text) {
+            catchup.replaceChildren(label, el('p', 'email-reader-catchup-text', s.text));
+          } else {
+            catchup.remove();
+          }
+        })
+        .catch(() => catchup.remove());
+    }
+
+    // --- Bodies ---
+    const bodyStack = el('div', 'email-reader-body-stack');
+    for (const msg of thread) {
+      const block = el('article', 'email-reader-msg');
+      block.appendChild(
+        el('p', 'email-reader-msg-meta', `${msg.from} · ${formatWhen(msg.date)}`),
+      );
+      const downloadable = (msg.attachments ?? []).filter((att) => !att.inline);
+      if (downloadable.length > 0) {
+        const attRow = el('div', 'email-reader-attachments');
+        attRow.appendChild(el('span', 'email-reader-att-label', 'Attachments'));
+        for (const att of downloadable) {
+          const chip = el(
+            'button',
+            'email-reader-att-chip',
+            `${att.filename} (${formatBytes(att.size)})`,
+          ) as HTMLButtonElement;
+          chip.type = 'button';
+          chip.title = previewKind(att.contentType, att.filename)
+            ? `Open ${att.filename}`
+            : `Download ${att.filename}`;
+          chip.addEventListener('click', async () => {
+            chip.disabled = true;
+            try {
+              const { blob, filename } = await downloadEmailAttachment(account.id, msg.id, att.index);
+              saveBlobAs(blob, filename);
+            } catch (err) {
+              options.onStatus?.('err', err instanceof Error ? err.message : 'Download failed');
+            } finally {
+              chip.disabled = false;
+            }
+          });
+          attRow.appendChild(chip);
+        }
+        block.appendChild(attRow);
+      }
+      block.appendChild(renderBodyWithRemoteControls(msg, 'html', account.id, options.onStatus));
+      bodyStack.appendChild(block);
+    }
+    scrollArea.appendChild(bodyStack);
+
+    // --- Compose mount + collapsed affordance ---
+    const composeMount = el('div', 'email-reader-compose-mount');
+    scrollArea.appendChild(composeMount);
+    const collapsed = el(
+      'button',
+      'email-compose-collapsed',
+      'Reply to this conversation…',
+    ) as HTMLButtonElement;
+    collapsed.type = 'button';
+    collapsed.addEventListener('click', () => openCompose('reply', thread, selected));
+    composeMount.appendChild(collapsed);
+
+    surface.classList.add('has-reader');
+  };
+
+  /** After marking a message seen, nudge the rail's unread badge down. */
+  const reportCountsAfterSeen = async (): Promise<void> => {
+    try {
+      const payload = await fetchInboxSummary(account.id);
+      summary = payload.summary;
+      followups = payload.followups ?? [];
+      reportCounts(payload);
+    } catch {
+      // A failed refresh just leaves the badge as it was.
+    }
+  };
+
+  // ---- Reload ----------------------------------------------------------
+  const reload = async (opts?: { showLoading?: boolean; keepFocus?: 'search' }): Promise<void> => {
+    if (opts?.showLoading) {
+      streamCol.replaceChildren(el('p', 'email-stream-loading', 'Loading…'));
+    }
+    try {
+      await loadData();
+      renderStream();
+      if (opts?.keepFocus === 'search') {
+        streamCol.querySelector<HTMLInputElement>('.email-stream-search input')?.focus();
+      }
+    } catch (err) {
+      streamCol.replaceChildren(
+        el('p', 'email-stream-loading', err instanceof Error ? err.message : 'Load failed'),
+      );
+    }
+  };
+
+  // ---- Boot ------------------------------------------------------------
+  streamCol.replaceChildren(el('p', 'email-stream-loading', 'Loading inbox…'));
+  await reload({ showLoading: false });
+
+  if (options.openComposeNew) {
+    dock.replaceChildren();
+    const close = iconBtn(EMAIL_ICONS.back, 'Close', 'email-icon-btn email-reader-dock-close');
+    close.addEventListener('click', () => closeReader());
+    const scrollArea = el('div', 'email-reader-dock-scroll');
+    const header = el('header', 'email-reader-head');
+    header.appendChild(el('h2', 'email-reader-subject', 'New message'));
+    scrollArea.appendChild(header);
+    const composeMount = el('div', 'email-reader-compose-mount');
+    scrollArea.appendChild(composeMount);
+    dock.append(close, scrollArea);
+    mountEmailCompose(composeMount, {
+      account,
+      mode: 'new',
+      onStatus: options.onStatus,
+      onSent: () => {
+        closeReader();
+        void reload({ showLoading: false });
+      },
+    });
+    surface.classList.add('has-reader');
+  } else if (options.initialThreadId) {
+    void openThread(options.initialThreadId);
+  }
+}
+
+/** Short relative label like "2m ago" for the readout's freshness. */
+function relativeTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'just now';
+  const delta = Date.now() - date.getTime();
+  if (delta < 60_000) return 'just now';
+  const minutes = Math.floor(delta / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}

--- a/src/ui/email/email-layout.ts
+++ b/src/ui/email/email-layout.ts
@@ -75,7 +75,7 @@ let imageAllowlist: string[] | null = null;
 const imagesLoadedFor = new Set<string>();
 
 /** Attachments we can show inline rather than only offer as a download. */
-function previewKind(contentType: string, filename: string): "image" | "pdf" | null {
+export function previewKind(contentType: string, filename: string): "image" | "pdf" | null {
   const ct = (contentType || "").toLowerCase();
   if (ct.startsWith("image/") || /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(filename)) return "image";
   if (ct === "application/pdf" || /\.pdf$/i.test(filename)) return "pdf";
@@ -83,7 +83,7 @@ function previewKind(contentType: string, filename: string): "image" | "pdf" | n
 }
 
 /** Attachment sizes, in the units a person reads them in. */
-function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number): string {
   const size = Number(bytes) || 0;
   if (size < 1024) return `${size} B`;
   if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
@@ -144,7 +144,7 @@ function iconBtn(
  * trusted the sender — see `server/email/remote-content.js` for why they are
  * blocked in the first place.
  */
-function renderBodyWithRemoteControls(
+export function renderBodyWithRemoteControls(
   msg: EmailMessage,
   viewMode: EmailBodyViewMode,
   accountId: string,
@@ -260,7 +260,7 @@ function renderBodyWithRemoteControls(
   return wrap;
 }
 
-function formatWhen(iso?: string): string {
+export function formatWhen(iso?: string): string {
   if (!iso) return "—";
 
   const date = new Date(iso);
@@ -306,7 +306,7 @@ function urgencyClass(urgency?: string): string {
 
 /** Parse display name from a From header like "Name <email@x.com>". */
 
-function parseSender(from: string): { name: string; email: string } {
+export function parseSender(from: string): { name: string; email: string } {
   const match = from.match(/^(.+?)\s*<([^>]+)>$/);
 
   if (match) {
@@ -325,7 +325,7 @@ function parseSender(from: string): { name: string; email: string } {
 
 /** Two-letter avatar initials from a sender string. */
 
-function senderInitials(from: string): string {
+export function senderInitials(from: string): string {
   const { name, email } = parseSender(from);
 
   const parts = name.split(/\s+/).filter(Boolean);
@@ -341,7 +341,7 @@ function senderInitials(from: string): string {
 
 /** Human label for common IMAP folder paths. */
 
-function folderLabel(path: string): string {
+export function folderLabel(path: string): string {
   const lower = path.toLowerCase();
 
   if (lower === "inbox") return "Inbox";

--- a/src/ui/email/email-panel.ts
+++ b/src/ui/email/email-panel.ts
@@ -10,17 +10,12 @@ import {
   updateEmailAccount,
   type EmailAccount,
 } from '../../email/client';
-import { subscribeEmailEvents } from '../../email/client-ext';
-import { renderEmailDashboard } from './email-dashboard';
-import { renderEmailLayout } from './email-layout';
+import { fetchEmailFolders, subscribeEmailEvents } from '../../email/client-ext';
 import { renderEmailAutomations } from './email-automations';
-import { EMAIL_ICONS } from './email-icons';
-import {
-  ACCOUNT_DOT_CLASSES,
-  ALL_INBOXES,
-  accountColorIndex,
-  renderUnifiedInbox,
-} from './email-unified';
+import { createEmailRail } from './email-rail';
+import { renderEmailInbox, type InboxScope } from './email-inbox';
+import { folderLabel } from './email-layout';
+import { ALL_INBOXES, renderUnifiedInbox } from './email-unified';
 
 /** Unsubscribe handles for SSE listeners keyed by panel mount element. */
 const panelEventUnsubs = new WeakMap<HTMLElement, () => void>();
@@ -40,15 +35,6 @@ function el<K extends keyof HTMLElementTagNameMap>(
   return node;
 }
 
-/** Human provider label for the active account chip in the chrome header. */
-function accountProviderLabel(account: EmailAccount): string {
-  const host = account.imap.host.toLowerCase();
-  if (host.includes('gmail') || host.includes('google')) return 'Gmail';
-  if (host.includes('outlook') || host.includes('office365')) return 'Outlook';
-  if (host.includes('fastmail')) return 'Fastmail';
-  return account.imap.host;
-}
-
 /**
  * Map an IMAP/connection error to the account-form field worth highlighting.
  *
@@ -66,16 +52,6 @@ function classifyAccountFieldError(message: string): { field: string } | null {
     return { field: 'imapHost' };
   }
   return null;
-}
-
-/** Icon-only chrome control with accessible name. */
-function chromeIconBtn(icon: string, label: string): HTMLButtonElement {
-  const btn = el('button', 'email-chrome-icon-btn') as HTMLButtonElement;
-  btn.type = 'button';
-  btn.title = label;
-  btn.setAttribute('aria-label', label);
-  btn.innerHTML = icon;
-  return btn;
 }
 
 interface AccountFormOptions extends EmailPanelOptions {
@@ -366,9 +342,7 @@ function renderAccountForm(mount: HTMLElement, options: AccountFormOptions): voi
   }
 }
 
-type EmailViewMode = 'dashboard' | 'mail' | 'automations' | 'setup';
-
-/** Main panel entry — dashboard default, mail view, automations. */
+/** Main panel entry — one spine rail, one workspace surface (MIN-358). */
 export async function renderEmailPanel(
   mount: HTMLElement,
   options: EmailPanelOptions = {},
@@ -400,13 +374,18 @@ export async function renderEmailPanel(
   }
 
   let accountFormMode: 'none' | 'add' | 'edit' = 'none';
-  let viewMode: EmailViewMode = 'dashboard';
-  let pendingThreadId: string | undefined;
-
   let activeAccount = accounts.find((row) => row.isDefault) ?? accounts[0];
-
-  /** True when the list is showing every mailbox at once. */
+  /** True when the stream is showing every mailbox at once. */
   let unified = false;
+  /** Which workspace surface is mounted right now. */
+  let surfaceMode: 'inbox' | 'automations' | 'setup' = 'inbox';
+  /** What the inbox stream is scoped to (driven by the rail's Views/Folders). */
+  let scope: InboxScope = { kind: 'triage' };
+  /** The rail nav id that reads as active. */
+  let activeNav = 'attn';
+  /** One-shot intents consumed by the next inbox render. */
+  let pendingComposeNew = false;
+  let pendingThreadId: string | undefined;
 
   /**
    * Status pass-through that also deep-links auth/connection failures to the
@@ -417,24 +396,15 @@ export async function renderEmailPanel(
     options.onStatus?.(state, message);
     if (state !== 'err' || unified || accountFormMode !== 'none') return;
     const hit = classifyAccountFieldError(message);
-    if (hit) openAccountSetup('edit', { highlightField: hit.field, errorMessage: message });
+    if (hit) openSettings({ highlightField: hit.field, errorMessage: message });
   };
 
-  const shell = el('div', 'email-shell email-shell-agent');
-  const chrome = el('header', 'email-chrome');
-  const body = el('div', 'email-body email-body-fill');
-  // The body is the tab panel; -1 lets focus land here on a view switch.
-  body.id = 'email-view-panel';
-  body.setAttribute('role', 'tabpanel');
-  body.tabIndex = -1;
+  // ---- Shell: spine rail + workspace ----------------------------------
+  const shell = el('div', 'email-shell email-shell-a');
+  const workspace = el('div', 'email-workspace');
 
-  // Announces the active view to assistive tech when tabs change.
-  const liveRegion = el('div', 'visually-hidden');
-  liveRegion.setAttribute('aria-live', 'polite');
-
-  // A hairline progress bar under the chrome carries sync state, replacing the
-  // disabled-button-as-status pattern. Ref-counted so overlapping syncs (manual
-  // + background) keep it lit until the last one finishes.
+  // A hairline progress bar above the surface carries sync state, ref-counted
+  // so overlapping syncs (manual + background) keep it lit until the last ends.
   const syncBar = el('div', 'email-sync-bar');
   syncBar.setAttribute('role', 'progressbar');
   syncBar.setAttribute('aria-label', 'Syncing mail');
@@ -447,259 +417,89 @@ export async function renderEmailPanel(
     syncBar.setAttribute('aria-hidden', on ? 'false' : 'true');
   };
 
-  const identity = el('div', 'email-chrome-identity');
-  identity.appendChild(el('p', 'email-chrome-kicker', 'Email'));
+  const surface = el('div', 'email-surface');
+  surface.id = 'email-view-panel';
+  workspace.append(syncBar, surface);
 
-  const accountWrap = el('div', 'email-chrome-account');
-
-  // A colour dot mirrors the per-account dots in the unified list, so a mailbox
-  // reads the same in the chrome as it does in "All inboxes". Only meaningful
-  // once there is more than one mailbox.
-  const accountDots = el('div', 'email-chrome-account-dots');
-  const paintAccountDots = (): void => {
-    accountDots.replaceChildren();
-    if (accounts.length < 2) return;
-    const ids = unified ? accounts.map((row) => row.id) : [activeAccount.id];
-    for (const id of ids) {
-      const dot = el(
-        'span',
-        `email-account-dot ${ACCOUNT_DOT_CLASSES[accountColorIndex(accounts, id)]}`,
-      );
-      dot.title = accounts.find((row) => row.id === id)?.label ?? '';
-      accountDots.appendChild(dot);
-    }
-  };
-
-  const accountSelect = el('select', 'email-chrome-account-select') as HTMLSelectElement;
-  accountSelect.setAttribute('aria-label', 'Active email account');
-
-  // Only offered when there is more than one mailbox to unify.
-  if (accounts.length > 1) {
-    const allOpt = el('option') as HTMLOptionElement;
-    allOpt.value = ALL_INBOXES;
-    allOpt.textContent = 'All inboxes';
-    accountSelect.appendChild(allOpt);
-  }
-
-  for (const account of accounts) {
-    const opt = el('option') as HTMLOptionElement;
-    opt.value = account.id;
-    opt.textContent = account.label;
-    opt.selected = account.id === activeAccount.id;
-    accountSelect.appendChild(opt);
-  }
-  const accountHint = el(
-    'span',
-    'email-chrome-account-hint',
-    `${accountProviderLabel(activeAccount)} · ${activeAccount.username}`,
-  );
-  accountWrap.appendChild(accountDots);
-  accountWrap.appendChild(accountSelect);
-  accountWrap.appendChild(accountHint);
-  identity.appendChild(accountWrap);
-  paintAccountDots();
-
-  const nav = el('nav', 'email-chrome-nav');
-  nav.setAttribute('role', 'tablist');
-  nav.setAttribute('aria-label', 'Email views');
-  const segments = el('div', 'email-chrome-segments');
-
-  const mkViewTab = (mode: EmailViewMode, label: string, icon: string) => {
-    const btn = el('button', 'email-chrome-segment') as HTMLButtonElement;
-    btn.type = 'button';
-    btn.setAttribute('role', 'tab');
-    btn.id = `email-tab-${mode}`;
-    btn.setAttribute('aria-controls', 'email-view-panel');
-    btn.dataset.view = mode;
-    // Roving tabindex: only the active tab is a Tab stop; arrows move within.
-    btn.tabIndex = -1;
-    btn.innerHTML = `${icon}<span class="email-chrome-segment-label">${label}</span>`;
-    return btn;
-  };
-
-  const dashBtn = mkViewTab('dashboard', 'Dashboard', EMAIL_ICONS.dashboard);
-  const mailBtn = mkViewTab('mail', 'Mail', EMAIL_ICONS.mail);
-  const autoBtn = mkViewTab('automations', 'Automations', EMAIL_ICONS.automations);
-  segments.appendChild(dashBtn);
-  segments.appendChild(mailBtn);
-  segments.appendChild(autoBtn);
-  nav.appendChild(segments);
-
-  const utils = el('div', 'email-chrome-utils');
-  const settingsBtn = chromeIconBtn(EMAIL_ICONS.settings, 'Account settings');
-  utils.appendChild(settingsBtn);
-
-  chrome.appendChild(identity);
-  chrome.appendChild(nav);
-  chrome.appendChild(utils);
-
-  shell.appendChild(chrome);
-  shell.appendChild(syncBar);
-  shell.appendChild(body);
-  shell.appendChild(liveRegion);
-  mount.replaceChildren(shell);
-
-  const viewTabs = [dashBtn, mailBtn, autoBtn];
-  const VIEW_LABELS: Record<EmailViewMode, string> = {
-    dashboard: 'Dashboard',
-    mail: 'Mail',
-    automations: 'Automations',
-    setup: 'Account settings',
-  };
-
-  const setActiveTab = (mode: EmailViewMode) => {
-    viewMode = mode;
-    for (const btn of viewTabs) {
-      const active = btn.dataset.view === mode;
-      btn.classList.toggle('is-active', active);
-      btn.setAttribute('aria-selected', active ? 'true' : 'false');
-      btn.tabIndex = active ? 0 : -1;
-    }
-    body.setAttribute('aria-labelledby', `email-tab-${mode}`);
-  };
-
-  setActiveTab(viewMode);
-
-  /** Switch views from a tab: render, then announce so SR users hear it. */
-  const activateTab = (mode: EmailViewMode): void => {
-    setActiveTab(mode);
-    liveRegion.textContent = `${VIEW_LABELS[mode]} view`;
-    void renderView();
-  };
-
-  const renderView = async () => {
-    if (accountFormMode !== 'none') {
-      return;
-    }
-    body.replaceChildren(el('p', 'email-loading', 'Loading…'));
-    if (viewMode === 'dashboard') {
-      await renderEmailDashboard(body, {
-        account: activeAccount,
-        onStatus: handleStatus,
-        onSyncActivity: setSyncing,
-        onRefresh: () => void renderView(),
-        onOpenThread: (threadId) => {
-          pendingThreadId = threadId;
-          setActiveTab('mail');
-          void renderView();
-        },
-        onOpenMail: () => {
-          pendingThreadId = undefined;
-          setActiveTab('mail');
-          void renderView();
-        },
-      });
-      return;
-    }
-    if (viewMode === 'mail') {
-      if (unified) {
-        await renderUnifiedInbox(body, {
-          accounts,
-          onStatus: handleStatus,
-          // Opening a message drops back into that mailbox's full surface,
-          // which is where reply, move and the rest actually live.
-          onOpen: (message) => {
-            const owner = accounts.find((row) => row.id === message.accountId);
-            if (!owner) return;
-            unified = false;
-            activeAccount = owner;
-            accountSelect.value = owner.id;
-            accountHint.textContent = `${accountProviderLabel(owner)} · ${owner.username}`;
-            paintAccountDots();
-            pendingThreadId = message.threadId;
-            void renderView();
-          },
-        });
-        return;
+  const rail = createEmailRail({
+    accounts,
+    activeAccountId: activeAccount.id,
+    unified,
+    onSelectAccount: (id) => {
+      if (id === ALL_INBOXES) {
+        unified = true;
+      } else {
+        const next = accounts.find((row) => row.id === id);
+        if (!next) return;
+        unified = false;
+        activeAccount = next;
       }
-
-      await renderEmailLayout(body, {
-        account: activeAccount,
-        initialThreadId: pendingThreadId,
-        onStatus: handleStatus,
-        onSyncActivity: setSyncing,
-      });
-      pendingThreadId = undefined;
-      return;
-    }
-    if (viewMode === 'automations') {
-      await renderEmailAutomations(body, {
-        account: activeAccount,
-        onStatus: handleStatus,
-        onClose: () => {
-          setActiveTab('dashboard');
-          void renderView();
-        },
-      });
-    }
-  };
-
-  dashBtn.addEventListener('click', () => activateTab('dashboard'));
-  mailBtn.addEventListener('click', () => activateTab('mail'));
-  autoBtn.addEventListener('click', () => activateTab('automations'));
-
-  // Arrow / Home / End move between tabs and activate, per the WAI-ARIA tabs
-  // pattern; focus follows the roving tabindex set in setActiveTab.
-  segments.addEventListener('keydown', (event) => {
-    const current = viewTabs.findIndex((btn) => btn.dataset.view === viewMode);
-    let nextIndex = -1;
-    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-      nextIndex = (current + 1) % viewTabs.length;
-    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
-      nextIndex = (current - 1 + viewTabs.length) % viewTabs.length;
-    } else if (event.key === 'Home') {
-      nextIndex = 0;
-    } else if (event.key === 'End') {
-      nextIndex = viewTabs.length - 1;
-    }
-    if (nextIndex < 0) return;
-    event.preventDefault();
-    const nextBtn = viewTabs[nextIndex];
-    activateTab(nextBtn.dataset.view as EmailViewMode);
-    nextBtn.focus();
+      rail.setAccount(unified ? ALL_INBOXES : activeAccount.id, unified, accounts);
+      surfaceMode = 'inbox';
+      accountFormMode = 'none';
+      void loadFolders();
+      renderSurface();
+    },
+    onCompose: () => {
+      unified = false;
+      surfaceMode = 'inbox';
+      accountFormMode = 'none';
+      pendingComposeNew = true;
+      renderSurface();
+    },
+    onSelectNav: (navId) => applyNav(navId),
+    onOpenAutomations: () => {
+      surfaceMode = 'automations';
+      accountFormMode = 'none';
+      activeNav = 'automations';
+      rail.setActiveNav('automations');
+      renderSurface();
+    },
+    onOpenSettings: () => openSettings(),
   });
 
-  accountSelect.addEventListener('change', () => {
-    if (accountSelect.value === ALL_INBOXES) {
-      unified = true;
-      accountHint.textContent = `${accounts.length} mailboxes`;
-      paintAccountDots();
-      void renderView();
-      return;
-    }
+  shell.append(rail.root, workspace);
+  mount.replaceChildren(shell);
+  rail.setActiveNav(activeNav);
 
-    const next = accounts.find((row) => row.id === accountSelect.value);
-    if (!next) return;
-    unified = false;
-    activeAccount = next;
-    accountHint.textContent = `${accountProviderLabel(next)} · ${next.username}`;
-    paintAccountDots();
-    void renderView();
-  });
-
-  const openAccountSetup = (
-    mode: 'add' | 'edit',
-    deepLink?: { highlightField?: string; errorMessage?: string },
-  ) => {
-    accountFormMode = mode;
-    body.replaceChildren();
-    if (mode === 'add') {
-      renderAccountForm(body, {
-        ...options,
-        title: 'Add email account',
-        isFirstAccount: false,
-        onSaved: () => void renderEmailPanel(mount, options),
-        onCancel: () => {
-          accountFormMode = 'none';
-          void renderView();
-        },
-      });
-      return;
+  /** Map a rail nav id onto an inbox scope, then render. */
+  function applyNav(navId: string): void {
+    surfaceMode = 'inbox';
+    accountFormMode = 'none';
+    activeNav = navId;
+    rail.setActiveNav(navId);
+    if (navId === 'waiting') {
+      scope = { kind: 'waiting' };
+    } else if (navId === 'unread' || navId === 'flagged' || navId === 'snoozed') {
+      scope = { kind: 'filter', filter: navId };
+    } else if (navId.startsWith('folder:')) {
+      scope = { kind: 'folder', path: navId.slice('folder:'.length) };
+    } else {
+      scope = { kind: 'triage' };
     }
-    // The settings button reads as active whenever the edit form is open,
-    // including when a connection error opened it.
-    settingsBtn.classList.add('is-active');
-    renderAccountForm(body, {
+    renderSurface();
+  }
+
+  /** Pull the folder list into the rail; fall back to the cached account list. */
+  async function loadFolders(): Promise<void> {
+    try {
+      const rows = await fetchEmailFolders(activeAccount.id);
+      rail.setFolders(rows.map((row) => ({ path: row.path, label: folderLabel(row.path) })));
+    } catch {
+      rail.setFolders(activeAccount.folders.map((path) => ({ path, label: folderLabel(path) })));
+    }
+  }
+
+  /** Open the account-settings form in the workspace. */
+  function openSettings(deepLink?: { highlightField?: string; errorMessage?: string }): void {
+    surfaceMode = 'setup';
+    accountFormMode = 'edit';
+    activeNav = 'settings';
+    rail.setActiveNav('settings');
+    surface.classList.remove('has-reader');
+    const wrap = el('div', 'email-setup-shell email-surface-scroll');
+    surface.replaceChildren(wrap);
+    renderAccountForm(wrap, {
       ...options,
       title: 'Edit email account',
       existing: activeAccount,
@@ -708,24 +508,68 @@ export async function renderEmailPanel(
       errorMessage: deepLink?.errorMessage,
       onSaved: () => void renderEmailPanel(mount, options),
       onSignedOut: () => void renderEmailPanel(mount, options),
-      onCancel: () => {
-        accountFormMode = 'none';
-        settingsBtn.classList.remove('is-active');
-        void renderView();
-      },
+      onCancel: () => applyNav('attn'),
     });
-  };
+  }
 
-  settingsBtn.addEventListener('click', () => {
-    if (accountFormMode === 'edit') {
-      accountFormMode = 'none';
-      settingsBtn.classList.remove('is-active');
-      void renderView();
+  /** Mount whichever surface the current state calls for. */
+  function renderSurface(): void {
+    if (surfaceMode === 'setup') {
+      // openSettings owns this surface; nothing to redraw here.
       return;
     }
-    openAccountSetup('edit');
-    settingsBtn.classList.add('is-active');
-  });
+    if (surfaceMode === 'automations') {
+      surface.classList.remove('has-reader');
+      const wrap = el('div', 'email-surface-scroll');
+      surface.replaceChildren(wrap);
+      void renderEmailAutomations(wrap, {
+        account: activeAccount,
+        onStatus: handleStatus,
+        onClose: () => applyNav('attn'),
+      });
+      return;
+    }
+
+    // Inbox surface. Unified keeps the simple all-mailboxes list for now.
+    if (unified) {
+      surface.classList.remove('has-reader');
+      const streamWrap = el('div', 'email-stream');
+      const col = el('div', 'email-stream-col');
+      streamWrap.appendChild(col);
+      surface.replaceChildren(streamWrap);
+      void renderUnifiedInbox(col, {
+        accounts,
+        onStatus: handleStatus,
+        // Opening a message drops into that mailbox's own inbox surface, where
+        // reply, archive and the rest actually live.
+        onOpen: (message) => {
+          const owner = accounts.find((row) => row.id === message.accountId);
+          if (!owner) return;
+          unified = false;
+          activeAccount = owner;
+          rail.setAccount(owner.id, false, accounts);
+          pendingThreadId = message.threadId;
+          void loadFolders();
+          applyNav('attn');
+        },
+      });
+      return;
+    }
+
+    const openComposeNew = pendingComposeNew;
+    pendingComposeNew = false;
+    const initialThreadId = pendingThreadId;
+    pendingThreadId = undefined;
+    void renderEmailInbox(surface, {
+      account: activeAccount,
+      scope,
+      onStatus: handleStatus,
+      onSyncActivity: setSyncing,
+      onCounts: (counts) => rail.setCounts(counts),
+      openComposeNew,
+      initialThreadId,
+    });
+  }
 
   panelEventUnsubs.get(mount)?.();
   panelEventUnsubs.set(
@@ -741,12 +585,15 @@ export async function renderEmailPanel(
         type === 'pending_actions_updated' ||
         type === 'followups_updated'
       ) {
-        if (viewMode === 'dashboard') {
-          void renderView();
+        // Only refresh the live triage stream. Re-rendering while a folder view
+        // or the reader is open would yank the surface out from under the user.
+        if (surfaceMode === 'inbox' && !unified && scope.kind === 'triage') {
+          renderSurface();
         }
       }
     }),
   );
 
-  await renderView();
+  await loadFolders();
+  renderSurface();
 }

--- a/src/ui/email/email-rail.ts
+++ b/src/ui/email/email-rail.ts
@@ -1,0 +1,293 @@
+/**
+ * The Email spine rail (MIN-358 Direction A).
+ *
+ * One navigation spine that absorbs what used to be the top tabs *and* the
+ * three-pane folder column: the account switcher, Compose, the agent Views
+ * (Needs attention, Waiting on, ...), the IMAP folders, and Automations /
+ * Settings at the foot. It owns no data — it renders from a model and reports
+ * intent through callbacks, so the panel stays the single source of truth.
+ */
+
+import type { EmailAccount } from '../../email/client';
+import { EMAIL_ICONS } from './email-icons';
+import { ACCOUNT_DOT_CLASSES, ALL_INBOXES, accountColorIndex } from './email-unified';
+
+export interface RailFolder {
+  path: string;
+  label: string;
+}
+
+export interface EmailRailOptions {
+  accounts: EmailAccount[];
+  /** Active account id, or ALL_INBOXES when unified. */
+  activeAccountId: string;
+  unified: boolean;
+  /** Account id, or ALL_INBOXES for "All inboxes". */
+  onSelectAccount(id: string): void;
+  onCompose(): void;
+  /** A view id ('attn' | 'waiting' | ...) or `folder:<path>`. */
+  onSelectNav(navId: string): void;
+  onOpenAutomations(): void;
+  onOpenSettings(): void;
+}
+
+export interface EmailRailHandle {
+  root: HTMLElement;
+  setFolders(folders: RailFolder[]): void;
+  /** Counts keyed by view id or folder path; undefined clears the badge. */
+  setCounts(counts: Record<string, number | undefined>): void;
+  setActiveNav(navId: string): void;
+  setAccount(accountId: string, unified: boolean, accounts: EmailAccount[]): void;
+}
+
+interface RailView {
+  id: string;
+  label: string;
+  tone?: 'attn' | 'wait';
+}
+
+/** The agent Views, in scan order. "Needs attention" is the default surface. */
+const RAIL_VIEWS: RailView[] = [
+  { id: 'attn', label: 'Needs attention', tone: 'attn' },
+  { id: 'waiting', label: 'Waiting on', tone: 'wait' },
+  { id: 'unread', label: 'Unread' },
+  { id: 'flagged', label: 'Flagged' },
+  { id: 'snoozed', label: 'Snoozed' },
+];
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+/** Human provider label for the active mailbox, matching the old chrome hint. */
+function providerLabel(account: EmailAccount): string {
+  const host = account.imap.host.toLowerCase();
+  if (host.includes('gmail') || host.includes('google')) return 'Gmail';
+  if (host.includes('outlook') || host.includes('office365')) return 'Outlook';
+  if (host.includes('fastmail')) return 'Fastmail';
+  return account.imap.host;
+}
+
+export function createEmailRail(options: EmailRailOptions): EmailRailHandle {
+  let accounts = options.accounts;
+  let activeAccountId = options.activeAccountId;
+  let unified = options.unified;
+
+  const root = el('aside', 'email-rail');
+  root.setAttribute('aria-label', 'Email navigation');
+
+  // ---- Brand -----------------------------------------------------------
+  const head = el('div', 'email-rail-head');
+  const mark = el('span', 'email-rail-mark', 'm');
+  mark.setAttribute('aria-hidden', 'true');
+  head.append(mark, el('span', 'email-rail-word', 'Email'));
+
+  // ---- Account switcher ------------------------------------------------
+  const accountBtn = el('button', 'email-rail-account') as HTMLButtonElement;
+  accountBtn.type = 'button';
+  accountBtn.setAttribute('aria-haspopup', 'true');
+  accountBtn.setAttribute('aria-expanded', 'false');
+  const accountDots = el('span', 'email-rail-account-dots');
+  const accountText = el('span', 'email-rail-account-text');
+  const accountName = el('span', 'email-rail-account-name');
+  const accountHint = el('span', 'email-rail-account-hint');
+  accountText.append(accountName, accountHint);
+  const caret = el('span', 'email-rail-account-caret');
+  caret.innerHTML = EMAIL_ICONS.chevronRight;
+  accountBtn.append(accountDots, accountText, caret);
+
+  const accountMenu = el('div', 'email-rail-account-menu');
+  accountMenu.hidden = true;
+  accountMenu.setAttribute('role', 'menu');
+
+  const paintDots = (host: HTMLElement, ids: string[]): void => {
+    host.replaceChildren();
+    for (const id of ids) {
+      const dot = el(
+        'span',
+        `email-account-dot ${ACCOUNT_DOT_CLASSES[accountColorIndex(accounts, id)]}`,
+      );
+      dot.title = accounts.find((row) => row.id === id)?.label ?? '';
+      host.appendChild(dot);
+    }
+  };
+
+  const paintAccountFace = (): void => {
+    paintDots(accountDots, unified ? accounts.map((row) => row.id) : [activeAccountId]);
+    if (unified) {
+      accountName.textContent = 'All inboxes';
+      accountHint.textContent = `${accounts.length} mailboxes`;
+      return;
+    }
+    const active = accounts.find((row) => row.id === activeAccountId) ?? accounts[0];
+    accountName.textContent = active?.label ?? 'Account';
+    accountHint.textContent = active
+      ? `${providerLabel(active)} · ${active.username}`
+      : '';
+  };
+
+  const closeMenu = (): void => {
+    accountMenu.hidden = true;
+    accountBtn.setAttribute('aria-expanded', 'false');
+  };
+
+  const buildMenu = (): void => {
+    accountMenu.replaceChildren();
+    const addOpt = (id: string, label: string, dotIds: string[], active: boolean): void => {
+      const opt = el('button', 'email-rail-account-opt') as HTMLButtonElement;
+      opt.type = 'button';
+      opt.setAttribute('role', 'menuitem');
+      if (active) opt.classList.add('is-active');
+      const dots = el('span', 'email-rail-account-dots');
+      paintDots(dots, dotIds);
+      opt.append(dots, el('span', '', label));
+      opt.addEventListener('click', () => {
+        closeMenu();
+        options.onSelectAccount(id);
+      });
+      accountMenu.appendChild(opt);
+    };
+
+    if (accounts.length > 1) {
+      addOpt(ALL_INBOXES, 'All inboxes', accounts.map((row) => row.id), unified);
+    }
+    for (const account of accounts) {
+      addOpt(account.id, account.label, [account.id], !unified && account.id === activeAccountId);
+    }
+  };
+
+  accountBtn.addEventListener('click', (event) => {
+    event.stopPropagation();
+    const willOpen = accountMenu.hidden;
+    if (willOpen) {
+      buildMenu();
+      accountMenu.hidden = false;
+      accountBtn.setAttribute('aria-expanded', 'true');
+      const onDocClick = (): void => {
+        closeMenu();
+        document.removeEventListener('click', onDocClick);
+      };
+      window.setTimeout(() => document.addEventListener('click', onDocClick), 0);
+    } else {
+      closeMenu();
+    }
+  });
+
+  // ---- Compose ---------------------------------------------------------
+  const composeBtn = el('button', 'email-rail-compose') as HTMLButtonElement;
+  composeBtn.type = 'button';
+  composeBtn.innerHTML = `${EMAIL_ICONS.compose}<span>Compose</span>`;
+  composeBtn.setAttribute('aria-label', 'Compose new message');
+  composeBtn.addEventListener('click', () => options.onCompose());
+
+  // ---- Navigation ------------------------------------------------------
+  const nav = el('nav', 'email-rail-nav');
+
+  /** Every nav button, keyed by its nav id, for active + count updates. */
+  const navItems = new Map<string, HTMLButtonElement>();
+
+  const mkItem = (
+    navId: string,
+    label: string,
+    opts: { tone?: 'attn' | 'wait'; icon?: string; onActivate?: () => void; track?: boolean } = {},
+  ): HTMLButtonElement => {
+    const btn = el('button', 'email-rail-item') as HTMLButtonElement;
+    btn.type = 'button';
+    btn.dataset.nav = navId;
+    if (opts.tone) {
+      const tick = el('span', `email-rail-item-tick is-${opts.tone}`);
+      tick.setAttribute('aria-hidden', 'true');
+      btn.appendChild(tick);
+    } else if (opts.icon) {
+      const icon = el('span', 'email-rail-item-icon');
+      icon.setAttribute('aria-hidden', 'true');
+      icon.innerHTML = opts.icon;
+      btn.appendChild(icon);
+    }
+    btn.appendChild(el('span', 'email-rail-item-label', label));
+    const count = el('span', 'email-rail-item-count');
+    btn.appendChild(count);
+    btn.addEventListener('click', opts.onActivate ?? (() => options.onSelectNav(navId)));
+    // Foot buttons (Automations, Settings) route to their own surfaces and are
+    // not part of the inbox nav's active/count tracking.
+    if (opts.track !== false) navItems.set(navId, btn);
+    return btn;
+  };
+
+  const viewsGroup = el('div', 'email-rail-group');
+  viewsGroup.appendChild(el('p', 'email-rail-group-label', 'Views'));
+  const viewsItems = el('div', 'email-rail-group-items');
+  for (const view of RAIL_VIEWS) {
+    viewsItems.appendChild(mkItem(view.id, view.label, { tone: view.tone }));
+  }
+  viewsGroup.appendChild(viewsItems);
+
+  const foldersGroup = el('div', 'email-rail-group');
+  foldersGroup.appendChild(el('p', 'email-rail-group-label', 'Folders'));
+  const foldersItems = el('div', 'email-rail-group-items');
+  foldersGroup.appendChild(foldersItems);
+
+  nav.append(viewsGroup, foldersGroup);
+
+  // ---- Foot ------------------------------------------------------------
+  const foot = el('div', 'email-rail-foot');
+  const autoBtn = mkItem('automations', 'Automations', {
+    icon: EMAIL_ICONS.automations,
+    onActivate: () => options.onOpenAutomations(),
+    track: false,
+  });
+  const settingsBtn = mkItem('settings', 'Settings', {
+    icon: EMAIL_ICONS.settings,
+    onActivate: () => options.onOpenSettings(),
+    track: false,
+  });
+  foot.append(autoBtn, settingsBtn);
+
+  root.append(head, accountBtn, accountMenu, composeBtn, nav, foot);
+
+  paintAccountFace();
+
+  const setActiveNav = (navId: string): void => {
+    for (const [id, btn] of navItems) {
+      btn.classList.toggle('is-active', id === navId);
+    }
+  };
+
+  const setCounts = (counts: Record<string, number | undefined>): void => {
+    for (const [id, btn] of navItems) {
+      const count = counts[id];
+      const cell = btn.querySelector<HTMLElement>('.email-rail-item-count');
+      if (!cell) continue;
+      cell.textContent = count && count > 0 ? String(count > 999 ? '999+' : count) : '';
+    }
+  };
+
+  const setFolders = (folders: RailFolder[]): void => {
+    foldersItems.replaceChildren();
+    // Drop stale folder entries from the nav map before rebuilding.
+    for (const key of [...navItems.keys()]) {
+      if (key.startsWith('folder:')) navItems.delete(key);
+    }
+    for (const folder of folders) {
+      foldersItems.appendChild(
+        mkItem(`folder:${folder.path}`, folder.label, { icon: EMAIL_ICONS.folder }),
+      );
+    }
+  };
+
+  const setAccount = (accountId: string, nextUnified: boolean, nextAccounts: EmailAccount[]): void => {
+    accounts = nextAccounts;
+    activeAccountId = accountId;
+    unified = nextUnified;
+    paintAccountFace();
+  };
+
+  return { root, setFolders, setCounts, setActiveNav, setAccount };
+}


### PR DESCRIPTION
## What

Rethinks the MinnowOS Email app's information architecture (Direction A, "One Stream"). The tabbed chrome and the three-pane folder rail are replaced by **one navigation spine + one workspace**, and the **Dashboard and Mail tabs merge into a single triage-first stream**.

This is the first slice of an IA-focused pass. The goal was to remove the two things that made the app read as generic: two parallel inboxes stitched together by tabs, and a Mail surface that was (by its own code comment) an "Acme-style three-column mail client" indistinguishable from Gmail/Outlook. The agent layer (digest, triage, quick replies) is now the head of the mail stream instead of being quarantined in its own tab.

## Why

`/impeccable craft MIN-358` with a confirmed shape brief: rethink layout & IA end-to-end because the app "feels generic in places." Two visual directions were prototyped; the user selected Direction A.

## Changes

- **`email-rail.ts`** (new) — the navigation spine: account switcher with colour-dot popover (replaces the bare `<select>`), accent Compose, agent **Views** (Needs attention / Waiting on / Unread / Flagged / Snoozed) with live counts, **Folders**, and Automations + Settings pinned at the foot.
- **`email-inbox.ts`** (new) — the unified stream: a quiet mono **readout** (replacing the boxed 4-cell KPI strip), the narrative **digest**, the **Needs attention** queue with inline quick-replies, an **"Everything else"** divider with search, then the conversation stream. The reader **docks in from the right** with a scrim rather than occupying a permanent third pane.
- **`email-panel.ts`** — shell rewired from tabs to rail + workspace; rail Views/Folders map onto inbox scopes; account / compose / automations / settings routing.
- **`email.css`** — new rail / workspace / stream / readout / reader-dock section, reusing the existing `.email-list-*`, `.email-reader-*`, `.email-dash-*` atoms.
- **`email-dashboard.ts` / `email-layout.ts`** — export `renderHighlightRow` and the body/format helpers so the new stream **reuses** the proven mail renderers rather than reimplementing them.

## Verification

- `tsc --noEmit` clean across the project.
- Rendered the real `tokens.css` + `email.css` against representative markup in swamp-dark: rail on `surface-0`, stream centered, readout metrics in danger/warning, active items in accent-soft, reader dock parked offscreen and sliding to `translateX(0)` with an opaque scrim on `has-reader`. No page overflow, no element collisions.

## Reviewer notes / known limitations (next slices)

- The **live data path is not exercised** here (needs a connected IMAP account), so integration is verified by types + structure, not a running inbox.
- Reader dock attachments are **download-only** for now (no inline image/PDF preview yet); snooze / move / "more" menu and stream keyboard nav (`j`/`k`) are not wired into the dock yet.
- **"All inboxes"** still uses the existing simple unified list inside the new stream frame.
- The old `renderEmailLayout` / `renderEmailDashboard` entry points are **retained** (their pieces are reused) but no longer routed; they can be retired in a later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)