### PR TITLE
✨ Add desktop chat workspace folder switching (MIN-430)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -158,7 +158,7 @@ Wire format may use multimodal `ContentPart[]` for VLMs; built in [`src/tools/lo
 - Persisted in `sessions/state.json` (schema version in [`src/types.ts`](../src/types.ts)).
 - Each chat has `workspacePath`; sidebar lists current workspace (+ Unassigned legacy).
 - Max **50** chats; newest `lastMessageAt` first.
-- **Desktop chat** uses a configurable workspace folder (default `~/.minnow/workspace`); change it from the desktop **Files** drawer (MRU select or folder picker). Persisted in `config.json` as `desktopWorkspace.path`. Legacy Chat app uses `~/.minnow/chats`.
+- **Desktop chat** uses a configurable workspace folder (default `~/.minnow/workspace`); change it from the desktop **Files** drawer (MRU select or folder picker). Persisted in `config.json` as `desktopWorkspace.path`. The file tree reloads on switch; `list_directory` tool-cache scopes include `workspaceRoot` so listings from one desktop folder are not reused for another. Legacy Chat app uses `~/.minnow/chats`.
 - **Email assistant chats** reuse the chats workspace for normal file permissions but persist with `Chat.appScope === 'email'`, `modeId === 'email'`, and `lastActiveChatIdByApp.email`, so they stay out of Code, Desktop, and Chat app rails.
 
 ### Backend-owned generations

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -158,7 +158,7 @@ Wire format may use multimodal `ContentPart[]` for VLMs; built in [`src/tools/lo
 - Persisted in `sessions/state.json` (schema version in [`src/types.ts`](../src/types.ts)).
 - Each chat has `workspacePath`; sidebar lists current workspace (+ Unassigned legacy).
 - Max **50** chats; newest `lastMessageAt` first.
-- **Desktop chat** uses `~/.minnow/workspace`; legacy Chat app uses `~/.minnow/chats`.
+- **Desktop chat** uses a configurable workspace folder (default `~/.minnow/workspace`); change it from the desktop **Files** drawer (MRU select or folder picker). Persisted in `config.json` as `desktopWorkspace.path`. Legacy Chat app uses `~/.minnow/chats`.
 - **Email assistant chats** reuse the chats workspace for normal file permissions but persist with `Chat.appScope === 'email'`, `modeId === 'email'`, and `lastActiveChatIdByApp.email`, so they stay out of Code, Desktop, and Chat app rails.
 
 ### Backend-owned generations

--- a/server/config/validators.js
+++ b/server/config/validators.js
@@ -2071,6 +2071,18 @@ export function mergeConfigMeta(existing, patch) {
     base.workspace = existingWorkspace;
   }
 
+  if (p.desktopWorkspace && typeof p.desktopWorkspace === 'object') {
+    const existingDesktopWorkspace =
+      base.desktopWorkspace && typeof base.desktopWorkspace === 'object'
+        ? { .../** @type {Record<string, unknown>} */ (base.desktopWorkspace) }
+        : { path: '' };
+    const dw = /** @type {Record<string, unknown>} */ (p.desktopWorkspace);
+    if (typeof dw.path === 'string' && dw.path.trim()) {
+      existingDesktopWorkspace.path = dw.path.trim();
+    }
+    base.desktopWorkspace = existingDesktopWorkspace;
+  }
+
   if (p.filePanel && typeof p.filePanel === 'object') {
     const existingPanel =
       base.filePanel && typeof base.filePanel === 'object'

--- a/server/desktop-workspace/paths.js
+++ b/server/desktop-workspace/paths.js
@@ -5,8 +5,11 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { readConfigJson, writeConfigJson } from '../config/store.js';
+import { mergeConfigMeta } from '../config/validators.js';
 import { getMinnowHome } from '../config/home.js';
 import { isResolvedPathUnderRoot } from '../workspace/safe-path.js';
+import { touchRecentWorkspacePath, validateWorkspacePath } from '../workspace/root.js';
 
 const DESKTOP_DIR_NAME = 'workspace';
 
@@ -19,9 +22,71 @@ This directory is the sandbox for MinnowOS desktop chat — attachments, notes, 
 - Do not store secrets here if you sync or share ~/.minnow.
 `;
 
-/** Absolute path to ~/.minnow/workspace (created on bootstrap). */
-export function getDesktopWorkspacePath() {
+/** Default sandbox under ~/.minnow/workspace (created on bootstrap). */
+function getDefaultDesktopWorkspacePath() {
   return path.join(getMinnowHome(), DESKTOP_DIR_NAME);
+}
+
+/** Active desktop chat workspace root (lazy — set on init or first read). */
+let desktopWorkspaceRoot = null;
+
+/** Reset in-memory desktop workspace path (tests only). */
+export function resetDesktopWorkspacePathForTests() {
+  desktopWorkspaceRoot = null;
+}
+
+/** Absolute path to the default desktop sandbox directory. */
+export function getDefaultDesktopSandboxPath() {
+  return getDefaultDesktopWorkspacePath();
+}
+
+/** Absolute path to the active desktop chat workspace. */
+export function getDesktopWorkspacePath() {
+  return desktopWorkspaceRoot ?? getDefaultDesktopWorkspacePath();
+}
+
+/**
+ * Load persisted desktop workspace from ~/.minnow/config.json (falls back to sandbox).
+ * @returns {Promise<string>}
+ */
+export async function initDesktopWorkspacePath() {
+  const meta = (await readConfigJson('config.json')) ?? {};
+  const saved =
+    meta.desktopWorkspace &&
+    typeof meta.desktopWorkspace === 'object' &&
+    typeof meta.desktopWorkspace.path === 'string'
+      ? meta.desktopWorkspace.path
+      : null;
+
+  if (saved && saved.trim()) {
+    try {
+      desktopWorkspaceRoot = await validateWorkspacePath(saved);
+      return desktopWorkspaceRoot;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[desktop-workspace] Ignoring invalid saved path: ${message}`);
+    }
+  }
+
+  desktopWorkspaceRoot = getDefaultDesktopWorkspacePath();
+  return desktopWorkspaceRoot;
+}
+
+/**
+ * Set desktop chat workspace root in memory and persist to config.json.
+ * @param {string} userPath
+ * @returns {Promise<string>} absolute path
+ */
+export async function setDesktopWorkspacePath(userPath) {
+  const resolved = await validateWorkspacePath(userPath);
+  desktopWorkspaceRoot = resolved;
+  const meta = (await readConfigJson('config.json')) ?? {};
+  const merged = mergeConfigMeta(meta, {
+    desktopWorkspace: { path: resolved },
+  });
+  await writeConfigJson('config.json', merged);
+  await touchRecentWorkspacePath(resolved);
+  return resolved;
 }
 
 /**
@@ -29,7 +94,7 @@ export function getDesktopWorkspacePath() {
  * @returns {Promise<string>} absolute desktop workspace path
  */
 export async function ensureDesktopWorkspace() {
-  const root = getDesktopWorkspacePath();
+  const root = getDefaultDesktopWorkspacePath();
   await fs.mkdir(root, { recursive: true });
 
   const readmePath = path.join(root, 'README.md');

--- a/server/desktop-workspace/routes.js
+++ b/server/desktop-workspace/routes.js
@@ -9,8 +9,26 @@ import { countDesktopWorkspaceFiles, listDesktopWorkspaceDirectory } from './lis
 import {
   getDesktopWorkspacePath,
   resolveSafeDesktopPath,
+  setDesktopWorkspacePath,
   toDesktopRelativePath,
 } from './paths.js';
+import { workspaceLabel } from '../workspace/root.js';
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch {
+        reject(new Error('Invalid JSON body'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
 
 function sendJson(res, status, payload) {
   res.statusCode = status;
@@ -64,7 +82,30 @@ export async function handleDesktopWorkspaceRequest(req, res, pathname, searchPa
     if (pathname === '/api/desktop-workspace' && req.method === 'GET') {
       const desktopPath = getDesktopWorkspacePath();
       const fileCount = await countDesktopWorkspaceFiles();
-      sendJson(res, 200, { ok: true, path: desktopPath, fileCount });
+      sendJson(res, 200, {
+        ok: true,
+        path: desktopPath,
+        label: workspaceLabel(desktopPath),
+        fileCount,
+      });
+      return true;
+    }
+
+    if (pathname === '/api/desktop-workspace' && req.method === 'PUT') {
+      const body = await readJsonBody(req);
+      const userPath = body?.path;
+      if (typeof userPath !== 'string' || !userPath.trim()) {
+        sendJson(res, 400, { error: 'path is required' });
+        return true;
+      }
+      const resolved = await setDesktopWorkspacePath(userPath);
+      const fileCount = await countDesktopWorkspaceFiles();
+      sendJson(res, 200, {
+        ok: true,
+        path: resolved,
+        label: workspaceLabel(resolved),
+        fileCount,
+      });
       return true;
     }
 

--- a/server/runtime/bootstrap.js
+++ b/server/runtime/bootstrap.js
@@ -6,7 +6,7 @@
 import { ensureAgentPacksLayout } from '../agent-packs/registry.js';
 import { ensureBenchmarkWorkspace } from '../benchmark-workspace/paths.js';
 import { ensureChatsWorkspace } from '../chats-workspace/paths.js';
-import { ensureDesktopWorkspace } from '../desktop-workspace/paths.js';
+import { ensureDesktopWorkspace, initDesktopWorkspacePath } from '../desktop-workspace/paths.js';
 import { ensureSchedulerWorkspace } from '../scheduler-workspace/paths.js';
 import { ensureMinnowLayout, getMinnowHome } from '../config/home.js';
 import { initLspConfig } from '../lsp/middleware.js';
@@ -27,6 +27,7 @@ export async function bootstrapMinnowRuntime() {
   await ensureMinnowLayout();
   await ensureChatsWorkspace();
   await ensureDesktopWorkspace();
+  await initDesktopWorkspacePath();
   await ensureBenchmarkWorkspace();
   await ensureSchedulerWorkspace();
   await ensureAgentPacksLayout();

--- a/src/lib/desktop-workspace.ts
+++ b/src/lib/desktop-workspace.ts
@@ -1,5 +1,5 @@
 /**
- * Client helper for the ~/.minnow/workspace sandbox (MinnowOS desktop chat).
+ * Client helper for the desktop chat workspace (MinnowOS desktop surface).
  */
 
 import { normalizeWorkspacePath } from './normalize-workspace-path';
@@ -7,20 +7,28 @@ import { normalizeWorkspacePath } from './normalize-workspace-path';
 export interface DesktopWorkspaceInfo {
   ok?: boolean;
   path: string;
+  label?: string;
   fileCount: number;
   error?: string;
 }
 
 let cachedDesktopWorkspacePath: string | null = null;
+let cachedDesktopWorkspaceLabel: string | null = null;
 
 /** Clear cached desktop workspace path (tests or server restart). */
 export function resetDesktopWorkspacePathCache(): void {
   cachedDesktopWorkspacePath = null;
+  cachedDesktopWorkspaceLabel = null;
 }
 
 /** Cached absolute desktop workspace path from the last successful API fetch. */
 export function getCachedDesktopWorkspacePath(): string | null {
   return cachedDesktopWorkspacePath;
+}
+
+/** Cached folder label from the last successful API fetch. */
+export function getCachedDesktopWorkspaceLabel(): string | null {
+  return cachedDesktopWorkspaceLabel;
 }
 
 /** True when a chat or tool workspace path is the desktop sandbox. */
@@ -31,6 +39,16 @@ export function isDesktopWorkspacePath(
   const desktopPath = desktopWorkspacePath ?? cachedDesktopWorkspacePath;
   if (!desktopPath) return false;
   return normalizeWorkspacePath(workspacePath) === normalizeWorkspacePath(desktopPath);
+}
+
+function applyDesktopWorkspaceInfo(data: DesktopWorkspaceInfo): string | null {
+  if (!data?.path || typeof data.path !== 'string') return null;
+  cachedDesktopWorkspacePath = data.path;
+  cachedDesktopWorkspaceLabel =
+    typeof data.label === 'string' && data.label.trim()
+      ? data.label.trim()
+      : data.path.split(/[/\\]/).filter(Boolean).pop() ?? data.path;
+  return cachedDesktopWorkspacePath;
 }
 
 /**
@@ -46,9 +64,7 @@ export async function getDesktopWorkspacePath(): Promise<string | null> {
     const res = await fetch('/api/desktop-workspace', { cache: 'no-store' });
     if (!res.ok) return null;
     const data = (await res.json()) as DesktopWorkspaceInfo;
-    if (!data?.path || typeof data.path !== 'string') return null;
-    cachedDesktopWorkspacePath = data.path;
-    return cachedDesktopWorkspacePath;
+    return applyDesktopWorkspaceInfo(data);
   } catch {
     return null;
   }
@@ -60,13 +76,26 @@ export async function fetchDesktopWorkspaceInfo(): Promise<DesktopWorkspaceInfo 
     const res = await fetch('/api/desktop-workspace', { cache: 'no-store' });
     if (!res.ok) return null;
     const data = (await res.json()) as DesktopWorkspaceInfo;
-    if (data?.path && typeof data.path === 'string') {
-      cachedDesktopWorkspacePath = data.path;
-    }
+    applyDesktopWorkspaceInfo(data);
     return data;
   } catch {
     return null;
   }
+}
+
+/** Set the desktop chat workspace folder (validated on server). */
+export async function setDesktopWorkspacePath(absPath: string): Promise<DesktopWorkspaceInfo> {
+  const res = await fetch('/api/desktop-workspace', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path: absPath }),
+  });
+  const json = (await res.json()) as DesktopWorkspaceInfo & { error?: string };
+  if (!res.ok) {
+    throw new Error(json.error ?? `HTTP ${res.status}`);
+  }
+  applyDesktopWorkspaceInfo(json);
+  return json;
 }
 
 export interface DesktopWorkspaceListEntry {

--- a/src/os/desktop-workspace-rail.ts
+++ b/src/os/desktop-workspace-rail.ts
@@ -277,12 +277,30 @@ export function renderDesktopWorkspaceRail(root: HTMLElement): void {
   metaRow.className = 'mn-os-workspace-rail-drawer-hdr-meta';
   metaRow.hidden = true;
 
+  const metaTop = document.createElement('div');
+  metaTop.className = 'mn-os-workspace-rail-drawer-meta-top';
+
+  const workspaceSelect = document.createElement('select');
+  workspaceSelect.id = 'desktopWorkspaceSelect';
+  workspaceSelect.className = 'mn-os-workspace-rail-drawer-select';
+  workspaceSelect.setAttribute('aria-label', 'Desktop workspace folder');
+
+  const folderBtn = document.createElement('button');
+  folderBtn.type = 'button';
+  folderBtn.id = 'btnDesktopWorkspaceFolder';
+  folderBtn.className = 'mn-os-workspace-rail-drawer-folder-btn';
+  folderBtn.setAttribute('aria-label', 'Change workspace folder');
+  folderBtn.title = 'Change workspace folder';
+  folderBtn.appendChild(createOsIcon('folder', { size: 14 }));
+
+  metaTop.append(workspaceSelect, folderBtn);
+
   const drawerPath = document.createElement('span');
   drawerPath.id = 'desktopWorkspaceDrawerPath';
   drawerPath.className = 'mn-os-workspace-rail-drawer-path';
   drawerPath.textContent = '~/.minnow/workspace';
 
-  metaRow.appendChild(drawerPath);
+  metaRow.append(metaTop, drawerPath);
   drawerHeader.append(headerTop, metaRow);
 
   const drawerBody = document.createElement('div');
@@ -387,7 +405,7 @@ export function wireDesktopWorkspaceRail(): void {
   });
 
   syncRailChrome();
-  void refreshDesktopWorkspaceDrawerPath();
+  void import('../ui/desktop-workspace-folder').then((m) => m.initDesktopWorkspaceFolderControls());
   void syncDesktopWorkspaceMounts();
 }
 
@@ -397,7 +415,16 @@ export async function refreshDesktopWorkspaceDrawerPath(): Promise<void> {
   if (!el) return;
   const { getDesktopWorkspacePath } = await import('../lib/desktop-workspace');
   const path = await getDesktopWorkspacePath();
-  if (path) el.textContent = path;
+  if (path) {
+    el.textContent = path;
+    el.title = path;
+  }
+  const { refreshDesktopWorkspaceFolderUi, refreshDesktopWorkspaceSelect } = await import(
+    '../ui/desktop-workspace-folder'
+  );
+  refreshDesktopWorkspaceFolderUi();
+  const select = document.getElementById('desktopWorkspaceSelect') as HTMLSelectElement | null;
+  await refreshDesktopWorkspaceSelect(select);
 }
 
 /** Reset rail bindings (tests). */

--- a/src/styles/desktop-workspace-rail.css
+++ b/src/styles/desktop-workspace-rail.css
@@ -215,6 +215,48 @@
 
 .mn-os-workspace-rail-drawer-hdr-meta {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mn-os-workspace-rail-drawer-meta-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.mn-os-workspace-rail-drawer-select {
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+  font-size: 0.75rem;
+  font-family: var(--mn-font-mono, ui-monospace, monospace);
+  color: var(--os-text);
+  background: var(--os-surface-2, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--os-border, rgba(255, 255, 255, 0.08));
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+
+.mn-os-workspace-rail-drawer-folder-btn {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid var(--os-border, rgba(255, 255, 255, 0.08));
+  background: var(--os-surface-2, rgba(255, 255, 255, 0.04));
+  color: var(--os-text-dim);
+  cursor: pointer;
+}
+
+.mn-os-workspace-rail-drawer-folder-btn:hover {
+  color: var(--os-text);
+  background: var(--os-surface-3, rgba(255, 255, 255, 0.08));
 }
 
 .mn-os-workspace-rail-drawer-path {

--- a/src/tools/result-cache.ts
+++ b/src/tools/result-cache.ts
@@ -12,6 +12,8 @@ import { getCachePolicyForTool, type ToolCachePolicy } from './tool-cache-policy
 /** Minimal executeTool context for cache scoping (avoids circular import with client.ts). */
 export interface ToolCacheContext {
   chatId?: string;
+  /** Override workspace root (desktop drawer, chats sandbox, worktree listing). */
+  workspaceRoot?: string;
 }
 
 /** Workspace root reader (bound at app init to avoid importing workspace state in tests). */
@@ -255,7 +257,9 @@ export function buildCacheKey(name: string, normalizedArgs: Record<string, unkno
 
 /** Scope id: normalized workspace path + chat id (or __no_chat__). */
 export function getCacheScope(context: ToolCacheContext): string {
-  const workspace = normalizeWorkspacePath(readWorkspacePathForCache());
+  const workspace = normalizeWorkspacePath(
+    context.workspaceRoot?.trim() || readWorkspacePathForCache(),
+  );
   const chat = context.chatId?.trim() || '__no_chat__';
   return `${workspace}:${chat}`;
 }

--- a/src/ui/desktop-workspace-folder.ts
+++ b/src/ui/desktop-workspace-folder.ts
@@ -1,0 +1,176 @@
+/**
+ * Desktop chat workspace folder switch — picker, MRU, and UI refresh.
+ */
+
+import { fetchWorkspace } from '../config/workspace-api';
+import {
+  getCachedDesktopWorkspaceLabel,
+  getCachedDesktopWorkspacePath,
+  getDesktopWorkspacePath,
+  resetDesktopWorkspacePathCache,
+  setDesktopWorkspacePath,
+} from '../lib/desktop-workspace';
+import { activateDesktopAssistantChatForApp } from '../state/sessions';
+import { getLocalServerAvailable } from '../tools/client';
+import { clearCachesForWorkspace } from '../tools/result-cache';
+import { openWorkspaceFolderPicker } from './workspace-folder-picker';
+import { setStatus } from './status';
+import { renderDesktopChatMessages } from '../os/desktop-chat';
+import { renderDesktopChatRail } from './desktop-chat-rail';
+import { refreshDesktopWorkspaceDrawerPath } from '../os/desktop-workspace-rail';
+import { syncDesktopWorkspaceMounts } from '../os/desktop-workspace-mounts';
+import { clearPanelCwdUserOverride, syncPanelFromActiveChat } from './git-panel';
+import { refreshContextUsageRing } from './context-usage-ring';
+import { syncChatItemDotsInDom } from './chat-item-dot';
+import { syncComposerFromStreamingState } from './composer-send';
+
+/** Update drawer path label and button chrome after a switch. */
+export function refreshDesktopWorkspaceFolderUi(): void {
+  const path = getCachedDesktopWorkspacePath();
+  const label = getCachedDesktopWorkspaceLabel();
+  const pathEl = document.getElementById('desktopWorkspaceDrawerPath');
+  if (pathEl && path) {
+    pathEl.textContent = path;
+    pathEl.title = path;
+  }
+  const btn = document.getElementById('btnDesktopWorkspaceFolder');
+  if (btn && path) {
+    const short = label?.trim() || 'Workspace';
+    btn.title = `Workspace: ${path}`;
+    btn.setAttribute('aria-label', `Workspace: ${short}. Click to change folder.`);
+  }
+}
+
+/** Shared refresh after PUT or folder picker — sessions, file tree, drawer label. */
+export async function applyDesktopWorkspaceSwitch(
+  info: { path: string; label?: string },
+  previousPath?: string,
+): Promise<void> {
+  const prev = previousPath?.trim() || getCachedDesktopWorkspacePath() || '';
+  clearCachesForWorkspace(prev);
+  const { renderChatFromHistory } = await import('./messages');
+  const { getActiveChat } = await import('../state/sessions');
+  const chat = activateDesktopAssistantChatForApp(info.path);
+  renderDesktopChatRail(info.path);
+  renderDesktopChatMessages();
+  renderChatFromHistory(chat);
+  clearPanelCwdUserOverride();
+  syncPanelFromActiveChat({ forceFileTree: true });
+  await syncDesktopWorkspaceMounts();
+  syncComposerFromStreamingState();
+  syncChatItemDotsInDom();
+  refreshContextUsageRing();
+  refreshDesktopWorkspaceFolderUi();
+  void import('../tools/stream-chat-dom').then((m) =>
+    m.remountStreamDomForChat(getActiveChat().id),
+  );
+  const short = info.label?.trim() || info.path.split(/[/\\]/).filter(Boolean).pop() || info.path;
+  setStatus('ok', `Desktop workspace: ${short}`);
+}
+
+/** Set desktop workspace by absolute path (server-validated). */
+export async function executeDesktopWorkspaceSwitch(
+  absPath: string,
+): Promise<{ path: string; label?: string } | null> {
+  const previousPath = await getDesktopWorkspacePath();
+  const info = await setDesktopWorkspacePath(absPath);
+  await applyDesktopWorkspaceSwitch(info, previousPath ?? undefined);
+  return info;
+}
+
+async function onOpenDesktopWorkspaceFolder(): Promise<void> {
+  if (!getLocalServerAvailable()) {
+    setStatus('err', 'Workspace requires npm start (local server)');
+    return;
+  }
+
+  setStatus('spin', 'Choose workspace folder…');
+  try {
+    const initialPath = (await getDesktopWorkspacePath()) || undefined;
+    const result = await openWorkspaceFolderPicker({ initialPath });
+    if (result.cancelled) {
+      setStatus('ok', 'Workspace unchanged');
+      return;
+    }
+    if (!result.path) {
+      setStatus('err', 'No folder selected');
+      return;
+    }
+
+    await executeDesktopWorkspaceSwitch(result.path);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    setStatus('err', message);
+  }
+}
+
+/** Populate the desktop workspace MRU <select> from server workspace list. */
+export async function refreshDesktopWorkspaceSelect(
+  select: HTMLSelectElement | null,
+): Promise<void> {
+  if (!select) return;
+  const currentPath = (await getDesktopWorkspacePath()) ?? '';
+  const info = await fetchWorkspace();
+  const recent = info?.recent?.filter((item) => item.exists) ?? [];
+  const selectedPath = select.value?.trim() || currentPath;
+  select.replaceChildren();
+
+  const paths = new Map<string, string>();
+  if (currentPath) {
+    paths.set(currentPath, getCachedDesktopWorkspaceLabel() ?? currentPath);
+  }
+  for (const item of recent) {
+    paths.set(item.path, item.label);
+  }
+  if (selectedPath && !paths.has(selectedPath)) {
+    paths.set(selectedPath, selectedPath.split(/[/\\]/).filter(Boolean).pop() ?? selectedPath);
+  }
+
+  for (const [path, label] of paths) {
+    const opt = document.createElement('option');
+    opt.value = path;
+    opt.textContent = label;
+    if (path === currentPath) {
+      opt.selected = true;
+    }
+    select.appendChild(opt);
+  }
+  if (selectedPath) {
+    select.value = selectedPath;
+  }
+}
+
+/** Wire desktop workspace folder controls in the workspace drawer. */
+export function initDesktopWorkspaceFolderControls(): void {
+  const browseBtn = document.getElementById('btnDesktopWorkspaceFolder');
+  if (browseBtn && browseBtn.dataset.bound !== '1') {
+    browseBtn.dataset.bound = '1';
+    browseBtn.addEventListener('click', () => {
+      void onOpenDesktopWorkspaceFolder();
+    });
+  }
+
+  const select = document.getElementById(
+    'desktopWorkspaceSelect',
+  ) as HTMLSelectElement | null;
+  if (select && select.dataset.bound !== '1') {
+    select.dataset.bound = '1';
+    select.addEventListener('change', () => {
+      const next = select.value?.trim();
+      if (!next) return;
+      void executeDesktopWorkspaceSwitch(next).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setStatus('err', message);
+      });
+    });
+    void refreshDesktopWorkspaceSelect(select);
+  }
+
+  void refreshDesktopWorkspaceDrawerPath();
+  refreshDesktopWorkspaceFolderUi();
+}
+
+/** Test helper — reset cached path before re-fetching. */
+export function resetDesktopWorkspaceSwitchForTests(): void {
+  resetDesktopWorkspacePathCache();
+}

--- a/src/ui/file-tree.ts
+++ b/src/ui/file-tree.ts
@@ -232,14 +232,47 @@ export function invalidateFileTreeCache(): void {
   }
 }
 
+/** Reload the file tree after the effective listing root changes. */
+async function refreshFileTreeForListingRootChange(
+  nextRoot: string | undefined,
+  prevRoot: string | undefined,
+): Promise<void> {
+  invalidateListingCacheScopes(prevRoot, nextRoot, getWorkspacePath().trim() || undefined);
+  setFileTreeListingWorkspaceRoot(nextRoot);
+
+  patchFilePanelState({
+    expandedDirs: [],
+    selectedPath: null,
+    openViewerTabs: [],
+    activeViewerTab: null,
+  });
+
+  const { closeFileViewerForce } = await import('./file-viewer');
+  closeFileViewerForce();
+
+  listingCache.clear();
+  invalidateFileTreeIndex();
+
+  await refreshFileTree();
+}
+
 /** Sync file tree listing root with git panel worktree cwd; reload when root changes. */
 export async function syncFileTreeToPanelWorktree(
   panelCwd?: string,
   options?: { force?: boolean },
 ): Promise<void> {
-  // Desktop drawer scopes the tree to ~/.minnow/workspace — ignore Code git-panel cwd.
+  // Desktop drawer scopes the tree to the selected desktop workspace folder.
   if (isDesktopWorkspaceHostingActive()) {
-    startFileTreeGitStatusPoll(getFileTreeListingWorkspaceRoot());
+    const { getDesktopWorkspacePath } = await import('../lib/desktop-workspace');
+    const desktopPath = await getDesktopWorkspacePath();
+    const nextRoot = desktopPath ?? undefined;
+    const prevRoot = getFileTreeListingWorkspaceRoot();
+
+    if (!fileTreeListingRootsEqual(prevRoot, nextRoot) || options?.force) {
+      await refreshFileTreeForListingRootChange(nextRoot, prevRoot);
+    }
+
+    startFileTreeGitStatusPoll(nextRoot ?? getFileTreeListingWorkspaceRoot());
     syncFileSidebarTitleFromFileTree();
     return;
   }
@@ -248,23 +281,7 @@ export async function syncFileTreeToPanelWorktree(
   const prevRoot = getFileTreeListingWorkspaceRoot();
 
   if (!fileTreeListingRootsEqual(prevRoot, nextRoot) || options?.force) {
-    invalidateListingCacheScopes(prevRoot, nextRoot, getWorkspacePath().trim() || undefined);
-    setFileTreeListingWorkspaceRoot(nextRoot);
-
-    patchFilePanelState({
-      expandedDirs: [],
-      selectedPath: null,
-      openViewerTabs: [],
-      activeViewerTab: null,
-    });
-
-    const { closeFileViewerForce } = await import('./file-viewer');
-    closeFileViewerForce();
-
-    listingCache.clear();
-    invalidateFileTreeIndex();
-
-    await refreshFileTree();
+    await refreshFileTreeForListingRootChange(nextRoot, prevRoot);
   }
 
   startFileTreeGitStatusPoll(nextRoot ?? getWorkspacePath());

--- a/test/desktop-workspace/api.test.mjs
+++ b/test/desktop-workspace/api.test.mjs
@@ -11,6 +11,9 @@ import { handleDesktopWorkspaceRequest } from '../../server/desktop-workspace/ro
 import {
   ensureDesktopWorkspace,
   getDesktopWorkspacePath,
+  initDesktopWorkspacePath,
+  resetDesktopWorkspacePathForTests,
+  setDesktopWorkspacePath,
 } from '../../server/desktop-workspace/paths.js';
 import { isAllowedWorkspaceRoot } from '../../server/chats-workspace/paths.js';
 import { ensureMinnowLayout } from '../../server/config/home.js';
@@ -28,10 +31,16 @@ function createDesktopTestServer() {
   });
 }
 
-function httpRequest(baseUrl, method, pathname) {
+function httpRequest(baseUrl, method, pathname, body) {
   return new Promise((resolve, reject) => {
     const url = new URL(pathname, baseUrl);
-    const req = http.request(url, { method }, (res) => {
+    const req = http.request(
+      url,
+      {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      },
+      (res) => {
       const chunks = [];
       res.on('data', (c) => chunks.push(c));
       res.on('end', () => {
@@ -44,8 +53,12 @@ function httpRequest(baseUrl, method, pathname) {
         }
         resolve({ status: res.statusCode, json, text, headers: res.headers });
       });
-    });
+    },
+    );
     req.on('error', reject);
+    if (body) {
+      req.write(JSON.stringify(body));
+    }
     req.end();
   });
 }
@@ -57,8 +70,10 @@ describe('desktop workspace API', () => {
 
   before(async () => {
     homeDir = setTestHome(process.env, 'minnow-test-desktop-workspace');
+    resetDesktopWorkspacePathForTests();
     await ensureMinnowLayout();
     await ensureDesktopWorkspace();
+    await initDesktopWorkspacePath();
 
     const desktopRoot = getDesktopWorkspacePath();
     await fs.writeFile(path.join(desktopRoot, 'note.txt'), 'hello desktop\n', 'utf8');
@@ -71,6 +86,7 @@ describe('desktop workspace API', () => {
 
   after(async () => {
     await new Promise((resolve) => server.close(resolve));
+    resetDesktopWorkspacePathForTests();
     await rmTestHome(homeDir);
   });
 
@@ -84,5 +100,27 @@ describe('desktop workspace API', () => {
 
   it('desktop workspace path is in tool workspaceRoot allowlist', () => {
     assert.equal(isAllowedWorkspaceRoot(getDesktopWorkspacePath()), true);
+  });
+
+  it('PUT /api/desktop-workspace changes the active desktop workspace path', async () => {
+    const customDir = path.join(homeDir, 'custom-desktop-ws');
+    await fs.mkdir(customDir, { recursive: true });
+
+    const { status, json } = await httpRequest(baseUrl, 'PUT', '/api/desktop-workspace', {
+      path: customDir,
+    });
+    assert.equal(status, 200);
+    assert.equal(json.ok, true);
+    assert.equal(json.path, customDir);
+    assert.equal(getDesktopWorkspacePath(), customDir);
+    assert.equal(isAllowedWorkspaceRoot(customDir), true);
+
+    const { readConfigJson } = await import('../../server/config/store.js');
+    const config = await readConfigJson('config.json');
+    assert.equal(config?.desktopWorkspace?.path, customDir);
+
+    resetDesktopWorkspacePathForTests();
+    await initDesktopWorkspacePath();
+    assert.equal(getDesktopWorkspacePath(), customDir);
   });
 });

--- a/test/file/file-tree-worktree-sync.test.mts
+++ b/test/file/file-tree-worktree-sync.test.mts
@@ -230,6 +230,47 @@ describe('syncFileTreeToPanelWorktree', () => {
     ]);
     assert.equal(getFilePanelState().activePreviewTab, 'tab-1');
   });
+
+  test('desktop workspace switch updates listing root and resets panel state', async () => {
+    setupDom();
+    const DESKTOP_A = 'C:/Users/me/.minnow/workspace';
+    const DESKTOP_B = 'C:/projects/minnow';
+    setWorkspaceFromServer({ path: MAIN_WS, label: 'minnow', isDefault: false });
+    setFileTreeListingWorkspaceRoot(DESKTOP_A);
+    setFileTreeServerAvailable(false);
+    patchFilePanelState({
+      expandedDirs: ['docs'],
+      selectedPath: 'docs/readme.md',
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('/api/desktop-workspace')) {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, path: DESKTOP_B, fileCount: 0 }),
+        } as Response;
+      }
+      return originalFetch(input);
+    }) as typeof fetch;
+
+    const { resetDesktopWorkspacePathCache, setDesktopWorkspacePath } = await import(
+      '../../src/lib/desktop-workspace.ts'
+    );
+    resetDesktopWorkspacePathCache();
+    await setDesktopWorkspacePath(DESKTOP_B);
+
+    const { syncFileTreeToPanelWorktree } = await import('../../src/ui/file-tree.ts');
+    await syncFileTreeToPanelWorktree(undefined, { force: true });
+
+    assert.equal(buildFileTreeToolContext().workspaceRoot, DESKTOP_B);
+    assert.deepEqual(getFilePanelState().expandedDirs, []);
+    assert.equal(getFilePanelState().selectedPath, null);
+
+    globalThis.fetch = originalFetch;
+    resetDesktopWorkspacePathCache();
+  });
 });
 
 describe('file tree tool context merge', () => {

--- a/test/tools/result-cache.test.mts
+++ b/test/tools/result-cache.test.mts
@@ -248,6 +248,36 @@ describe('TTL and scope clear', () => {
   });
 });
 
+describe('getCacheScope workspaceRoot override', () => {
+  test('scopes list_directory separately per workspaceRoot', async () => {
+    bindWorkspacePathForToolCache(() => '/code-workspace');
+    let calls = 0;
+    const inner = async () => {
+      calls += 1;
+      return { content: `listing-${calls}` };
+    };
+    const args = { path: '.' };
+
+    const scopeA = getCacheScope({ workspaceRoot: '/desktop/a' });
+    const scopeB = getCacheScope({ workspaceRoot: '/desktop/b' });
+    assert.notEqual(scopeA, scopeB);
+
+    const rA1 = await executeWithResultCache('list_directory', args, { workspaceRoot: '/desktop/a' }, inner);
+    const rB1 = await executeWithResultCache('list_directory', args, { workspaceRoot: '/desktop/b' }, inner);
+    const rA2 = await executeWithResultCache('list_directory', args, { workspaceRoot: '/desktop/a' }, inner);
+
+    assert.equal(calls, 2);
+    assert.equal(rA1.content, 'listing-1');
+    assert.equal(rB1.content, 'listing-2');
+    assert.equal(rA2.content, 'listing-1');
+  });
+
+  test('falls back to bound workspace when workspaceRoot is omitted', () => {
+    bindWorkspacePathForToolCache(() => '/code-workspace');
+    assert.equal(getCacheScope({}), '/code-workspace:__no_chat__');
+  });
+});
+
 describe('changedPathAffectsDirectoryListing', () => {
   test('parent listing invalidates when child file changes', () => {
     assert.equal(changedPathAffectsDirectoryListing('src', 'src/foo.ts'), true);

--- a/test/ui/desktop-workspace-folder.test.mts
+++ b/test/ui/desktop-workspace-folder.test.mts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { resetDesktopWorkspacePathCache } from '../../src/lib/desktop-workspace.ts';
+import {
+  refreshDesktopWorkspaceFolderUi,
+  resetDesktopWorkspaceSwitchForTests,
+} from '../../src/ui/desktop-workspace-folder.ts';
+import { setSessionStateForTests, createEmptyChatObject } from '../../src/state/sessions.ts';
+
+const DESKTOP_WS = '/home/user/.minnow/workspace';
+const PROJECT_WS = '/home/user/myproject';
+
+describe('desktop-workspace-folder', () => {
+  beforeEach(async () => {
+    resetDesktopWorkspaceSwitchForTests();
+    const { Window } = await import('happy-dom');
+    const win = new Window();
+    const g = globalThis as typeof globalThis & {
+      window: Window;
+      document: Document;
+      HTMLElement: typeof HTMLElement;
+    };
+    g.window = win as unknown as Window & typeof globalThis.window;
+    g.document = win.document;
+    g.HTMLElement = win.HTMLElement;
+
+    win.document.body.innerHTML = `
+      <span id="desktopWorkspaceDrawerPath"></span>
+      <button type="button" id="btnDesktopWorkspaceFolder"></button>
+      <select id="desktopWorkspaceSelect"></select>
+      <div id="desktopChatCol"></div>
+      <div id="desktopChatSessionList"></div>
+    `;
+
+    const { resetDesktopWorkspacePathCache: resetCache } = await import(
+      '../../src/lib/desktop-workspace.ts'
+    );
+    resetCache();
+
+    const { setDesktopWorkspacePath } = await import('../../src/lib/desktop-workspace.ts');
+    // Prime cache via mocked fetch in apply test; label helper uses cache only here.
+    const mod = await import('../../src/lib/desktop-workspace.ts');
+    void mod;
+  });
+
+  afterEach(() => {
+    setSessionStateForTests(null);
+    resetDesktopWorkspaceSwitchForTests();
+  });
+
+  test('refreshDesktopWorkspaceFolderUi updates path label and button', async () => {
+    const { fetchDesktopWorkspaceInfo } = await import('../../src/lib/desktop-workspace.ts');
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      if (String(url).includes('/api/desktop-workspace')) {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            path: PROJECT_WS,
+            label: 'myproject',
+            fileCount: 1,
+          }),
+        } as Response;
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    await fetchDesktopWorkspaceInfo();
+    refreshDesktopWorkspaceFolderUi();
+
+    const pathEl = document.getElementById('desktopWorkspaceDrawerPath');
+    assert.equal(pathEl?.textContent, PROJECT_WS);
+    assert.equal(pathEl?.title, PROJECT_WS);
+
+    const btn = document.getElementById('btnDesktopWorkspaceFolder');
+    assert.match(btn?.getAttribute('aria-label') ?? '', /myproject/);
+
+    globalThis.fetch = originalFetch;
+    resetDesktopWorkspacePathCache();
+  });
+
+  test('activateDesktopAssistantChatForApp restores remembered chat for workspace', async () => {
+    setSessionStateForTests({
+      version: 5,
+      activeId: 'old-chat',
+      sidebarCollapsed: false,
+      lastActiveChatIdByWorkspace: { [PROJECT_WS]: 'project-chat' },
+      lastActiveChatIdByApp: { desktop: 'project-chat' },
+      chats: [
+        {
+          ...createEmptyChatObject('model-a'),
+          id: 'old-chat',
+          name: 'Sandbox chat',
+          workspacePath: DESKTOP_WS,
+          modeId: 'desktop',
+          history: [{ role: 'user', content: 'sandbox' }],
+        },
+        {
+          ...createEmptyChatObject('model-a'),
+          id: 'project-chat',
+          name: 'Project chat',
+          workspacePath: PROJECT_WS,
+          modeId: 'desktop',
+          history: [{ role: 'user', content: 'project work' }],
+        },
+      ],
+    });
+
+    const { activateDesktopAssistantChatForApp, getActiveChat } = await import(
+      '../../src/state/sessions.ts'
+    );
+    activateDesktopAssistantChatForApp(PROJECT_WS);
+    assert.equal(getActiveChat().id, 'project-chat');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **MIN-430** by letting users change the workspace folder used by MinnowOS desktop chat.

Previously, desktop chat was fixed to `~/.minnow/workspace`. This adds a configurable desktop workspace path with UI in the desktop **Files** drawer.

## Changes

- **Server:** Persist `desktopWorkspace.path` in `config.json`; add `PUT /api/desktop-workspace` to set the active folder; load path on bootstrap via `initDesktopWorkspacePath()`.
- **Client:** New `desktop-workspace-folder` module handles MRU select, folder picker, and post-switch refresh (chat rail, file tree, tools, drawer label).
- **UI:** Desktop workspace drawer header now shows an MRU dropdown and folder button next to the path.
- **Tests:** API coverage for PUT + persistence; UI unit tests for label refresh and session restore.

## How to verify

1. `npm start` and open desktop chat.
2. Open the right-edge **Files** drawer.
3. Use the workspace dropdown or folder button to pick a different directory.
4. Confirm the path label updates, file tree lists the new folder, and desktop chat sessions switch per workspace.

## Notes

- Default remains `~/.minnow/workspace` when no custom path is saved.
- Selected folders are added to the shared workspace MRU list.
- Tool `workspaceRoot` allowlist automatically includes the active desktop workspace path.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-430](https://linear.app/minnowai/issue/MIN-430/20-add-the-ability-to-change-workspace-folders-in-the-desktop-chat)

<div><a href="https://cursor.com/agents/bc-31e4863e-1b58-452c-a11d-1eba98f00931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31e4863e-1b58-452c-a11d-1eba98f00931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

