### PR TITLE
🐛 Fix orchestrator queue jump during merge/fixer windows (MIN-409)

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -288,6 +288,8 @@ State: `Chat.orchestratePlanPath`, `ChatGroup.orchestrateBoard`, [`src/ui/orches
 
 **Board view browse root (MIN-464):** When board view is active and worktree isolation is on, the file explorer, terminal, and Source Control browse cwd follow the board **integration worktree** (not per-task chat worktrees). Chat view continues to sync browse cwd from the active chat's composer run-target. Helpers: [`resolveBoardIntegrationWorktreePath`](../src/state/worktree-isolation.ts), [`syncPanelFromActiveChat`](../src/ui/git-panel.ts).
 
+**Pipeline holds (MIN-409):** Non-streaming merge/fixer phases occupy a concurrency slot via ref-counted holds in [`src/state/orchestrate-pipeline-holds.ts`](../src/state/orchestrate-pipeline-holds.ts) (WeakMap keyed by board object identity; TTL-on-read + sweep). `countRunningTaskChats` counts chat slots plus hold-only tasks; `isTaskStalledForRestart` treats held tasks as not stalled. The running-tasks strip shows a non-interactive **Merging** chip for hold-only slots. Sequential → AFK pins `maxConcurrentTasks` to 1 when unset (`setBoardExecutionMode`).
+
 ### Experts
 
 Personas under `src/chat/prompts/experts/<id>/`. Chats: `Chat.kind === 'expert'`, memory under `pages/experts/<id>/facts/`. UI: Experts' Lab on desktop + `#/experts`.

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -63,6 +63,17 @@ import {
 import { emitBoardChange } from './orchestrate-board-events.ts';
 import { isTaskReadyForAuto, isTaskStalledForRestart, isBoardAutoMode, isBoardRunning, getBoardExecutionMode, syncOrchestrateBoardTimer, updateTask, logTaskStatus, logBoardReportNudge, logBuildVerdict, logTestVerdict, logMergeResult, logWorktreeAllocated, logTaskRetry, logModeChange, logAutoStart, logAutoStop, logFinalTestStarted, logFinalTestVerdict, quarantineTaskAndDependents } from './orchestrate-board-store.ts';
 import {
+  acquirePipelineHold,
+  heldTaskIdsForOccupancy,
+  hasPipelineHold,
+  listPipelineHolds,
+  releaseAllPipelineHolds,
+  releasePipelineHold,
+  releasePipelineHoldsForTask,
+  setPipelineHoldMaxMsForTests,
+  sweepExpiredPipelineHolds,
+} from './orchestrate-pipeline-holds.ts';
+import {
   isIsolationActive,
   resolveIsolationMode,
   worktreeBranchFor,
@@ -1250,14 +1261,14 @@ function skipBackgroundBoardChatLaunch(): boolean {
   );
 }
 
-/** Phase label for a running board task slot (build / test / fix / final integration). */
-export type RunningBoardTaskPhase = 'build' | 'test' | 'fix' | 'final';
+/** Phase label for a running board task slot (build / test / fix / merge / final integration). */
+export type RunningBoardTaskPhase = 'build' | 'test' | 'fix' | 'merge' | 'final';
 
-/** One concurrency slot occupied by a streaming or launching task chat. */
+/** One concurrency slot occupied by a streaming or launching task chat, or a pipeline hold. */
 export interface RunningBoardTaskSlot {
   taskId: string;
   title: string;
-  chatId: string;
+  chatId?: string;
   phase: RunningBoardTaskPhase;
   task?: BoardTask;
   isFinalTest?: boolean;
@@ -1273,15 +1284,40 @@ function runningSlotPhaseForTask(
   return 'build';
 }
 
-/** Running task / tester / final-integration chats occupying a concurrency slot. */
+/** Running task / tester / final-integration chats plus pipeline holds occupying a slot. */
 export function countRunningTaskChats(
   board: NonNullable<ChatGroup['orchestrateBoard']>,
 ): number {
-  return listRunningBoardTaskSlots(board).length;
+  const slots = listChatRunningBoardTaskSlots(board);
+  const withChat = new Set(slots.map((s) => s.taskId));
+  let holds = 0;
+  for (const taskId of heldTaskIdsForOccupancy(board)) {
+    if (!withChat.has(taskId)) holds += 1;
+  }
+  return slots.length + holds;
 }
 
 /** Enumerate active board task chats (build, test, fixer, final integration). */
 export function listRunningBoardTaskSlots(
+  board: NonNullable<ChatGroup['orchestrateBoard']>,
+): RunningBoardTaskSlot[] {
+  const slots = listChatRunningBoardTaskSlots(board);
+  const withChatTaskIds = new Set(slots.map((s) => s.taskId));
+  for (const hold of listPipelineHolds(board)) {
+    if (withChatTaskIds.has(hold.taskId)) continue;
+    const task = board.tasks.find((t) => t.id === hold.taskId);
+    slots.push({
+      taskId: hold.taskId,
+      title: task?.title ?? hold.taskId,
+      phase: 'merge',
+      task,
+    });
+    withChatTaskIds.add(hold.taskId);
+  }
+  return slots;
+}
+
+function listChatRunningBoardTaskSlots(
   board: NonNullable<ChatGroup['orchestrateBoard']>,
 ): RunningBoardTaskSlot[] {
   const seen = new Set<string>();
@@ -1354,10 +1390,11 @@ export function isTaskChatActiveForStallCheck(chatId: string): boolean {
   return isTaskChatActive(chatId);
 }
 
-/** Running slots minus one reserved-only chat that must not block its own launch. */
+/** Running slots minus one reserved-only chat and one self-hold that must not block launch. */
 function effectiveRunningTaskCount(
   board: NonNullable<ChatGroup['orchestrateBoard']>,
   excludeReservedOnlyChatId?: string,
+  excludeHoldTaskId?: string,
 ): number {
   let count = countRunningTaskChats(board);
   const exclude = excludeReservedOnlyChatId?.trim();
@@ -1369,6 +1406,15 @@ function effectiveRunningTaskCount(
   ) {
     count = Math.max(0, count - 1);
   }
+  const excludeHold = excludeHoldTaskId?.trim();
+  if (excludeHold && hasPipelineHold(board, excludeHold)) {
+    const withChat = new Set(
+      listChatRunningBoardTaskSlots(board).map((s) => s.taskId),
+    );
+    if (!withChat.has(excludeHold)) {
+      count = Math.max(0, count - 1);
+    }
+  }
   return count;
 }
 
@@ -1379,7 +1425,7 @@ function canLaunchBoardTask(
 ): boolean {
   const exclude =
     task?.status === 'testing' ? task.testChatId?.trim() : undefined;
-  return effectiveRunningTaskCount(board, exclude) < maxConcurrent(board);
+  return effectiveRunningTaskCount(board, exclude, task?.id) < maxConcurrent(board);
 }
 
 /** Release a leaked launch reservation on a task test chat before early return. */
@@ -1753,6 +1799,7 @@ export async function recoverMergingBoardTask(
     stopGeneration(fixerId);
     releaseLaunchSlot(fixerId);
   }
+  releasePipelineHoldsForTask(board, taskId);
 
   await reconcileMergingTasks(group, plannerChat);
   emitBoardChange(group.id);
@@ -1766,51 +1813,56 @@ async function restartStallNudgeFallback(
   priorError?: string,
   stalledChatId?: string,
 ): Promise<void> {
-  const stalled = stalledChatId?.trim();
-  if (!stalled || stalled === task.chatId?.trim()) {
-    await startTask(group, task.id, plannerChat);
-    return;
-  }
-  if (
-    stalled === task.testChatId?.trim() ||
-    group.orchestrateBoard?.finalTest?.chatId?.trim() === stalled
-  ) {
-    await startTaskTesting(group, task.id, plannerChat);
-    return;
-  }
-  if (stalled === task.fixerChatId?.trim()) {
-    if (task.status === 'merging') {
-      const branch = task.worktreeBranch?.trim();
-      const board = group.orchestrateBoard;
-      if (branch && board?.integrationBranch) {
-        await startMergeConflictFixer(group, task, plannerChat, [], task.mergePreSha);
+  const hold = acquirePipelineHold(group.orchestrateBoard, task.id, 'merge');
+  try {
+    const stalled = stalledChatId?.trim();
+    if (!stalled || stalled === task.chatId?.trim()) {
+      await startTask(group, task.id, plannerChat);
+      return;
+    }
+    if (
+      stalled === task.testChatId?.trim() ||
+      group.orchestrateBoard?.finalTest?.chatId?.trim() === stalled
+    ) {
+      await startTaskTesting(group, task.id, plannerChat);
+      return;
+    }
+    if (stalled === task.fixerChatId?.trim()) {
+      if (task.status === 'merging') {
+        const branch = task.worktreeBranch?.trim();
+        const board = group.orchestrateBoard;
+        if (branch && board?.integrationBranch) {
+          await startMergeConflictFixer(group, task, plannerChat, [], task.mergePreSha);
+          return;
+        }
+        quarantineTaskAndDependents(
+          group,
+          task.id,
+          {
+            category: 'merge',
+            summary: priorError || 'Merge fixer chat missing and merge context invalid',
+            resolutionSteps: ['inspect merge state, then Requeue'],
+            at: Date.now(),
+          },
+          plannerChat,
+        );
         return;
       }
-      quarantineTaskAndDependents(
-        group,
-        task.id,
-        {
-          category: 'merge',
-          summary: priorError || 'Merge fixer chat missing and merge context invalid',
-          resolutionSteps: ['inspect merge state, then Requeue'],
-          at: Date.now(),
-        },
-        plannerChat,
-      );
-      return;
+      if (task.fixerKind === 'env') {
+        await startEnvFixer(
+          group,
+          task,
+          plannerChat,
+          task.envFixPhase ?? 'build',
+          priorError || 'Environment fixer stalled',
+        );
+        return;
+      }
     }
-    if (task.fixerKind === 'env') {
-      await startEnvFixer(
-        group,
-        task,
-        plannerChat,
-        task.envFixPhase ?? 'build',
-        priorError || 'Environment fixer stalled',
-      );
-      return;
-    }
+    await startTask(group, task.id, plannerChat);
+  } finally {
+    releasePipelineHold(hold);
   }
-  await startTask(group, task.id, plannerChat);
 }
 
 /** Run a continue nudge on an existing task chat (no original-prompt reseed). */
@@ -2011,6 +2063,12 @@ export async function stopRunningBoardSlot(
 async function drainTaskQueue(group: ChatGroup, plannerChat: Chat): Promise<void> {
   const board = group.orchestrateBoard;
   if (!board) return;
+  for (const taskId of sweepExpiredPipelineHolds(board)) {
+    reportBackgroundError(
+      'pipeline-hold-expired',
+      new Error(`Pipeline hold expired for task ${taskId}`),
+    );
+  }
   if (drainInFlightByGroupId.has(group.id)) return;
   drainInFlightByGroupId.add(group.id);
   try {
@@ -2329,6 +2387,8 @@ export async function startMergeConflictFixer(
   const board = group.orchestrateBoard;
   if (!board?.integrationBranch) return;
 
+  const hold = acquirePipelineHold(board, task.id, 'merge-fixer-start');
+  try {
   const boardId = group.id;
 
   const ensured = await ensureIntegrationWorktree({
@@ -2473,6 +2533,9 @@ export async function startMergeConflictFixer(
     releaseLaunchSlotAndDrive(group, plannerChat, fixerChat.id);
     throw err;
   }
+  } finally {
+    releasePipelineHold(hold);
+  }
 }
 
 /**
@@ -2507,6 +2570,7 @@ async function finalizeMergeFixerOnStreamEnd(
   if (task.status !== 'merging') return;
   if (fixerFinalizeInFlight.has(task.id)) return;
   fixerFinalizeInFlight.add(task.id);
+  const hold = acquirePipelineHold(group.orchestrateBoard, task.id, 'merge-fixer-finalize');
   try {
     const fresh = group.orchestrateBoard?.tasks.find((t) => t.id === task.id) ?? task;
 
@@ -2725,6 +2789,7 @@ async function finalizeMergeFixerOnStreamEnd(
       makeSelfHealDeps(),
     ).catch((err) => reportBackgroundError('self-heal-fixer-terminal', err));
   } finally {
+    releasePipelineHold(hold);
     fixerFinalizeInFlight.delete(task.id);
   }
 }
@@ -2862,6 +2927,7 @@ async function finalizeEnvFixerOnStreamEnd(
   if (task.fixerKind !== 'env') return;
   if (fixerFinalizeInFlight.has(task.id)) return;
   fixerFinalizeInFlight.add(task.id);
+  const hold = acquirePipelineHold(group.orchestrateBoard, task.id, 'env-fixer-finalize');
   try {
     const fresh = group.orchestrateBoard?.tasks.find((t) => t.id === task.id) ?? task;
 
@@ -2976,6 +3042,7 @@ async function finalizeEnvFixerOnStreamEnd(
   } catch (err) {
     reportBackgroundError('finalize-env-fixer', err);
   } finally {
+    releasePipelineHold(hold);
     fixerFinalizeInFlight.delete(task.id);
   }
 }
@@ -3060,7 +3127,7 @@ export async function startTask(
     return;
   }
 
-  if (countRunningTaskChats(board) >= maxConcurrent(board)) {
+  if (!canLaunchBoardTask(board, task)) {
     enqueueTask(group.id, taskId);
     return;
   }
@@ -3431,58 +3498,63 @@ export async function finalizeTaskTestingOnStreamEnd(
 
   if (outcome === 'pass') {
     updateTask(group, fresh.id, { error: undefined }, plannerChat);
-    const mergeResult = await enqueueMergeCompletedTaskWorktree(group, fresh, plannerChat);
-    if (mergeResult.outcome === 'merged' || mergeResult.outcome === 'skipped') {
-      moveTaskStatus(group, fresh.id, 'complete', plannerChat);
-    } else if (mergeResult.outcome === 'conflict') {
-      updateTask(
-        group,
-        fresh.id,
-        {
-          error: `Integration merge conflict on ${fresh.worktreeBranch ?? fresh.id}`,
-        },
-        plannerChat,
-      );
-      await startMergeConflictFixer(
-        group,
-        fresh,
-        plannerChat,
-        mergeResult.conflictedFiles,
-        mergeResult.integrationSha,
-      );
-    } else {
-      // Merge-failed (non-conflict error) → self-heal merge path.
-      const mergeSummary = mergeResult.message || 'Integration merge failed';
-      updateTask(group, fresh.id, { error: mergeSummary }, plannerChat);
-      void runSelfHeal(
-        group,
-        fresh,
-        plannerChat,
-        { phase: 'merge', category: 'merge', summary: mergeSummary },
-        makeSelfHealDeps(),
-      ).catch((err) => reportBackgroundError('self-heal-merge', err));
-      return;
-    }
+    const hold = acquirePipelineHold(group.orchestrateBoard, fresh.id, 'merge');
+    try {
+      const mergeResult = await enqueueMergeCompletedTaskWorktree(group, fresh, plannerChat);
+      if (mergeResult.outcome === 'merged' || mergeResult.outcome === 'skipped') {
+        moveTaskStatus(group, fresh.id, 'complete', plannerChat);
+      } else if (mergeResult.outcome === 'conflict') {
+        updateTask(
+          group,
+          fresh.id,
+          {
+            error: `Integration merge conflict on ${fresh.worktreeBranch ?? fresh.id}`,
+          },
+          plannerChat,
+        );
+        await startMergeConflictFixer(
+          group,
+          fresh,
+          plannerChat,
+          mergeResult.conflictedFiles,
+          mergeResult.integrationSha,
+        );
+      } else {
+        // Merge-failed (non-conflict error) → self-heal merge path.
+        const mergeSummary = mergeResult.message || 'Integration merge failed';
+        updateTask(group, fresh.id, { error: mergeSummary }, plannerChat);
+        void runSelfHeal(
+          group,
+          fresh,
+          plannerChat,
+          { phase: 'merge', category: 'merge', summary: mergeSummary },
+          makeSelfHealDeps(),
+        ).catch((err) => reportBackgroundError('self-heal-merge', err));
+        return;
+      }
 
-    const testChatId = fresh.testChatId?.trim();
-    const testChat = testChatId ? findChatById(testChatId) : null;
-    if (testChat) {
-      const { providerId, modelId } = resolvePlannerModelBinding(plannerChat);
-      const lastAssistant = [...testChat.history].reverse().find((m) => m.role === 'assistant');
-      const assistantText = lastAssistant && typeof lastAssistant.content === 'string'
-        ? lastAssistant.content
-        : '';
-      schedulePostTurnSynthesis({
-        chatId: testChat.id,
-        messages: buildSynthesisMessages(testChat),
-        roundCount: testChat.history.filter((m) => m.role === 'assistant').length,
-        toolCount: 0,
-        sourceExcerpt: buildSynthesisExcerpt(testChat),
-        assistantText,
-        force: true,
-        providerId: providerId || undefined,
-        modelId: modelId || undefined,
-      });
+      const testChatIdAfterMerge = fresh.testChatId?.trim();
+      const testChat = testChatIdAfterMerge ? findChatById(testChatIdAfterMerge) : null;
+      if (testChat) {
+        const { providerId, modelId } = resolvePlannerModelBinding(plannerChat);
+        const lastAssistant = [...testChat.history].reverse().find((m) => m.role === 'assistant');
+        const assistantText = lastAssistant && typeof lastAssistant.content === 'string'
+          ? lastAssistant.content
+          : '';
+        schedulePostTurnSynthesis({
+          chatId: testChat.id,
+          messages: buildSynthesisMessages(testChat),
+          roundCount: testChat.history.filter((m) => m.role === 'assistant').length,
+          toolCount: 0,
+          sourceExcerpt: buildSynthesisExcerpt(testChat),
+          assistantText,
+          force: true,
+          providerId: providerId || undefined,
+          modelId: modelId || undefined,
+        });
+      }
+    } finally {
+      releasePipelineHold(hold);
     }
     return;
   }
@@ -3841,6 +3913,7 @@ export async function stopTask(
     stopTaskChatSupervision(task.fixerChatId);
     stopGeneration(task.fixerChatId);
   }
+  releasePipelineHoldsForTask(group.orchestrateBoard, taskId);
   await drainTaskQueue(group, plannerChat);
 }
 
@@ -3962,6 +4035,12 @@ export function setBoardExecutionMode(
   if (!board) return;
   const prevMode = getBoardExecutionMode(board);
   board.executionMode = mode;
+  // Sequential → AFK must not silently lift the one-at-a-time cap. Sequential
+  // disables the concurrency stepper (ui/orchestrate-board.ts), so the user
+  // never had a chance to pick a value; pin it to 1 and let them raise it in AFK.
+  if (mode === 'afk' && prevMode === 'sequential' && board.maxConcurrentTasks === undefined) {
+    board.maxConcurrentTasks = 1;
+  }
   if (mode !== 'afk') delete board.pendingAfk;
   if (mode === 'manual') board.autoRunning = false;
   board.lastUpdatedAt = Date.now();
@@ -4106,6 +4185,12 @@ export async function reconcileMergingTasks(
   }
   const board = group.orchestrateBoard;
   if (!board) return;
+  for (const taskId of sweepExpiredPipelineHolds(board)) {
+    reportBackgroundError(
+      'pipeline-hold-expired',
+      new Error(`Pipeline hold expired for task ${taskId}`),
+    );
+  }
   const isFixerActive = options?.isFixerChatActive ?? isTaskChatActive;
   const pending: Promise<void>[] = [];
   for (const task of board.tasks) {
@@ -4187,6 +4272,7 @@ export function stopBoardAutoRun(
   board.lastUpdatedAt = Date.now();
   logAutoStop(group);
   taskQueueByGroupId.delete(group.id);
+  releaseAllPipelineHolds(board);
   for (const task of board.tasks) {
     if (task.chatId) {
       stopTaskChatSupervision(task.chatId);
@@ -4264,7 +4350,7 @@ export async function autoDelegateNext(
       return board.tasks.indexOf(a) - board.tasks.indexOf(b);
     });
   for (const task of ready) {
-    if (countRunningTaskChats(board) >= maxConcurrent(board)) {
+    if (!canLaunchBoardTask(board, task)) {
       enqueueTask(group.id, task.id);
       continue;
     }
@@ -4312,7 +4398,7 @@ export async function startWave(
     (t) => t.wave === waveId && t.status === 'planned',
   );
   for (const task of planned) {
-    if (countRunningTaskChats(board) >= maxConcurrent(board)) {
+    if (!canLaunchBoardTask(board, task)) {
       enqueueTask(group.id, task.id);
     } else {
       await startTask(group, task.id, plannerChat);
@@ -4395,6 +4481,29 @@ export async function drainTaskQueueForTests(
   plannerChat: Chat,
 ): Promise<void> {
   return drainTaskQueue(group, plannerChat);
+}
+
+export { setPipelineHoldMaxMsForTests };
+
+export function getPipelineHoldsForTests(
+  board: NonNullable<ChatGroup['orchestrateBoard']>,
+): ReturnType<typeof listPipelineHolds> {
+  return listPipelineHolds(board);
+}
+
+export function acquirePipelineHoldForTests(
+  board: NonNullable<ChatGroup['orchestrateBoard']>,
+  taskId: string,
+  reason: Parameters<typeof acquirePipelineHold>[2],
+): ReturnType<typeof acquirePipelineHold> {
+  return acquirePipelineHold(board, taskId, reason);
+}
+
+export function releasePipelineHoldsForTaskForTests(
+  board: NonNullable<ChatGroup['orchestrateBoard']>,
+  taskId: string,
+): number {
+  return releasePipelineHoldsForTask(board, taskId);
 }
 
 export function startTaskChatSupervisionForTests(chatId: string): void {

--- a/src/state/orchestrate-board-store.ts
+++ b/src/state/orchestrate-board-store.ts
@@ -26,6 +26,7 @@ import type {
 } from '../types.ts';
 import { getBoardGroupForChat, getPlannerChatForGroup, linkPlannerChatToBoardFolder } from './chat-groups.ts';
 import { emitBoardChange } from './orchestrate-board-events.ts';
+import { hasPipelineHold } from './orchestrate-pipeline-holds.ts';
 import { scheduleSaveSessions, sessionState, touchChat } from './sessions.ts';
 
 /** Injectable clock for deterministic tests. */
@@ -627,6 +628,9 @@ export function isTaskStalledForRestart(
   // builder/tester chat is intentionally idle, so this is not a stuck slot.
   const fixerId = task.fixerChatId?.trim();
   if (fixerId && isChatActive(fixerId)) return false;
+  // A live pipeline hold (integration merge, fixer handoff, phase re-run) owns the
+  // task; its chat is intentionally idle. Mirrors the fixer-active guard above.
+  if (hasPipelineHold(board, task.id)) return false;
   const chatId =
     task.status === 'testing'
       ? task.testChatId?.trim() || task.chatId?.trim()

--- a/src/state/orchestrate-pipeline-holds.ts
+++ b/src/state/orchestrate-pipeline-holds.ts
@@ -1,0 +1,215 @@
+/**
+ * Pipeline holds — concurrency slots occupied by a task id during non-streaming
+ * pipeline phases (merge, fixer handoff, env-fixer finalize).
+ *
+ * Keyed by board object identity (stable per session). If the board object is
+ * ever swapped, holds vanish — fails open to pre-hold behaviour, never deadlocks.
+ */
+
+import type { OrchestrateBoardState } from '../types.ts';
+
+export type PipelineHoldReason =
+  | 'merge'
+  | 'merge-fixer-start'
+  | 'merge-fixer-finalize'
+  | 'env-fixer-finalize';
+
+export interface PipelineHold {
+  board: OrchestrateBoardState;
+  taskId: string;
+  id: string;
+  reason: PipelineHoldReason;
+  acquiredAt: number;
+}
+
+const PIPELINE_HOLD_MAX_MS = 10 * 60_000;
+
+/** Test override for hold TTL (null restores production cap). */
+let pipelineHoldMaxMsOverride: number | null = null;
+
+type HoldEntry = { acquiredAt: number; reason: PipelineHoldReason };
+
+/** Per-board ref-counted holds: taskId → holdId → entry. */
+const holdsByBoard = new WeakMap<
+  OrchestrateBoardState,
+  Map<string, Map<string, HoldEntry>>
+>();
+
+let holdIdSeq = 0;
+
+function resolveHoldMaxMs(): number {
+  return pipelineHoldMaxMsOverride ?? PIPELINE_HOLD_MAX_MS;
+}
+
+function getBoardHolds(board: OrchestrateBoardState): Map<string, Map<string, HoldEntry>> {
+  let map = holdsByBoard.get(board);
+  if (!map) {
+    map = new Map();
+    holdsByBoard.set(board, map);
+  }
+  return map;
+}
+
+/** Drop holds older than TTL; returns task ids that had at least one hold released. */
+function pruneExpiredHolds(
+  board: OrchestrateBoardState,
+  nowMs: number,
+): string[] {
+  const maxMs = resolveHoldMaxMs();
+  const boardHolds = holdsByBoard.get(board);
+  if (!boardHolds) return [];
+  const released: string[] = [];
+  for (const [taskId, holdMap] of boardHolds) {
+    for (const [holdId, entry] of holdMap) {
+      if (nowMs - entry.acquiredAt > maxMs) {
+        holdMap.delete(holdId);
+        if (!released.includes(taskId)) released.push(taskId);
+      }
+    }
+    if (holdMap.size === 0) boardHolds.delete(taskId);
+  }
+  if (boardHolds.size === 0) holdsByBoard.delete(board);
+  return released;
+}
+
+/** Task ids with at least one non-expired hold (TTL-on-read). */
+function heldTaskIds(board: OrchestrateBoardState, nowMs = Date.now()): string[] {
+  pruneExpiredHolds(board, nowMs);
+  const boardHolds = holdsByBoard.get(board);
+  if (!boardHolds) return [];
+  return [...boardHolds.keys()];
+}
+
+/** Acquire a pipeline hold for a task; null when board or taskId is missing. */
+export function acquirePipelineHold(
+  board: OrchestrateBoardState | undefined | null,
+  taskId: string | undefined,
+  reason: PipelineHoldReason,
+): PipelineHold | null {
+  const id = taskId?.trim();
+  if (!board || !id) return null;
+  const nowMs = Date.now();
+  pruneExpiredHolds(board, nowMs);
+  const boardHolds = getBoardHolds(board);
+  let taskHolds = boardHolds.get(id);
+  if (!taskHolds) {
+    taskHolds = new Map();
+    boardHolds.set(id, taskHolds);
+  }
+  const holdId = `ph-${++holdIdSeq}`;
+  const acquiredAt = nowMs;
+  taskHolds.set(holdId, { acquiredAt, reason });
+  return { board, taskId: id, id: holdId, reason, acquiredAt };
+}
+
+/** Release one hold (idempotent). Does not drain the task queue. */
+export function releasePipelineHold(hold: PipelineHold | null | undefined): void {
+  if (!hold) return;
+  const boardHolds = holdsByBoard.get(hold.board);
+  if (!boardHolds) return;
+  const taskHolds = boardHolds.get(hold.taskId);
+  if (!taskHolds) return;
+  taskHolds.delete(hold.id);
+  if (taskHolds.size === 0) boardHolds.delete(hold.taskId);
+  if (boardHolds.size === 0) holdsByBoard.delete(hold.board);
+}
+
+/** Release every hold for a task; returns count released. */
+export function releasePipelineHoldsForTask(
+  board: OrchestrateBoardState | undefined | null,
+  taskId: string | undefined,
+): number {
+  const id = taskId?.trim();
+  if (!board || !id) return 0;
+  const boardHolds = holdsByBoard.get(board);
+  if (!boardHolds) return 0;
+  const taskHolds = boardHolds.get(id);
+  if (!taskHolds) return 0;
+  const count = taskHolds.size;
+  boardHolds.delete(id);
+  if (boardHolds.size === 0) holdsByBoard.delete(board);
+  return count;
+}
+
+/** Release all holds on a board; returns count released. */
+export function releaseAllPipelineHolds(
+  board: OrchestrateBoardState | undefined | null,
+): number {
+  if (!board) return 0;
+  const boardHolds = holdsByBoard.get(board);
+  if (!boardHolds) return 0;
+  let count = 0;
+  for (const taskHolds of boardHolds.values()) {
+    count += taskHolds.size;
+  }
+  holdsByBoard.delete(board);
+  return count;
+}
+
+/** True when the task has a non-expired hold (TTL-on-read). */
+export function hasPipelineHold(
+  board: OrchestrateBoardState | undefined | null,
+  taskId: string | undefined,
+  nowMs = Date.now(),
+): boolean {
+  const id = taskId?.trim();
+  if (!board || !id) return false;
+  pruneExpiredHolds(board, nowMs);
+  const taskHolds = holdsByBoard.get(board)?.get(id);
+  return Boolean(taskHolds && taskHolds.size > 0);
+}
+
+/** Count distinct tasks with non-expired holds, optionally excluding one task. */
+export function countHeldTaskIds(
+  board: OrchestrateBoardState | undefined | null,
+  excludeTaskId?: string,
+  nowMs = Date.now(),
+): number {
+  if (!board) return 0;
+  const exclude = excludeTaskId?.trim();
+  let count = 0;
+  for (const taskId of heldTaskIds(board, nowMs)) {
+    if (exclude && taskId === exclude) continue;
+    count += 1;
+  }
+  return count;
+}
+
+/** List active holds for UI / diagnostics (expired holds pruned). */
+export function listPipelineHolds(
+  board: OrchestrateBoardState | undefined | null,
+  nowMs = Date.now(),
+): Array<{ taskId: string; reason: PipelineHoldReason; acquiredAt: number }> {
+  if (!board) return [];
+  pruneExpiredHolds(board, nowMs);
+  const boardHolds = holdsByBoard.get(board);
+  if (!boardHolds) return [];
+  const out: Array<{ taskId: string; reason: PipelineHoldReason; acquiredAt: number }> = [];
+  for (const [taskId, holdMap] of boardHolds) {
+    for (const entry of holdMap.values()) {
+      out.push({ taskId, reason: entry.reason, acquiredAt: entry.acquiredAt });
+    }
+  }
+  return out;
+}
+
+/** Active sweep — release expired holds; returns released task ids. */
+export function sweepExpiredPipelineHolds(
+  board: OrchestrateBoardState | undefined | null,
+  nowMs = Date.now(),
+): string[] {
+  if (!board) return [];
+  return pruneExpiredHolds(board, nowMs);
+}
+
+/** Test override for hold TTL. */
+export function setPipelineHoldMaxMsForTests(ms: number | null): void {
+  pipelineHoldMaxMsOverride = ms;
+}
+
+/** Internal: iterate held task ids for occupancy dedupe. */
+export function heldTaskIdsForOccupancy(
+  board: OrchestrateBoardState,
+): string[] {
+  return heldTaskIds(board);
+}

--- a/src/ui/orchestrate-board.ts
+++ b/src/ui/orchestrate-board.ts
@@ -1736,7 +1736,8 @@ function sumChatTotalTokens(chat: Chat | undefined): number | null {
 }
 
 function resolveRunningSlotElapsedMs(slot: RunningBoardTaskSlot, chat?: Chat): number {
-  const mainTurn = getMainTurnActivity(slot.chatId);
+  const chatId = slot.chatId?.trim();
+  const mainTurn = chatId ? getMainTurnActivity(chatId) : undefined;
   if (mainTurn?.startedAtMs) return Math.max(0, Date.now() - mainTurn.startedAtMs);
   if (slot.task?.startedAt) return Math.max(0, Date.now() - slot.task.startedAt);
   if (chat?.updatedAt) return Math.max(0, Date.now() - chat.updatedAt);
@@ -1747,20 +1748,22 @@ function runningSlotShowsContinue(
   board: BoardState,
   slot: RunningBoardTaskSlot,
 ): boolean {
-  if (slot.isFinalTest || !slot.task) return false;
-  if (isChatStreaming(slot.chatId)) return false;
+  if (slot.isFinalTest || !slot.task || !slot.chatId?.trim()) return false;
+  const chatId = slot.chatId.trim();
+  if (isChatStreaming(chatId)) return false;
   return (
     isTaskStalledForRestart(board, slot.task, isTaskChatActiveForStallCheck) ||
-    isTaskChatActive(slot.chatId)
+    isTaskChatActive(chatId)
   );
 }
 
-type RunningTaskIconKind = 'build' | 'test' | 'fix' | 'final';
+type RunningTaskIconKind = 'build' | 'test' | 'fix' | 'merge' | 'final';
 
 const RUNNING_TASK_ICON_PATHS: Record<RunningTaskIconKind, readonly string[]> = {
   build: [BOARD_CATEGORY_ICON_PATHS.build!],
   test: [BOARD_CATEGORY_ICON_PATHS.test!],
   fix: [BOARD_CATEGORY_ICON_PATHS.fix!],
+  merge: ['M6 3v12', 'M18 9V3', 'M6 15l6-6 6 6'],
   final: ['M12 2v20', 'M2 12h20', 'M5 5l14 14', 'M19 5 5 19'],
 };
 
@@ -1817,25 +1820,30 @@ function buildRunningTaskChip(
   group: ChatGroup,
   plannerChat: Chat,
 ): HTMLElement {
-  const chat = findChatById(slot.chatId);
+  const chatId = slot.chatId?.trim();
+  const chat = chatId ? findChatById(chatId) : undefined;
   const chip = document.createElement('article');
   chip.className = `board-running-tasks__chip board-running-tasks__chip--${slot.phase}`;
-  chip.dataset.boardRunningChatId = slot.chatId;
+  if (chatId) chip.dataset.boardRunningChatId = chatId;
   chip.dataset.boardRunningTaskId = slot.taskId;
+  chip.dataset.boardRunningSlotKey = chatId || `hold:${slot.taskId}`;
   chip.setAttribute('role', 'listitem');
-  const streaming = isChatStreaming(slot.chatId);
+  const streaming = chatId ? isChatStreaming(chatId) : false;
   if (streaming) chip.classList.add('board-running-tasks__chip--streaming');
-  chip.setAttribute(
-    'aria-label',
-    `${slot.taskId} ${slot.title}, ${streaming ? 'running' : 'starting'}`,
-  );
+  const statusLabel =
+    slot.phase === 'merge' ? 'merging' : streaming ? 'running' : 'starting';
+  chip.setAttribute('aria-label', `${slot.taskId} ${slot.title}, ${statusLabel}`);
 
   const icon = document.createElement('span');
   icon.className = `board-running-tasks__phase board-running-tasks__phase--${slot.phase}`;
   icon.appendChild(
     createRunningTaskIcon(slot.phase, 'icon-svg board-running-tasks__phase-icon'),
   );
-  icon.title = slot.phase === 'final' ? 'Final integration test' : slot.phase;
+  icon.title = slot.phase === 'final'
+    ? 'Final integration test'
+    : slot.phase === 'merge'
+      ? 'Merging'
+      : slot.phase;
   chip.appendChild(icon);
 
   const dot = document.createElement('span');
@@ -1868,55 +1876,58 @@ function buildRunningTaskChip(
   stats.appendChild(tokens);
   chip.appendChild(stats);
 
-  const controls = document.createElement('div');
-  controls.className = 'board-running-tasks__controls';
-  controls.appendChild(
-    createRunningTaskControlButton('stop', `Stop ${slot.taskId}`, () => {
-      void stopRunningBoardSlot(group, slot, plannerChat).then(() =>
-        refreshActiveBoardIfMounted(),
+  if (chatId) {
+    const controls = document.createElement('div');
+    controls.className = 'board-running-tasks__controls';
+    controls.appendChild(
+      createRunningTaskControlButton('stop', `Stop ${slot.taskId}`, () => {
+        void stopRunningBoardSlot(group, slot, plannerChat).then(() =>
+          refreshActiveBoardIfMounted(),
+        );
+      }),
+    );
+    const mergingSlot =
+      !slot.isFinalTest && slot.task && slot.task.status === 'merging';
+    if (!mergingSlot) {
+      controls.appendChild(
+        createRunningTaskControlButton('restart', `Restart ${slot.taskId}`, () => {
+          if (slot.isFinalTest) {
+            void stopRunningBoardSlot(group, slot, plannerChat)
+              .then(() => startFinalIntegrationTestForPlannerChat(plannerChat))
+              .then(() => refreshActiveBoardIfMounted());
+            return;
+          }
+          void restartBoardTask(group, slot.taskId, plannerChat).then(() =>
+            refreshActiveBoardIfMounted(),
+          );
+        }),
       );
-    }),
-  );
-  const mergingSlot = !slot.isFinalTest && slot.task.status === 'merging';
-  if (!mergingSlot) {
+    }
+    if (!mergingSlot && runningSlotShowsContinue(board, slot)) {
+      controls.appendChild(
+        createRunningTaskControlButton('continue', `Continue ${slot.taskId}`, () => {
+          void continueBoardTask(group, slot.taskId, plannerChat).then(() =>
+            refreshActiveBoardIfMounted(),
+          );
+        }),
+      );
+    }
+    if (!slot.isFinalTest && !mergingSlot) {
+      controls.appendChild(
+        createRunningTaskControlButton('move', `Move ${slot.taskId} to new chat`, () => {
+          void moveTaskToNewChat(group, slot.taskId, plannerChat).then(() =>
+            refreshActiveBoardIfMounted(),
+          );
+        }),
+      );
+    }
     controls.appendChild(
-      createRunningTaskControlButton('restart', `Restart ${slot.taskId}`, () => {
-        if (slot.isFinalTest) {
-          void stopRunningBoardSlot(group, slot, plannerChat)
-            .then(() => startFinalIntegrationTestForPlannerChat(plannerChat))
-            .then(() => refreshActiveBoardIfMounted());
-          return;
-        }
-        void restartBoardTask(group, slot.taskId, plannerChat).then(() =>
-          refreshActiveBoardIfMounted(),
-        );
+      createRunningTaskControlButton('open', `Open chat for ${slot.taskId}`, () => {
+        if (chat) switchChat(chat.id);
       }),
     );
+    chip.appendChild(controls);
   }
-  if (!mergingSlot && runningSlotShowsContinue(board, slot)) {
-    controls.appendChild(
-      createRunningTaskControlButton('continue', `Continue ${slot.taskId}`, () => {
-        void continueBoardTask(group, slot.taskId, plannerChat).then(() =>
-          refreshActiveBoardIfMounted(),
-        );
-      }),
-    );
-  }
-  if (!slot.isFinalTest && !mergingSlot) {
-    controls.appendChild(
-      createRunningTaskControlButton('move', `Move ${slot.taskId} to new chat`, () => {
-        void moveTaskToNewChat(group, slot.taskId, plannerChat).then(() =>
-          refreshActiveBoardIfMounted(),
-        );
-      }),
-    );
-  }
-  controls.appendChild(
-    createRunningTaskControlButton('open', `Open chat for ${slot.taskId}`, () => {
-      if (chat) switchChat(chat.id);
-    }),
-  );
-  chip.appendChild(controls);
   return chip;
 }
 
@@ -1926,13 +1937,14 @@ function buildRunningTasksStripKey(
 ): string {
   return slots
     .map((slot) => {
-      const chat = findChatById(slot.chatId);
+      const chatId = slot.chatId?.trim();
+      const chat = chatId ? findChatById(chatId) : undefined;
       const tokens = sumChatTotalTokens(chat);
-      const streaming = isChatStreaming(slot.chatId) ? 1 : 0;
+      const streaming = chatId && isChatStreaming(chatId) ? 1 : 0;
       const continueVisible = runningSlotShowsContinue(board, slot) ? 1 : 0;
-      const moveVisible = slot.isFinalTest ? 0 : 1;
+      const moveVisible = slot.isFinalTest || !chatId ? 0 : 1;
       return [
-        slot.chatId,
+        chatId || `hold:${slot.taskId}`,
         slot.taskId,
         slot.phase,
         slot.title,
@@ -2002,11 +2014,13 @@ function syncBoardRunningTasksStrip(
   }
 
   for (const slot of slots) {
+    const slotKey = slot.chatId?.trim() || `hold:${slot.taskId}`;
     const chip = existing.querySelector(
-      `[data-board-running-chat-id="${slot.chatId}"]`,
+      `[data-board-running-slot-key="${slotKey}"]`,
     ) as HTMLElement | null;
     if (!chip) continue;
-    const chat = findChatById(slot.chatId);
+    const chatId = slot.chatId?.trim();
+    const chat = chatId ? findChatById(chatId) : undefined;
     const elapsedEl = chip.querySelector('[data-board-running-elapsed="true"]');
     if (elapsedEl) {
       elapsedEl.textContent = formatElapsed(resolveRunningSlotElapsedMs(slot, chat));
@@ -2015,7 +2029,9 @@ function syncBoardRunningTasksStrip(
     if (tokensEl) {
       tokensEl.textContent = formatRunningTaskTokens(sumChatTotalTokens(chat));
     }
-    chip.classList.toggle('board-running-tasks__chip--streaming', isChatStreaming(slot.chatId));
+    if (chatId) {
+      chip.classList.toggle('board-running-tasks__chip--streaming', isChatStreaming(chatId));
+    }
   }
 }
 

--- a/test/orchestrate/_board-flow-helpers.mts
+++ b/test/orchestrate/_board-flow-helpers.mts
@@ -194,6 +194,46 @@ export function mockWorktreeOps(responses: Record<string, unknown>): () => void 
   };
 }
 
+/**
+ * Like mockWorktreeOps, but listed ops block until release(op) is called.
+ * Gives deterministic slow merges without production seams.
+ */
+export function mockWorktreeOpsGated(
+  responses: Record<string, unknown>,
+  gatedOps: string[],
+): { restore: () => void; release: (op: string) => void } {
+  const gates = new Map<string, { resolve: () => void; promise: Promise<void> }>();
+  for (const op of gatedOps) {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    gates.set(op, { resolve, promise });
+  }
+  const saved = globalThis.fetch;
+  // @ts-ignore — test-only replacement
+  globalThis.fetch = async (_url: unknown, opts?: { body?: unknown }) => {
+    let op = '';
+    try {
+      op = (JSON.parse(opts?.body as string) as { op?: string }).op ?? '';
+    } catch {
+      /* ignore */
+    }
+    const gate = gates.get(op);
+    if (gate) await gate.promise;
+    const payload = op in responses ? responses[op] : { ok: false, error: 'not_mocked' };
+    return { ok: true, json: async () => payload };
+  };
+  return {
+    restore: () => {
+      globalThis.fetch = saved;
+    },
+    release: (op: string) => {
+      gates.get(op)?.resolve();
+    },
+  };
+}
+
 export function cleanMergeMocks(integrationSha = 'cafebabe'): Record<string, unknown> {
   return {
     merge: { ok: true, integrationSha },

--- a/test/orchestrate/delegate-tasks.test.mts
+++ b/test/orchestrate/delegate-tasks.test.mts
@@ -24,7 +24,12 @@ import {
   executeBoardTool,
   validateDelegateTasksArgs,
 } from '../../src/tools/board-tools.ts';
-import { setBoardMaxConcurrent } from '../../src/state/orchestrate-board-actions.ts';
+import {
+  activateAfk,
+  resolveBoardMaxConcurrent,
+  setBoardExecutionMode,
+  setBoardMaxConcurrent,
+} from '../../src/state/orchestrate-board-actions.ts';
 import { setSessionStateForTests } from '../../src/state/sessions.ts';
 import {
   initBoard,
@@ -326,6 +331,44 @@ describe('sequential execution mode', () => {
   test('getBoardExecutionMode falls back to manual for unknown values', () => {
     const board = { executionMode: 'unknown' as any };
     assert.equal(getBoardExecutionMode(board as any), 'manual');
+  });
+
+  test('sequential → afk pins maxConcurrentTasks to 1 when unset', () => {
+    const { planner, group } = seedBoard('manual');
+    const board = group.orchestrateBoard!;
+    board.executionMode = 'sequential';
+    delete board.maxConcurrentTasks;
+    assert.equal(resolveBoardMaxConcurrent(board), 1);
+    activateAfk(group, planner);
+    assert.equal(board.maxConcurrentTasks, 1);
+    assert.equal(resolveBoardMaxConcurrent(board), 1);
+  });
+
+  test('sequential → afk keeps explicit maxConcurrentTasks', () => {
+    const { planner, group } = seedBoard('manual');
+    const board = group.orchestrateBoard!;
+    board.executionMode = 'sequential';
+    board.maxConcurrentTasks = 5;
+    activateAfk(group, planner);
+    assert.equal(board.maxConcurrentTasks, 5);
+    assert.equal(resolveBoardMaxConcurrent(board), 5);
+  });
+
+  test('auto → afk does not change maxConcurrentTasks', () => {
+    const { planner, group } = seedBoard('auto');
+    const board = group.orchestrateBoard!;
+    delete board.maxConcurrentTasks;
+    setBoardExecutionMode(group, 'afk', planner);
+    assert.equal(board.maxConcurrentTasks, undefined);
+  });
+
+  test('setBoardExecutionMode afk from sequential pins concurrency', () => {
+    const { planner, group } = seedBoard('manual');
+    const board = group.orchestrateBoard!;
+    board.executionMode = 'sequential';
+    delete board.maxConcurrentTasks;
+    setBoardExecutionMode(group, 'afk', planner);
+    assert.equal(board.maxConcurrentTasks, 1);
   });
 });
 

--- a/test/orchestrate/pipeline-holds.test.mts
+++ b/test/orchestrate/pipeline-holds.test.mts
@@ -1,0 +1,99 @@
+/**
+ * Pipeline hold module — occupancy TTL-on-read and stall-restart guard integration.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  acquirePipelineHold,
+  countHeldTaskIds,
+  hasPipelineHold,
+  releasePipelineHold,
+  releasePipelineHoldsForTask,
+  setPipelineHoldMaxMsForTests,
+} from '../../src/state/orchestrate-pipeline-holds.ts';
+import {
+  initBoard,
+  isTaskStalledForRestart,
+  updateTask,
+} from '../../src/state/orchestrate-board-store.ts';
+import type { Chat, ChatGroup } from '../../src/types.ts';
+
+const PLANNER_ID = '11111111-1111-1111-1111-111111111111';
+const GROUP_ID = 'grp_11111111-1111-1111-1111-111111111111';
+const TEST_CHAT_ID = '44444444-4444-4444-4444-444444444444';
+
+function makePlanner(): Chat {
+  return {
+    id: PLANNER_ID,
+    name: 'Planner',
+    workspacePath: '/tmp/ws',
+    modeId: 'orchestrate',
+    modelId: 'm1',
+    history: [],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    boardGroupId: GROUP_ID,
+  };
+}
+
+function makeBoardGroup(): ChatGroup {
+  const planner = makePlanner();
+  const group: ChatGroup = {
+    id: GROUP_ID,
+    name: 'Board',
+    workspacePath: '/tmp/ws',
+    collapsed: false,
+    order: 0,
+    plannerChatId: PLANNER_ID,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    viewMode: 'board',
+  };
+  initBoard(group, planner, {
+    planPath: 'documentation/plans/test.md',
+    tasks: [{ id: 'W1-A', title: 'A', wave: 'W1', category: 'build' }],
+    waves: [{ id: 'W1' }],
+  });
+  return group;
+}
+
+describe('pipeline holds', () => {
+  afterEach(() => {
+    setPipelineHoldMaxMsForTests(null);
+  });
+
+  test('isTaskStalledForRestart false while held, true once released', () => {
+    const group = makeBoardGroup();
+    const planner = makePlanner();
+    const board = group.orchestrateBoard!;
+    updateTask(
+      group,
+      'W1-A',
+      { status: 'testing', testChatId: TEST_CHAT_ID, chatId: 'build-chat' },
+      planner,
+    );
+    const task = board.tasks[0]!;
+    assert.equal(isTaskStalledForRestart(board, task, () => false), true);
+    const hold = acquirePipelineHold(board, 'W1-A', 'merge');
+    assert.ok(hold);
+    assert.equal(isTaskStalledForRestart(board, task, () => false), false);
+    releasePipelineHold(hold);
+    assert.equal(isTaskStalledForRestart(board, task, () => false), true);
+  });
+
+  test('TTL-on-read: expired hold is invisible to hasPipelineHold and countHeldTaskIds', async () => {
+    const group = makeBoardGroup();
+    const board = group.orchestrateBoard!;
+    setPipelineHoldMaxMsForTests(1);
+    const hold = acquirePipelineHold(board, 'W1-A', 'merge');
+    assert.ok(hold);
+    assert.equal(hasPipelineHold(board, 'W1-A'), true);
+    assert.equal(countHeldTaskIds(board), 1);
+    await new Promise<void>((r) => setTimeout(r, 5));
+    assert.equal(hasPipelineHold(board, 'W1-A'), false);
+    assert.equal(countHeldTaskIds(board), 0);
+    releasePipelineHoldsForTask(board, 'W1-A');
+  });
+});

--- a/test/orchestrate/task-stream-end.test.mts
+++ b/test/orchestrate/task-stream-end.test.mts
@@ -17,6 +17,8 @@ import {
   drainTaskQueueForTests,
   enqueueTaskForTests,
   finalizeBoardTaskOnStreamEnd,
+  finalizeTaskTestingOnStreamEnd,
+  getPipelineHoldsForTests,
   getTaskQueueForTests,
   MAX_STOP_RETRY_ATTEMPTS,
   releaseLaunchSlotForTests,
@@ -24,9 +26,13 @@ import {
   resolveTaskChatStopReason,
   resolveTaskChatStreamOutcome,
   trackDrainResumeCallsForTests,
+  autoDelegateNext,
+  isTaskChatActiveForStallCheck,
 } from '../../src/state/orchestrate-board-actions.ts';
 import { initBoard, isTaskStalledForRestart, markBoardTaskInProgressFromChat, updateTask } from '../../src/state/orchestrate-board-store.ts';
 import { setSessionStateForTests } from '../../src/state/sessions.ts';
+import { setLocalServerAvailableForTests } from '../../src/tools/config.ts';
+import { cleanMergeMocks, mockWorktreeOpsGated } from './_board-flow-helpers.mts';
 import type { Chat, ChatGroup } from '../../src/types.ts';
 
 const PLANNER_ID = '11111111-1111-1111-1111-111111111111';
@@ -684,5 +690,154 @@ describe('build→test handoff slot accounting', () => {
     const resumed = trackDrainResumeCallsForTests(false);
     assert.deepEqual(resumed, ['W1-B']);
     assert.deepEqual(getTaskQueueForTests(GROUP_ID), []);
+  });
+});
+
+describe('pipeline merge hold blocks queue drain', () => {
+  let restoreFetch: (() => void) | undefined;
+  let releaseMerge: (() => void) | undefined;
+
+  beforeEach(() => {
+    setSessionStateForTests(null);
+    clearTaskQueuesForTests();
+    releaseLaunchSlotForTests(TEST_CHAT_ID);
+    releaseLaunchSlotForTests(TASK_CHAT_ID);
+    setLocalServerAvailableForTests(true);
+    const gated = mockWorktreeOpsGated(cleanMergeMocks(), ['merge']);
+    restoreFetch = gated.restore;
+    releaseMerge = () => gated.release('merge');
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = undefined;
+    releaseMerge = undefined;
+    setLocalServerAvailableForTests(false);
+    clearTaskQueuesForTests();
+  });
+
+  function makeSequentialMergeGroup(): { group: ChatGroup; planner: Chat } {
+    const planner = makePlanner();
+    const group: ChatGroup = {
+      id: GROUP_ID,
+      name: 'Board',
+      workspacePath: '/tmp/ws',
+      collapsed: false,
+      order: 0,
+      plannerChatId: PLANNER_ID,
+      orchestratePlanPath: 'documentation/plans/test.md',
+      viewMode: 'board',
+    };
+    initBoard(group, planner, {
+      planPath: 'documentation/plans/test.md',
+      tasks: [
+        { id: 'W1-A', title: 'First', wave: 'W1', category: 'build' },
+        { id: 'W1-B', title: 'Second', wave: 'W1', category: 'build' },
+      ],
+      waves: [{ id: 'W1', status: 'in_progress' }],
+    });
+    const board = group.orchestrateBoard!;
+    board.executionMode = 'sequential';
+    board.autoRunning = true;
+    board.maxConcurrentTasks = 1;
+    board.integrationBranch = 'minnow/integration/grp_11111111';
+    updateTask(
+      group,
+      'W1-A',
+      {
+        status: 'testing',
+        chatId: TASK_CHAT_ID,
+        testChatId: TEST_CHAT_ID,
+        worktreeBranch: 'minnow/board/W1-A',
+        boardReport: { outcome: 'pass', summary: 'ok' },
+      },
+      planner,
+    );
+    updateTask(group, 'W1-B', { status: 'planned' }, planner);
+    enqueueTaskForTests(GROUP_ID, 'W1-B');
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+    return { group, planner };
+  }
+
+  test('gated merge blocks T2 until T1 completes', async () => {
+    const { group, planner } = makeSequentialMergeGroup();
+    const board = group.orchestrateBoard!;
+    const task = board.tasks.find((t) => t.id === 'W1-A')!;
+    reserveLaunchSlotForTests(TEST_CHAT_ID);
+
+    trackDrainResumeCallsForTests(true);
+    const finalizePromise = finalizeTaskTestingOnStreamEnd(group, task, planner);
+    assert.equal(countRunningTaskChats(board), 1);
+
+    releaseLaunchSlotForTests(TEST_CHAT_ID);
+    await drainTaskQueueForTests(group, planner);
+    const resumedWhileGated = trackDrainResumeCallsForTests(false);
+    assert.deepEqual(resumedWhileGated, []);
+    assert.deepEqual(getTaskQueueForTests(GROUP_ID), ['W1-B']);
+    assert.equal(board.tasks.find((t) => t.id === 'W1-A')!.status, 'testing');
+
+    releaseMerge!();
+    await finalizePromise;
+    assert.equal(board.tasks.find((t) => t.id === 'W1-A')!.status, 'complete');
+    assert.equal(getPipelineHoldsForTests(board).length, 0);
+
+    trackDrainResumeCallsForTests(true);
+    await drainTaskQueueForTests(group, planner);
+    const resumedAfter = trackDrainResumeCallsForTests(false);
+    assert.deepEqual(resumedAfter, ['W1-B']);
+  });
+
+  test('countRunningTaskChats is 1 while merge gated, 0 after settle', async () => {
+    const { group, planner } = makeSequentialMergeGroup();
+    const board = group.orchestrateBoard!;
+    const task = board.tasks.find((t) => t.id === 'W1-A')!;
+    reserveLaunchSlotForTests(TEST_CHAT_ID);
+
+    const finalizePromise = finalizeTaskTestingOnStreamEnd(group, task, planner);
+    assert.equal(countRunningTaskChats(board), 1);
+    releaseLaunchSlotForTests(TEST_CHAT_ID);
+    assert.equal(countRunningTaskChats(board), 1);
+
+    releaseMerge!();
+    await finalizePromise;
+    assert.equal(countRunningTaskChats(board), 0);
+  });
+
+  test('autoDelegateNext does not relaunch Tester mid-merge', async () => {
+    const { group, planner } = makeSequentialMergeGroup();
+    const board = group.orchestrateBoard!;
+    const task = board.tasks.find((t) => t.id === 'W1-A')!;
+    reserveLaunchSlotForTests(TEST_CHAT_ID);
+
+    const finalizePromise = finalizeTaskTestingOnStreamEnd(group, task, planner);
+    releaseLaunchSlotForTests(TEST_CHAT_ID);
+    assert.equal(
+      isTaskStalledForRestart(board, task, isTaskChatActiveForStallCheck),
+      false,
+    );
+    await autoDelegateNext(group, planner);
+    assert.equal(board.tasks.find((t) => t.id === 'W1-A')!.status, 'testing');
+
+    releaseMerge!();
+    await finalizePromise;
+  });
+
+  test('merge error early return releases hold', async () => {
+    restoreFetch?.();
+    restoreFetch = undefined;
+    const saved = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ ok: false, error: 'merge_failed' }),
+    });
+    const { group, planner } = makeSequentialMergeGroup();
+    const board = group.orchestrateBoard!;
+    const task = board.tasks.find((t) => t.id === 'W1-A')!;
+    await finalizeTaskTestingOnStreamEnd(group, task, planner);
+    assert.equal(
+      getPipelineHoldsForTests(board).filter((h) => h.reason === 'merge').length,
+      0,
+    );
+    globalThis.fetch = saved;
   });
 });


### PR DESCRIPTION
## Summary
- Add ref-counted **pipeline holds** so a task keeps its concurrency slot through merge, merge-fixer preflight, and env-fixer finalize (no gap between tester stream-end and integration merge).
- Wire holds into `countRunningTaskChats`, `canLaunchBoardTask` (self-exclusion), and `isTaskStalledForRestart`; show a non-interactive **Merging** chip in the running-tasks strip.
- Pin `maxConcurrentTasks` to 1 when switching Sequential → AFK with no explicit cap.

## Test plan
- [x] `pipeline-holds.test.mts` — stall guard + TTL-on-read
- [x] `task-stream-end.test.mts` — gated merge blocks T2, occupancy stays 1, no mid-merge tester relaunch, merge-error hold release
- [x] `delegate-tasks.test.mts` — Sequential → AFK concurrency clamp
- [x] Existing build→test handoff slot accounting tests unchanged
- [ ] Manual: Sequential board, 3 dependent tasks — Merging chip holds slot until complete before next Builder
