### PR TITLE
✨ Show confirmation on onboarding cloud provider chips (MIN-440)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -376,7 +376,7 @@ Design reference: [`DESIGN.md`](../DESIGN.md), [`documentation/design-system/`](
 
 Multi-provider registry: `~/.minnow/providers/`. UI: Models app → Providers. Chat uses composite model keys (`providerId` + model id) in [`src/lib/model-select-key.ts`](../src/lib/model-select-key.ts).
 
-**One-click presets:** shared catalog in [`src/providers/presets.ts`](../src/providers/presets.ts) — OpenCode Go/Zen, Anthropic, DeepSeek, GitHub Copilot, plus OpenRouter/OpenAI/Groq/Mistral. **Settings → Providers** uses the `settings-general` emphasis-panel layout (like Routing and Usage): grouped picker (local servers, featured APIs, more cloud APIs, then custom), flat provider rows inside the configured panel, and related links to Routing and Usage. Styles: [`src/styles/settings-providers.css`](../src/styles/settings-providers.css).
+**One-click presets:** shared catalog in [`src/providers/presets.ts`](../src/providers/presets.ts) — OpenCode Go/Zen, Anthropic, DeepSeek, GitHub Copilot, plus OpenRouter/OpenAI/Groq/Mistral. **Onboarding → Cloud API** shows preset chips with a green check when that provider already has a saved API key (`onboarding-cloud-<preset>` ids in the registry). **Settings → Providers** uses the `settings-general` emphasis-panel layout (like Routing and Usage): grouped picker (local servers, featured APIs, more cloud APIs, then custom), flat provider rows inside the configured panel, and related links to Routing and Usage. Styles: [`src/styles/settings-providers.css`](../src/styles/settings-providers.css).
 
 `fetchModels()` loads all enabled providers. Main chat streams via generations API; `postChatCompletions` shim for headless/sub-agents.
 

--- a/documentation/guides/settings-reference.md
+++ b/documentation/guides/settings-reference.md
@@ -141,7 +141,7 @@ Also: `config.activeProviderId`.
 
 #### One-click provider presets
 
-Catalog: [`src/providers/presets.ts`](../../src/providers/presets.ts). Presets appear as chips in **onboarding → Cloud API** and as a preset grid in **Settings → Models → Providers → Add provider** (choose a preset or **Add custom provider** for the full form).
+Catalog: [`src/providers/presets.ts`](../../src/providers/presets.ts). Presets appear as chips in **onboarding → Cloud API** (a green check on a chip means that preset already has a saved API key) and as a preset grid in **Settings → Models → Providers → Add provider** (choose a preset or **Add custom provider** for the full form).
 
 | Preset | Base URL | API kind | Auth | Notes |
 |--------|----------|----------|------|-------|

--- a/src/onboarding/state-core.ts
+++ b/src/onboarding/state-core.ts
@@ -16,6 +16,33 @@ export function hasUserConfiguredProviderIds(providerIds: readonly string[]): bo
   return providerIds.some((id) => !ONBOARDING_SEED_PROVIDER_IDS.has(id));
 }
 
+/** Prefix for cloud providers saved during onboarding (one row per preset id). */
+export const ONBOARDING_CLOUD_PROVIDER_PREFIX = 'onboarding-cloud-';
+
+/** Stable provider id for an onboarding cloud preset chip. */
+export function onboardingCloudProviderId(presetId: string): string {
+  return `${ONBOARDING_CLOUD_PROVIDER_PREFIX}${presetId}`;
+}
+
+/** Map a saved onboarding cloud provider id back to its preset chip id. */
+export function presetIdFromOnboardingCloudProviderId(providerId: string): string | null {
+  if (!providerId.startsWith(ONBOARDING_CLOUD_PROVIDER_PREFIX)) return null;
+  return providerId.slice(ONBOARDING_CLOUD_PROVIDER_PREFIX.length);
+}
+
+/** Preset chip ids that already have an API key saved during onboarding. */
+export function listConfiguredOnboardingCloudPresetIds(
+  providers: ReadonlyArray<{ id: string; hasApiKey: boolean }>,
+): string[] {
+  const configured: string[] = [];
+  for (const provider of providers) {
+    if (!provider.hasApiKey) continue;
+    const presetId = presetIdFromOnboardingCloudProviderId(provider.id);
+    if (presetId) configured.push(presetId);
+  }
+  return configured;
+}
+
 /** True when persisted chats contain real messages (not just model binding). */
 export function hasExistingChatMessageHistory(
   chats: ReadonlyArray<{ history?: readonly unknown[] }> | undefined,

--- a/src/onboarding/steps/provider.ts
+++ b/src/onboarding/steps/provider.ts
@@ -6,6 +6,7 @@ import {
   createProvider,
   updateProvider,
   updateProviderSecrets,
+  listProviders,
   type CreateProviderPayload,
 } from '../../providers/store';
 import type { ProviderPublic } from '../../providers/types';
@@ -19,7 +20,11 @@ import {
 } from '../provider-probe';
 import { ONBOARDING_CLOUD_PRESETS } from '../../providers/presets';
 import type { OnboardingContext, OnboardingStep, OnboardingStepActions } from '../types';
-import { recordStepProgress } from '../state-core';
+import {
+  listConfiguredOnboardingCloudPresetIds,
+  onboardingCloudProviderId,
+  recordStepProgress,
+} from '../state-core';
 
 let selectedPath: OnboardingContext['providerPath'] = null;
 let probeResults: ProviderProbeResult[] = [];
@@ -30,6 +35,9 @@ let cloudBaseUrl = 'https://openrouter.ai/api';
 let cloudApiKey = '';
 let connectionStatus: 'idle' | 'ok' | 'err' = 'idle';
 let connectionError = '';
+/** Preset chip ids the user has already tested and saved during this wizard session. */
+const configuredCloudPresets = new Set<string>();
+let cloudProviderLoadGen = 0;
 
 export const providerChoiceStep: OnboardingStep = {
   id: 'provider-choice',
@@ -211,20 +219,25 @@ export const providerCloudStep: OnboardingStep = {
 
     const presetRow = el('div', 'mn-onboarding-chip-row');
     ONBOARDING_CLOUD_PRESETS.forEach((preset) => {
-      const chip = el('button', 'mn-onboarding-wallpaper-chip', preset.label);
-      chip.type = 'button';
-      if (preset.id === cloudPreset) chip.classList.add('is-selected');
-      if (preset.authHint) chip.title = preset.authHint;
-      chip.addEventListener('click', () => {
+      const chip = createCloudPresetChip(preset, configuredCloudPresets.has(preset.id), () => {
         cloudPreset = preset.id;
         if (preset.baseUrl) cloudBaseUrl = preset.baseUrl;
-        actions.setPrimaryEnabled(false);
-        connectionStatus = 'idle';
+        connectionError = '';
+        if (configuredCloudPresets.has(preset.id)) {
+          connectionStatus = 'ok';
+          localProviderId = onboardingCloudProviderId(preset.id);
+        } else {
+          connectionStatus = 'idle';
+          actions.setPrimaryEnabled(false);
+        }
         rerenderCloud(container, ctx, actions);
       });
+      if (preset.id === cloudPreset) chip.classList.add('is-selected');
       presetRow.appendChild(chip);
     });
     container.appendChild(presetRow);
+
+    void refreshConfiguredCloudPresets(container, ctx, actions);
 
     const selectedPreset = ONBOARDING_CLOUD_PRESETS.find((preset) => preset.id === cloudPreset);
     if (selectedPreset?.authHint) {
@@ -267,7 +280,9 @@ export const providerCloudStep: OnboardingStep = {
     container.appendChild(statusRow);
 
     actions.setPrimaryLabel('Continue');
-    actions.setPrimaryEnabled(connectionStatus === 'ok');
+    actions.setPrimaryEnabled(
+      connectionStatus === 'ok' || configuredCloudPresets.has(cloudPreset),
+    );
   },
 
   async commit(ctx) {
@@ -294,6 +309,57 @@ function rerenderCloud(
   actions: OnboardingStepActions,
 ): void {
   providerCloudStep.render(container, ctx, actions);
+}
+
+/** Cloud preset chip with an optional saved-key confirmation mark. */
+function createCloudPresetChip(
+  preset: (typeof ONBOARDING_CLOUD_PRESETS)[number],
+  isConfigured: boolean,
+  onSelect: () => void,
+): HTMLButtonElement {
+  const chip = el('button', 'mn-onboarding-wallpaper-chip');
+  chip.type = 'button';
+  if (preset.authHint) chip.title = preset.authHint;
+  if (isConfigured) chip.classList.add('is-added');
+
+  const label = el('span', 'mn-onboarding-wallpaper-chip__label', preset.label);
+  chip.appendChild(label);
+
+  if (isConfigured) {
+    const check = el('span', 'mn-onboarding-wallpaper-chip__check', '✓');
+    check.setAttribute('aria-hidden', 'true');
+    chip.appendChild(check);
+    chip.setAttribute('aria-label', `${preset.label}, added`);
+  }
+
+  chip.addEventListener('click', onSelect);
+  return chip;
+}
+
+/** Merge saved onboarding cloud providers from the registry into chip state. */
+async function refreshConfiguredCloudPresets(
+  container: HTMLElement,
+  ctx: OnboardingContext,
+  actions: OnboardingStepActions,
+): Promise<void> {
+  const gen = ++cloudProviderLoadGen;
+  try {
+    const { providers } = await listProviders();
+    if (gen !== cloudProviderLoadGen) return;
+    const beforeSize = configuredCloudPresets.size;
+    for (const presetId of listConfiguredOnboardingCloudPresetIds(providers)) {
+      configuredCloudPresets.add(presetId);
+    }
+    if (configuredCloudPresets.size === beforeSize) return;
+    if (configuredCloudPresets.has(cloudPreset)) {
+      connectionStatus = 'ok';
+      localProviderId = onboardingCloudProviderId(cloudPreset);
+      actions.setPrimaryEnabled(true);
+    }
+    rerenderCloud(container, ctx, actions);
+  } catch {
+    // Offline / vite-only — chip state stays session-local.
+  }
 }
 
 /** Create provider or update when npm start already seeded the same id. */
@@ -388,7 +454,7 @@ async function testCloudConnection(
   const preset = ONBOARDING_CLOUD_PRESETS.find((p) => p.id === cloudPreset);
   const apiKind = preset?.apiKind ?? 'openai-v1';
   const paths = getDefaultPaths(apiKind);
-  const id = `onboarding-cloud-${cloudPreset}`;
+  const id = onboardingCloudProviderId(cloudPreset);
   const result = await ensureOnboardingProvider({
     id,
     label: preset?.label ?? 'Cloud',
@@ -423,6 +489,7 @@ async function testCloudConnection(
     await fetchModelsForProvider(result.provider, new AbortController().signal);
     connectionStatus = 'ok';
     localProviderId = id;
+    configuredCloudPresets.add(cloudPreset);
     actions.setPrimaryEnabled(true);
   } catch (err) {
     connectionStatus = 'err';

--- a/src/styles/onboarding.css
+++ b/src/styles/onboarding.css
@@ -788,6 +788,9 @@ html.onboarding-active .mn-os-shell {
 }
 
 .mn-onboarding-wallpaper-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 8px 12px;
   border: 1px solid var(--mn-border, var(--border));
   border-radius: var(--mn-radius-sm, 6px);
@@ -796,6 +799,40 @@ html.onboarding-active .mn-os-shell {
   cursor: pointer;
   appearance: none;
   transition: border-color 0.15s ease-out, background-color 0.15s ease-out;
+}
+
+.mn-onboarding-wallpaper-chip.is-added {
+  border-color: var(
+    --mn-success-border,
+    color-mix(in oklch, var(--mn-success, var(--success)) 35%, var(--mn-border, var(--border)))
+  );
+}
+
+.mn-onboarding-wallpaper-chip__label {
+  line-height: 1.2;
+}
+
+.mn-onboarding-wallpaper-chip__check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--mn-success-ink, var(--mn-success, var(--success)));
+  background: var(
+    --mn-success-soft,
+    color-mix(in oklch, var(--mn-success, var(--success)) 12%, transparent)
+  );
+  border: 1px solid
+    var(
+      --mn-success-border,
+      color-mix(in oklch, var(--mn-success, var(--success)) 35%, transparent)
+    );
 }
 
 .mn-onboarding-wallpaper-chip.is-selected {

--- a/test/onboarding/cloud-provider-presets.test.mjs
+++ b/test/onboarding/cloud-provider-presets.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * Onboarding cloud preset id helpers — configured-provider confirmation chips.
+ */
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+const {
+  ONBOARDING_CLOUD_PROVIDER_PREFIX,
+  listConfiguredOnboardingCloudPresetIds,
+  onboardingCloudProviderId,
+  presetIdFromOnboardingCloudProviderId,
+} = await import('../../src/onboarding/state-core.ts');
+
+describe('onboarding cloud provider preset ids', () => {
+  test('onboardingCloudProviderId uses stable onboarding prefix', () => {
+    assert.equal(onboardingCloudProviderId('openrouter'), `${ONBOARDING_CLOUD_PROVIDER_PREFIX}openrouter`);
+  });
+
+  test('presetIdFromOnboardingCloudProviderId round-trips preset ids', () => {
+    assert.equal(
+      presetIdFromOnboardingCloudProviderId('onboarding-cloud-groq'),
+      'groq',
+    );
+    assert.equal(presetIdFromOnboardingCloudProviderId('openrouter'), null);
+  });
+
+  test('listConfiguredOnboardingCloudPresetIds returns presets with saved keys only', () => {
+    const configured = listConfiguredOnboardingCloudPresetIds([
+      { id: 'onboarding-cloud-openrouter', hasApiKey: true },
+      { id: 'onboarding-cloud-groq', hasApiKey: false },
+      { id: 'lm-studio-local', hasApiKey: true },
+      { id: 'onboarding-cloud-custom', hasApiKey: true },
+    ]);
+    assert.deepEqual(configured.sort(), ['custom', 'openrouter']);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [MIN-440](https://linear.app/minnow/issue/MIN-440): users could add multiple cloud providers during onboarding but had no visual feedback about which presets were already configured.

## Changes

- **Cloud API step:** each preset chip now shows a green checkmark and subtle success border after **Test and save** succeeds
- **Registry sync:** on step load, existing `onboarding-cloud-<preset>` providers with saved API keys are detected and marked as added (supports navigating back within the wizard)
- **Re-select behavior:** clicking an already-added preset restores the connected state and enables **Continue** without re-entering the key
- **Helpers:** `onboardingCloudProviderId`, `presetIdFromOnboardingCloudProviderId`, and `listConfiguredOnboardingCloudPresetIds` in `state-core.ts` with unit tests

## Testing

- `npx tsx --import ./test/test-loader.mjs --test test/onboarding/cloud-provider-presets.test.mjs test/onboarding/state.test.mjs`
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-440](https://linear.app/minnowai/issue/MIN-440/10-onboarding-provider-setup)

<div><a href="https://cursor.com/agents/bc-09dd3e45-d009-4f86-b9a7-241ecf4e6ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09dd3e45-d009-4f86-b9a7-241ecf4e6ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

