### PR TITLE
🐛 Stop thinking timer when tool calls begin (MIN-467)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -148,7 +148,7 @@ Loader dismiss: [`src/boot/app-ready.ts`](../src/boot/app-ready.ts) on `DOMConte
 | Role | Shape | Notes |
 |------|--------|-------|
 | `user` | `{ role, content: string }` | Attachments as `[image: …]` / `<file name="…">` in content |
-| `assistant` | `{ role, content, thinking?, tool_calls?, stats? }` | Markdown UI; optional `thinking[]` |
+| `assistant` | `{ role, content, thinking?, thinkingDurationMs?, tool_calls?, stats? }` | Markdown UI; optional `thinking[]` and wall-clock reasoning duration |
 | `tool` | `{ role, tool_call_id, content }` | Paired to `tool_calls` in UI |
 
 Wire format may use multimodal `ContentPart[]` for VLMs; built in [`src/tools/loop.ts`](../src/tools/loop.ts) (`buildApiMessages`).
@@ -168,6 +168,8 @@ Main chat: `POST /api/generations` + `GET .../stream` with replay. Client stores
 SSE parsing: [`src/api/sse-parse.ts`](../src/api/sse-parse.ts) — event boundaries and glued JSON chunks; do not `Response.json()` on the generations shim.
 
 **Live metrics (MIN-413):** [`src/chat/streaming-stats.ts`](../src/chat/streaming-stats.ts) updates `chat.lastStats` and the bottom metrics strip during SSE (throttled ~100ms). Provider `usage` from chunks is preferred when `completion_tokens` is present; otherwise completion tokens are estimated from partial assistant prose only (`chars ÷ 4`). Tool-loop rounds roll up via [`aggregateTurnUsageSegments`](../src/chat/orchestrate/stats-math.ts) — sum completions, keep the latest prompt (each API call reports full context, not a delta).
+
+**Thinking duration (MIN-467):** [`ThinkingDurationTracker`](../src/ui/thinking-duration.ts) accumulates wall time only while reasoning SSE is active. [`streamCompletionTurn`](../src/tools/loop.ts) ends the reasoning phase when the first `tool_calls` delta arrives so the live “Thinking…” timer and persisted `thinkingDurationMs` do not include tool-call streaming or execution.
 
 **Turn runs** (`chat.runs`): semantic branches for replay/fork ([`src/state/runs-store.ts`](../src/state/runs-store.ts)), separate from transport generations. Branch picker ([`src/ui/branch-picker.ts`](../src/ui/branch-picker.ts)) calls `activateBranch`, which snapshots the active branch’s continuation into `outputMessages` before swapping so follow-up turns survive switching between branches; it also calls `switchActiveChat` so the next composer send stays on that chat (desktop/chat-app send no longer re-resolves a different sandbox chat when history is already present). After fork/replay turns settle, `loop.ts` calls `refreshBranchPickerAtFork` so the picker appears without reloading the chat.
 

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -863,13 +863,6 @@ async function streamCompletionTurn(
   function handleChunk(chunk: ChatCompletionChunk): void {
     streamMeta = mergeStreamMeta(streamMeta, chunk);
     toolAcc = mergeToolCallDelta(toolAcc, chunk);
-    if (domVisible && onToolCallStreaming) {
-      const streamingName = getLatestStreamingToolName(toolAcc);
-      if (streamingName && streamingName !== lastAnnouncedToolName) {
-        lastAnnouncedToolName = streamingName;
-        onToolCallStreaming(streamingName);
-      }
-    }
     const reasoning = extractReasoningDelta(chunk);
     if (reasoning) {
       feedThinkingBudget(reasoning);
@@ -889,6 +882,17 @@ async function streamCompletionTurn(
         prefillEchoPartial = '';
       }
       routeContentDelta(routedDelta);
+    }
+    // Reasoning ends before tool_calls JSON streams; stop the thinking timer here (MIN-467).
+    if (Object.keys(toolAcc).length > 0) {
+      thoughtController?.endReasoningPhase();
+    }
+    if (domVisible && onToolCallStreaming) {
+      const streamingName = getLatestStreamingToolName(toolAcc);
+      if (streamingName && streamingName !== lastAnnouncedToolName) {
+        lastAnnouncedToolName = streamingName;
+        onToolCallStreaming(streamingName);
+      }
     }
     emitStreamProgress();
     if (domVisible) {

--- a/src/ui/thought-bubbles.ts
+++ b/src/ui/thought-bubbles.ts
@@ -52,6 +52,9 @@ export class ThoughtBubbleController {
 
   private thinkingStartNotified = false;
 
+  /** True after `endReasoningPhase` fires `onReasoningEnded` for the current stream. */
+  private reasoningPhaseEnded = false;
+
   /** Anthropic thinking signature for the current reasoning block (tool-loop replay). */
   private anthropicThinkingSignature: string | null = null;
 
@@ -63,6 +66,7 @@ export class ThoughtBubbleController {
   /** Reset phase callbacks for a new streaming shell in the same user send (e.g. after tools). */
   resetStreamPhaseHints(): void {
     this.thinkingStartNotified = false;
+    this.reasoningPhaseEnded = false;
     this.anthropicThinkingSignature = null;
   }
 
@@ -140,7 +144,8 @@ export class ThoughtBubbleController {
    * flushes any open reasoning, removes the live stage from the DOM.
    */
   endReasoningPhase(): void {
-    if (this.disposed) return;
+    if (this.disposed || this.reasoningPhaseEnded) return;
+    this.reasoningPhaseEnded = true;
     const tail = this.openBuffer.trim();
     this.openBuffer = '';
     if (tail) {
@@ -180,6 +185,7 @@ export class ThoughtBubbleController {
     this.openBuffer = '';
     this.teardownStage();
     this.thinkingStartNotified = false;
+    this.reasoningPhaseEnded = false;
     this.expanded = false;
     this.elapsedMs = null;
     return segments;

--- a/test/ui/thought-bubbles.test.mjs
+++ b/test/ui/thought-bubbles.test.mjs
@@ -5,6 +5,7 @@ import { Window } from 'happy-dom';
 const { ThoughtBubbleController, renderThoughtsToggle } = await import(
   '../../src/ui/thought-bubbles.ts'
 );
+const { ThinkingDurationTracker } = await import('../../src/ui/thinking-duration.ts');
 
 function setupDom() {
   const window = new Window();
@@ -101,6 +102,38 @@ describe('ThoughtBubbleController', { concurrency: false }, () => {
     assert.equal(label?.textContent, 'Thinking… 5.0s');
 
     ctrl.endReasoningPhase();
+  });
+
+  test('endReasoningPhase is idempotent and stops thinking timer for tool calls', () => {
+    let now = 0;
+    const original = performance.now;
+    performance.now = () => now;
+
+    setupDom();
+    const wrap = assistantWrap();
+    let reasoningEndedCount = 0;
+    const tracker = new ThinkingDurationTracker();
+    const ctrl = new ThoughtBubbleController(wrap, {
+      onThinkingStart: () => tracker.startSegment(),
+      onReasoningEnded: () => {
+        reasoningEndedCount += 1;
+        tracker.endSegment();
+      },
+    });
+
+    ctrl.appendReasoningDelta('Plan the tool call');
+    now += 250;
+    ctrl.endReasoningPhase();
+
+    now += 8000;
+    assert.equal(reasoningEndedCount, 1);
+    assert.equal(tracker.getElapsedMs(), 250);
+
+    ctrl.endReasoningPhase();
+    assert.equal(reasoningEndedCount, 1);
+    assert.equal(tracker.getElapsedMs(), 250);
+
+    performance.now = original;
   });
 
   test('consumePersistedSegments returns segments and clears state for the next response', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [MIN-467](https://linear.app/minnow/issue/MIN-467): the live "Thinking…" duration kept increasing during subsequent tool calls because the reasoning phase was not ended until the full SSE stream finished.

## Changes

- End the reasoning phase as soon as the first `tool_calls` delta arrives in `streamCompletionTurn`, so `ThinkingDurationTracker` stops before tool-call JSON streaming and execution.
- Reorder chunk handling so reasoning/content in the same chunk are processed before ending the phase.
- Make `ThoughtBubbleController.endReasoningPhase()` idempotent so stream-end cleanup does not double-fire callbacks.
- Add regression test covering timer stop + idempotent phase end.
- Document `thinkingDurationMs` behavior in `documentation/context.md`.

## Test plan

- [x] `npx tsx --import ./test/test-loader.mjs --test test/ui/thought-bubbles.test.mjs test/ui/thinking-duration.test.mjs`
- [x] `npx tsc --noEmit`
- [ ] Manual: send a prompt that triggers reasoning then a tool call; confirm the live thinking timer stops when "Calling …" appears and persisted duration excludes tool time.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-467](https://linear.app/minnowai/issue/MIN-467/19-thinking-timer-increase-during-tool-call)

<div><a href="https://cursor.com/agents/bc-054cf018-1427-458c-9941-703bf3f9c7b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-054cf018-1427-458c-9941-703bf3f9c7b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

