### PR TITLE
🐛 Stop the watchdog from killing long plan reviews

### DIFF
--- a/documentation/maintainer/settings-reference.md
+++ b/documentation/maintainer/settings-reference.md
@@ -284,9 +284,10 @@ Drop-in work agent bundles under `~/.minnow/agent-packs/<pack-id>/` (`manifest.j
 |---------|-------------|
 | Enabled | Master toggle |
 | Max concurrent | Global cap |
-| Default timeout | ms |
+| Default timeout | ms; a caller-supplied `timeoutMs` on the spawn wins over this and over the per-type value |
 | Check-in nudge | ms (0 = off) |
-| Duplicate tool limit | Identical tool+args calls before watchdog repetition recovery (`0` = off, max 256; default 5) |
+
+Stall, heartbeat, and loop detection are **not** here — see [Watchdog](#watchdog-configjson--chat-sub-agentsjson).
 
 **Types (8):** `generalPurpose`, `explore`, `researcher`, `shell`, `explorer`, `debugger`, `bug-planner`, `plan-reviewer`
 
@@ -298,13 +299,17 @@ Per type: enabled, max concurrent, timeout, max input tokens, context policy, su
 |-------|----------|
 | Board defaults | Execution mode (`manual`/`sequential`/`auto`/`afk`), isolation (`auto`/`off`/`per-task`/`per-wave`), max concurrent tasks |
 | Test & build retries | Per-task test/build attempts, final test attempts, continue smart-route (`off`/`conservative`/`aggressive`) |
-| Heartbeat & stall | Heartbeat interval, progress stall, heartbeat dead (ms) |
+| Heartbeat & stall | Moved to **Watchdog → Agent supervision** (the legacy `autopilot.heartbeatIntervalMs` / `progressStallMs` / `heartbeatDeadMs` keys are still read as a fallback, never written) |
 | Planner model fallback | Provider + model |
 | Self-heal & provisioning | Max self-heal rounds, infra provision timeout, auto-provision infra, auto-restart stalled tasks, guard `cd` outside worktree |
 
-### Watchdog (`config.json` → `chat`)
+`selfHealMaxRounds` doubles as the watchdog recovery-attempt cap: it bounds total dispatches per logical task across the tier-1/tier-2 restart chain.
 
-Settings → **Agents → Watchdog** — server-side limits while streaming from the model.
+### Watchdog (`config.json` → `chat`, `sub-agents.json`)
+
+Settings → **Agents → Watchdog**.
+
+**Generation timeouts** — server-side limits while streaming from the model:
 
 | Setting | Key |
 |---------|-----|
@@ -312,6 +317,19 @@ Settings → **Agents → Watchdog** — server-side limits while streaming from
 | Max duration (minutes) | `chat.generationMaxDurationMs` |
 
 Idle timeout resets when new tokens arrive; applies to the next generation without restart.
+
+**Agent supervision** (`sub-agents.json`) — one policy covering sub-agents *and* orchestrate task chats. Both write the same `heartbeatConfig` singleton in `agents/controller/wrapper`, so they must resolve from one store; `config/supervision-thresholds.ts` is that resolver.
+
+| Setting | Key | Range | Default |
+|---------|-----|-------|---------|
+| Stall timeout | `progressStallMs` | 10 s – 30 min | 90 s |
+| Unresponsive after | `heartbeatDeadMs` | 5 s – 5 min | 30 s |
+| Heartbeat interval | `heartbeatIntervalMs` | 1 s – 60 s | 7 s |
+| Repeated tool limit | `duplicateToolCallThreshold` | 0 – 256 (`0` = off) | 5 |
+
+Progress is bumped by streamed messages, live activity, and tool calls — a model that reasons for longer than the stall timeout in one non-streaming completion trips it. Repeated-tool detection uses a sliding window (`4x` the threshold, min 12 recent calls), so identical calls spread across a long run are ignored.
+
+On a trip: read-only agent types are restarted from scratch (tier 1) until `autopilot.selfHealMaxRounds` dispatches are used; write-capable types go straight to blocked (tier 2), except on running AFK/auto boards where they are re-dispatched under the same cap.
 
 ---
 

--- a/documentation/manual/apps/settings.md
+++ b/documentation/manual/apps/settings.md
@@ -45,10 +45,25 @@ Theme family and mode — 16 themes in total, eight families each with a dark an
 | **Agents** | Prompt profiles (Full / Lite / custom) with a live token estimate, composer modes, Super Plan pipeline settings, plan granularity, work agents, sub-agent types, context policy, setup profile export and import |
 | **Rules** | Standing instructions injected into every prompt, organised into groups |
 | **Agent packs** | Download a template or the built-in pack, upload a zip, manage installed packs |
-| **Autopilot** | Defaults for orchestrate boards: execution mode, isolation, concurrency, planner model, retries, heartbeat, self-heal, infra provisioning |
-| **Watchdog** | Generation limits while streaming — idle timeout and maximum duration |
+| **Autopilot** | Defaults for orchestrate boards: execution mode, isolation, concurrency, planner model, retries, self-heal, infra provisioning |
+| **Watchdog** | Generation limits while streaming, plus agent stall, heartbeat, and loop detection |
 
-**Watchdog** is the setting to reach for when a model hangs mid-stream and the run sits there forever. The idle timeout resets whenever new tokens arrive, so it catches a genuinely stalled stream without cutting off a slow one.
+**Watchdog** is the setting to reach for when a run hangs and sits there forever. It has two halves.
+
+**Generation timeouts** cover the model stream itself. The idle timeout resets whenever new tokens arrive, so it catches a genuinely stalled stream without cutting off a slow one.
+
+**Agent supervision** covers agents — both sub-agents and orchestrate task chats:
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| **Stall timeout** | 90 sec | How long an agent may go without producing anything visible — streamed text, reasoning, or a tool call — before it counts as stuck |
+| **Unresponsive after** | 30 sec | How long without any heartbeat before the run is treated as dead. Liveness only, not model output |
+| **Heartbeat interval** | 7 sec | How often a running agent reports in |
+| **Repeated tool limit** | 5 | How many identical tool calls (same name and arguments) may occur close together before the run counts as looping. `0` turns it off |
+
+When a run trips one of these, read-only agents are restarted from scratch, bounded by **Max self-heal rounds** under Autopilot. Agents that can write files are not auto-restarted — the task is marked blocked instead.
+
+The stall timeout is the usual culprit behind a long plan review or research pass getting cut short: a model that reasons for two minutes in one non-streaming completion produces nothing observable for that whole time. Raise it before reaching for anything else. Repeats spread across a long run no longer count as a loop — only bunched-up identical calls do — so the repeated tool limit rarely needs changing.
 
 ### Integrations
 

--- a/documentation/manual/orchestrate/super-plan.md
+++ b/documentation/manual/orchestrate/super-plan.md
@@ -44,6 +44,7 @@ Answering "you decide" to everything produces a plan where the model decided eve
 | Setting | Default | What it does |
 |---------|---------|--------------|
 | **Review rounds** | 2 | 0 skips review entirely; 1 gives one critique and one rewrite; up to 4 |
+| **Review timeout** | 20 min | How long one review pass may run before the stage gives up (5–120). Raise it for slow reviewer models or large plans |
 | **Interview** | On | Turn off to skip straight to the spec |
 | **Question budget** | ~20 | Between 5 and 40 |
 | **Research** | On | Turn off when you already know the domain |
@@ -55,6 +56,8 @@ Answering "you decide" to everything produces a plan where the model decided eve
 **Stage models are the highest-leverage setting here.** The reviewer is doing the hardest thinking in the pipeline — finding what a plan is missing. Binding a strong model to the reviewer and a cheaper one to the drafting turns often gives better plans than running everything on one mid-tier model.
 
 **Plan granularity** — large, medium or small — lives in the same section and controls how finely the resulting plan is split into tasks. That directly shapes the board you get next.
+
+If a review pass keeps getting cut short, the review timeout is only half the story: the watchdog also stops a reviewer that goes quiet for too long. See [Settings → Agents → Watchdog](../apps/settings.md) → Agent supervision for the stall timeout and repeated-tool limit.
 
 ## What you end up with
 

--- a/server/settings/registry-manifest.json
+++ b/server/settings/registry-manifest.json
@@ -86,6 +86,7 @@
   {
     "key": "general.desktop.zoom",
     "label": "Interface zoom",
+    "description": "Scale the Minnow desktop window (Electron shell only).",
     "keywords": [
       "zoom",
       "scale",
@@ -1313,7 +1314,7 @@
   {
     "key": "agents.watchdog",
     "label": "Watchdog",
-    "description": "Server-side generation limits while models and agents stream.",
+    "description": "Limits that stop a hung run: generation timeouts plus agent stall and loop detection.",
     "keywords": [
       "timeout",
       "stall",
@@ -1349,6 +1350,34 @@
     "type": "number",
     "sensitivity": "normal",
     "writable": true,
+    "refreshAreas": [
+      "watchdog"
+    ]
+  },
+  {
+    "key": "agents.watchdog.supervision",
+    "label": "Agent supervision",
+    "description": "Stall timeout, heartbeat liveness, and repeated-tool loop detection for sub-agents and orchestrate task chats.",
+    "keywords": [
+      "stall",
+      "progress stall",
+      "heartbeat",
+      "heartbeat dead",
+      "unresponsive",
+      "duplicate tool",
+      "repeated tool",
+      "loop",
+      "repetition",
+      "recovery",
+      "sub-agent",
+      "plan review"
+    ],
+    "category": "agents",
+    "area": "watchdog",
+    "storage": "section",
+    "type": "string",
+    "sensitivity": "normal",
+    "writable": false,
     "refreshAreas": [
       "watchdog"
     ]

--- a/src/agents/controller/controller.ts
+++ b/src/agents/controller/controller.ts
@@ -7,6 +7,7 @@ import { normalizeModeId } from '../../chat/modes/types';
 import { getBoardGroupForChat } from '../../state/chat-groups';
 import { appendTaskRunHistory, getBoardExecutionMode, isBoardRunning, updateTask } from '../../state/orchestrate-board-store';
 import { resolveSelfHealMaxRounds } from '../../config/autopilot-meta';
+import { resolveSupervisionThresholds } from '../../config/supervision-thresholds';
 import { findChatById } from '../../state/sessions';
 import { executeTool, getEnabledToolDefinitionsForMode } from '../../tools/client';
 import { loadSubAgentConfig } from '../sub-agent-config';
@@ -478,11 +479,9 @@ async function executeRun(internals: RunInternals, modeId: string): Promise<void
     const timeoutMs = internals.spawnTimeoutMs ?? typeConfig.timeoutMs ?? config.defaultTimeoutMs;
     const checkInMs = config.checkInNudgeMs ?? 0;
     armRunTimers(internals, timeoutMs, checkInMs, runTimerHandlers);
-    setHeartbeatConfig({
-      heartbeatIntervalMs: config.heartbeatIntervalMs,
-      progressStallMs: config.progressStallMs,
-      heartbeatDeadMs: config.heartbeatDeadMs,
-    });
+    // Resolved centrally so a board dispatch and a sub-agent dispatch cannot write
+    // different values into the shared heartbeat singleton.
+    setHeartbeatConfig(resolveSupervisionThresholds());
     setRepetitionThresholds({
       duplicateToolCallThreshold: config.duplicateToolCallThreshold,
     });
@@ -1149,11 +1148,15 @@ async function tier1RestartSubAgent(runId: string, reason: string): Promise<void
     category,
     idempotencyKey,
     attempt,
+    providerId,
+    modelId,
   } = old;
 
   const note = `Watchdog tier-1 recovery (${reason})`;
   const nextTask = `${note}\n\n${task}`;
 
+  // Carry the spawn-site model and timeout: without them the recovery run silently
+  // falls back to the type/parent binding and the caller's own deadline.
   const result = await spawnSubAgentInternal({
     type,
     task: nextTask,
@@ -1164,6 +1167,11 @@ async function tier1RestartSubAgent(runId: string, reason: string): Promise<void
     boardTaskId: boardTaskId ?? undefined,
     category,
     modeId: internals.spawnModeId,
+    ...(providerId ? { providerId } : {}),
+    ...(modelId ? { modelId } : {}),
+    ...(internals.spawnTimeoutMs !== undefined
+      ? { timeoutMs: internals.spawnTimeoutMs }
+      : {}),
   });
 
   internals.run.supersededByRunId = result.runId;
@@ -1219,6 +1227,8 @@ async function tier2AutoRecover(runId: string, reason: string): Promise<void> {
     category,
     idempotencyKey,
     attempt,
+    providerId,
+    modelId,
   } = old;
 
   const cap = resolveSelfHealMaxRounds();
@@ -1240,6 +1250,11 @@ async function tier2AutoRecover(runId: string, reason: string): Promise<void> {
     boardTaskId: boardTaskId ?? undefined,
     category,
     modeId: internals.spawnModeId,
+    ...(providerId ? { providerId } : {}),
+    ...(modelId ? { modelId } : {}),
+    ...(internals.spawnTimeoutMs !== undefined
+      ? { timeoutMs: internals.spawnTimeoutMs }
+      : {}),
   });
 
   internals.run.supersededByRunId = result.runId;
@@ -1415,6 +1430,7 @@ function registerControllerWatchdogHandlers(): void {
     tier2Surface: tier2SurfaceSubAgent,
     tier2AutoRecover,
     isRunAfkSupervised,
+    resolveMaxRecoveryAttempts: resolveSelfHealMaxRounds,
     finalizeDoneUnacked: finalizeDoneUnackedSubAgent,
     onLifecycleChange: (run) => {
       mirrorRegistryEntry(run);

--- a/src/agents/controller/watchdog.ts
+++ b/src/agents/controller/watchdog.ts
@@ -37,6 +37,9 @@ const runState = new Map<string, WatchdogRunState>();
 
 let tickTimer: ReturnType<typeof setInterval> | null = null;
 
+/** Recovery attempts allowed when the controller has not supplied a cap. */
+export const DEFAULT_MAX_RECOVERY_ATTEMPTS = 4;
+
 export interface WatchdogHandlers {
   tier1Restart: (runId: string, reason: string) => Promise<void>;
   tier2Surface: (runId: string, reason: string) => void;
@@ -44,6 +47,8 @@ export interface WatchdogHandlers {
   isRunAfkSupervised: (run: SubAgentRun) => boolean;
   finalizeDoneUnacked: (runId: string) => void;
   onLifecycleChange: (run: SubAgentRun) => void;
+  /** Total dispatches allowed per logical task, across the supersession chain. */
+  resolveMaxRecoveryAttempts: () => number;
 }
 
 const noopHandlers: WatchdogHandlers = {
@@ -53,6 +58,7 @@ const noopHandlers: WatchdogHandlers = {
   isRunAfkSupervised: () => false,
   finalizeDoneUnacked: () => {},
   onLifecycleChange: () => {},
+  resolveMaxRecoveryAttempts: () => DEFAULT_MAX_RECOVERY_ATTEMPTS,
 };
 
 let handlers: WatchdogHandlers = { ...noopHandlers };
@@ -186,8 +192,13 @@ async function enterSuspect(run: SubAgentRun, reason: string): Promise<void> {
   try {
     setRunLifecycle(run, 'suspect');
 
+    // `tier1Attempted` only guards this run id, and a tier-1 restart mints a new one,
+    // so it alone would let a structurally-stalled task restart forever. `run.attempt`
+    // carries across the supersession chain and is the real cap.
     const canTier1 =
-      isNonMutatingSubAgentRun(run) && !state.tier1Attempted;
+      isNonMutatingSubAgentRun(run) &&
+      !state.tier1Attempted &&
+      (run.attempt ?? 1) < handlers.resolveMaxRecoveryAttempts();
 
     if (canTier1) {
       state.tier1Attempted = true;

--- a/src/agents/self-healing/detector.ts
+++ b/src/agents/self-healing/detector.ts
@@ -22,6 +22,32 @@ export interface DetectionResult {
 export interface DetectorThresholds {
   duplicateToolCallThreshold: number;
   sameErrorThreshold: number;
+  /**
+   * How many of the most recent calls to consider. Defaults to 4x the duplicate
+   * threshold (floor {@link MIN_REPETITION_WINDOW}).
+   */
+  windowSize?: number;
+}
+
+/**
+ * Smallest sliding window, so a low duplicate threshold still needs the repeats
+ * to be genuinely close together.
+ */
+export const MIN_REPETITION_WINDOW = 12;
+
+/** Sliding-window size for duplicate detection. */
+export function resolveRepetitionWindow(
+  duplicateToolCallThreshold: number,
+  windowSize?: number,
+): number {
+  if (
+    typeof windowSize === 'number' &&
+    Number.isFinite(windowSize) &&
+    windowSize > 0
+  ) {
+    return Math.max(duplicateToolCallThreshold, Math.round(windowSize));
+  }
+  return Math.max(MIN_REPETITION_WINDOW, duplicateToolCallThreshold * 4);
 }
 
 function stableHash(input: string): string {
@@ -52,7 +78,14 @@ function normalizeArgsJson(argsJson: string): string {
   }
 }
 
-/** Detect duplicate tool calls with identical normalized args. */
+/**
+ * Detect duplicate tool calls with identical normalized args.
+ *
+ * Only the most recent {@link resolveRepetitionWindow} calls are considered. Counting
+ * over the whole run instead flags ordinary work — a reviewer that re-reads the same
+ * plan file five times across a long run is not looping, but five identical calls
+ * bunched together is.
+ */
 export function detectRepetition(
   log: ToolCallLogEntry[],
   thresholds: DetectorThresholds,
@@ -65,8 +98,14 @@ export function detectRepetition(
     return null;
   }
 
+  const windowSize = resolveRepetitionWindow(
+    thresholds.duplicateToolCallThreshold,
+    thresholds.windowSize,
+  );
+  const recent = log.length > windowSize ? log.slice(-windowSize) : log;
+
   const counts = new Map<string, number>();
-  for (const entry of log) {
+  for (const entry of recent) {
     const key = `${entry.name}::${normalizeArgsJson(entry.argsJson)}`;
     counts.set(key, (counts.get(key) ?? 0) + 1);
     if ((counts.get(key) ?? 0) >= thresholds.duplicateToolCallThreshold) {

--- a/src/agents/sub-agent-config.ts
+++ b/src/agents/sub-agent-config.ts
@@ -232,6 +232,7 @@ export async function saveSubAgentConfigToServer(
   writeLocalSubAgents(overrides);
   runtimeUserOverrides = overrides;
   cachedMerged = null;
+  cachedUserOverrides = undefined;
   return true;
 }
 

--- a/src/chat/super-plan/stages.ts
+++ b/src/chat/super-plan/stages.ts
@@ -5,6 +5,7 @@
 import type { AggregateResult } from '../../agents/types';
 import { spawnSubAgent, waitForSubAgent } from '../../agents/orchestrator';
 import {
+  DEFAULT_SUPER_PLAN_CONFIG,
   getSuperPlanConfigSync,
   loadSuperPlanConfig,
   resolveSuperPlanResearchMaxRounds,
@@ -147,7 +148,6 @@ async function readFileOrEmpty(path: string | undefined): Promise<string> {
 const RESEARCH_POLL_INTERVAL_MS = 3000;
 const RESEARCH_TIMEOUT_MS = 30 * 60 * 1000;
 const RESEARCH_MAX_CONSECUTIVE_POLL_FAILURES = 5;
-const REVIEW_SUB_AGENT_TIMEOUT_MS = 20 * 60 * 1000;
 
 type ResearchWaitResult = { kind: 'done'; report: string } | { kind: 'paused' };
 
@@ -214,10 +214,10 @@ function isAggregateResult(value: unknown): value is AggregateResult {
 }
 
 /** Friendly message shared by both timeout detection paths (abort + type-level timer). */
-function reviewTimeoutError(pass: number): Error {
+function reviewTimeoutError(pass: number, timeoutMs: number): Error {
   return new Error(
-    `Plan review (pass ${pass}) timed out after ${REVIEW_SUB_AGENT_TIMEOUT_MS / 60000} minutes — ` +
-      'retry the stage, or lower review rounds in Super Plan settings.',
+    `Plan review (pass ${pass}) timed out after ${Math.round(timeoutMs / 60000)} minutes — ` +
+      'retry the stage, or raise the review timeout in Super Plan settings.',
   );
 }
 
@@ -225,6 +225,7 @@ function reviewTimeoutError(pass: number): Error {
 export function assertPlanReviewerAggregate(
   result: unknown,
   pass: number,
+  timeoutMs: number = DEFAULT_SUPER_PLAN_CONFIG.reviewTimeoutMs,
 ): AggregateResult {
   if (!isAggregateResult(result)) {
     throw new Error(`Plan review (pass ${pass}) did not return a sub-agent result.`);
@@ -232,7 +233,7 @@ export function assertPlanReviewerAggregate(
   if (result.status === 'cancelled' && result.error === 'timeout') {
     // The sub-agent type's own wall-clock timer fired (possibly racing the
     // stage's AbortSignal.timeout below) — report it the same way either way.
-    throw reviewTimeoutError(pass);
+    throw reviewTimeoutError(pass, timeoutMs);
   }
   const summary = (result.outcome?.summary ?? result.summary ?? '').trim();
   const placeholder = 'Sub-agent completed with no text output.';
@@ -389,13 +390,14 @@ async function runReviewStage(
     priorCritique: pass === 2 ? state.review1Critique : undefined,
   });
 
+  const reviewTimeoutMs = config.reviewTimeoutMs;
   const spawned = await spawnSubAgent({
     type: 'plan-reviewer',
     task,
     wait: false,
     parentChatId: chat.id,
     modeId: 'super-plan',
-    timeoutMs: REVIEW_SUB_AGENT_TIMEOUT_MS,
+    timeoutMs: reviewTimeoutMs,
     ...(config.reviewerModel.providerId?.trim()
       ? { providerId: config.reviewerModel.providerId.trim() }
       : {}),
@@ -412,11 +414,11 @@ async function runReviewStage(
   try {
     result = await waitForSubAgent(
       spawned.runId,
-      AbortSignal.timeout(REVIEW_SUB_AGENT_TIMEOUT_MS),
+      AbortSignal.timeout(reviewTimeoutMs),
     );
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
-      throw reviewTimeoutError(pass);
+      throw reviewTimeoutError(pass, reviewTimeoutMs);
     }
     throw err;
   } finally {
@@ -432,7 +434,7 @@ async function runReviewStage(
     return { kind: 'paused' };
   }
 
-  const aggregate = assertPlanReviewerAggregate(result, pass);
+  const aggregate = assertPlanReviewerAggregate(result, pass, reviewTimeoutMs);
   const critique = formatReviewCritiqueForPass2(
     aggregate.outcome?.summary ?? aggregate.summary,
     JSON.stringify(aggregate.outcome?.findings ?? [], null, 2),

--- a/src/config/autopilot-meta.ts
+++ b/src/config/autopilot-meta.ts
@@ -28,8 +28,11 @@ export interface AutopilotMeta {
   maxFinalTestAttempts: number;
   /** When Continue should auto-route to a fresh summarized chat instead of nudging. */
   continueSmartRoute: AutopilotContinueSmartRoute;
+  /** @deprecated Read-only legacy fallback — see config/supervision-thresholds. */
   heartbeatIntervalMs: number;
+  /** @deprecated Read-only legacy fallback — see config/supervision-thresholds. */
   progressStallMs: number;
+  /** @deprecated Read-only legacy fallback — see config/supervision-thresholds. */
   heartbeatDeadMs: number;
   plannerProviderId: string;
   plannerModelId: string;

--- a/src/config/super-plan-meta.ts
+++ b/src/config/super-plan-meta.ts
@@ -37,6 +37,8 @@ export interface SuperPlanConfig {
   reviewerModel: SuperPlanStageModelBinding;
   /** Optional model override for planner draft/finalize chat turns. */
   plannerModel: SuperPlanStageModelBinding;
+  /** Wall-clock budget for one plan-review pass (spawn timeout + stage wait). */
+  reviewTimeoutMs: number;
 }
 
 const SUPER_PLAN_META_STORAGE_KEY = 'minnow.superPlanMeta';
@@ -53,7 +55,15 @@ export const DEFAULT_SUPER_PLAN_CONFIG: SuperPlanConfig = {
   researchModel: { providerId: '', modelId: '' },
   reviewerModel: { providerId: '', modelId: '' },
   plannerModel: { providerId: '', modelId: '' },
+  reviewTimeoutMs: 20 * 60 * 1000,
 };
+
+/** Coerce the review budget to [5 min, 120 min]. */
+export function clampReviewTimeoutMs(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return DEFAULT_SUPER_PLAN_CONFIG.reviewTimeoutMs;
+  return Math.min(7_200_000, Math.max(300_000, Math.round(n)));
+}
 
 let cachedSuperPlan: SuperPlanConfig | null = null;
 
@@ -122,6 +132,7 @@ function parseSuperPlanBlock(raw: unknown): SuperPlanConfig {
     researchModel: parseStageModelBinding(models.research ?? block.researchModel),
     reviewerModel: parseStageModelBinding(models.reviewer ?? block.reviewerModel),
     plannerModel: parseStageModelBinding(models.planner ?? block.plannerModel),
+    reviewTimeoutMs: clampReviewTimeoutMs(block.reviewTimeoutMs),
   };
 }
 
@@ -210,6 +221,7 @@ function serializeSuperPlanForMeta(config: SuperPlanConfig): Record<string, unkn
     researchScope: config.researchScope,
     researchMaxRounds: config.researchMaxRounds,
     researchDepth: config.researchDepth,
+    reviewTimeoutMs: config.reviewTimeoutMs,
     models: {
       research: config.researchModel,
       reviewer: config.reviewerModel,
@@ -263,6 +275,10 @@ export async function saveSuperPlanConfig(
       patch.plannerModel !== undefined
         ? parseStageModelBinding(patch.plannerModel)
         : current.plannerModel,
+    reviewTimeoutMs:
+      patch.reviewTimeoutMs !== undefined
+        ? clampReviewTimeoutMs(patch.reviewTimeoutMs)
+        : current.reviewTimeoutMs,
   };
   cachedSuperPlan = next;
   writeLocalSuperPlanConfig(next);

--- a/src/config/supervision-thresholds.ts
+++ b/src/config/supervision-thresholds.ts
@@ -1,0 +1,119 @@
+/**
+ * Single source of truth for agent supervision thresholds (heartbeat interval H,
+ * progress stall P, heartbeat-dead D).
+ *
+ * These drive the sub-agent watchdog *and* orchestrate board task chats, which both
+ * write the one `heartbeatConfig` singleton in agents/controller/wrapper. They used to
+ * be read from two different stores — sub-agents.json for sub-agents, the config.json
+ * `autopilot` block for boards — so whichever subsystem dispatched last silently won,
+ * and the Autopilot sliders never took effect for sub-agents. Everything resolves here
+ * now, and sub-agents.json is the only place these are written.
+ *
+ * The `autopilot` block is still read as a fallback so values saved before the stores
+ * merged keep applying until they are next changed.
+ */
+
+import DEFAULTS from '../agents/defaults/sub-agents.json';
+import {
+  clampHeartbeatDeadMs,
+  clampHeartbeatIntervalMs,
+  clampProgressStallMs,
+  getSubAgentUserOverridesSync,
+  loadSubAgentConfig,
+  saveSubAgentConfigToServer,
+} from '../agents/sub-agent-config';
+import type { SubAgentsFile } from '../agents/types';
+import { DEFAULT_AUTOPILOT_META, getAutopilotMetaSync } from './autopilot-meta';
+
+export interface SupervisionThresholds {
+  /** How often a running agent reports liveness. */
+  heartbeatIntervalMs: number;
+  /** No observable progress for this long marks the run suspect. */
+  progressStallMs: number;
+  /** No heartbeat for this long treats the run as dead. */
+  heartbeatDeadMs: number;
+}
+
+const SHIPPED = DEFAULTS as SubAgentsFile;
+
+export const DEFAULT_SUPERVISION_THRESHOLDS: SupervisionThresholds = {
+  heartbeatIntervalMs: clampHeartbeatIntervalMs(SHIPPED.heartbeatIntervalMs),
+  progressStallMs: clampProgressStallMs(SHIPPED.progressStallMs),
+  heartbeatDeadMs: clampHeartbeatDeadMs(SHIPPED.heartbeatDeadMs),
+};
+
+/**
+ * Legacy `autopilot` value for a threshold, or null when it was never changed.
+ * DEFAULT_AUTOPILOT_META mirrors the shipped defaults, so equality means "untouched".
+ */
+function legacyAutopilotValue(key: keyof SupervisionThresholds): number | null {
+  const value = getAutopilotMetaSync()[key];
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (value === DEFAULT_AUTOPILOT_META[key]) return null;
+  return value;
+}
+
+/**
+ * Effective thresholds: sub-agents.json override → legacy autopilot value → shipped
+ * default. Sync; callers that need fresh data should await {@link loadSupervisionThresholds}.
+ */
+export function resolveSupervisionThresholds(): SupervisionThresholds {
+  const user = getSubAgentUserOverridesSync();
+  return {
+    heartbeatIntervalMs: clampHeartbeatIntervalMs(
+      user?.heartbeatIntervalMs ??
+        legacyAutopilotValue('heartbeatIntervalMs') ??
+        DEFAULT_SUPERVISION_THRESHOLDS.heartbeatIntervalMs,
+      DEFAULT_SUPERVISION_THRESHOLDS.heartbeatIntervalMs,
+    ),
+    progressStallMs: clampProgressStallMs(
+      user?.progressStallMs ??
+        legacyAutopilotValue('progressStallMs') ??
+        DEFAULT_SUPERVISION_THRESHOLDS.progressStallMs,
+      DEFAULT_SUPERVISION_THRESHOLDS.progressStallMs,
+    ),
+    heartbeatDeadMs: clampHeartbeatDeadMs(
+      user?.heartbeatDeadMs ??
+        legacyAutopilotValue('heartbeatDeadMs') ??
+        DEFAULT_SUPERVISION_THRESHOLDS.heartbeatDeadMs,
+      DEFAULT_SUPERVISION_THRESHOLDS.heartbeatDeadMs,
+    ),
+  };
+}
+
+/** Prime the sub-agents config cache, then resolve. */
+export async function loadSupervisionThresholds(): Promise<SupervisionThresholds> {
+  await loadSubAgentConfig();
+  return resolveSupervisionThresholds();
+}
+
+/** Persist thresholds to sub-agents.json (the only writable store). */
+export async function saveSupervisionThresholds(
+  patch: Partial<SupervisionThresholds>,
+): Promise<SupervisionThresholds> {
+  const current = await loadSubAgentConfig();
+  const next = { ...current };
+
+  if (patch.heartbeatIntervalMs !== undefined) {
+    next.heartbeatIntervalMs = clampHeartbeatIntervalMs(
+      patch.heartbeatIntervalMs,
+      DEFAULT_SUPERVISION_THRESHOLDS.heartbeatIntervalMs,
+    );
+  }
+  if (patch.progressStallMs !== undefined) {
+    next.progressStallMs = clampProgressStallMs(
+      patch.progressStallMs,
+      DEFAULT_SUPERVISION_THRESHOLDS.progressStallMs,
+    );
+  }
+  if (patch.heartbeatDeadMs !== undefined) {
+    next.heartbeatDeadMs = clampHeartbeatDeadMs(
+      patch.heartbeatDeadMs,
+      DEFAULT_SUPERVISION_THRESHOLDS.heartbeatDeadMs,
+    );
+  }
+
+  const ok = await saveSubAgentConfigToServer(next);
+  if (!ok) throw new Error('Could not save supervision thresholds');
+  return resolveSupervisionThresholds();
+}

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -30,6 +30,7 @@ import {
   resolveSelfHealMaxRounds,
   resolveMaxEnvFixAttempts,
 } from '../config/autopilot-meta.ts';
+import { resolveSupervisionThresholds } from '../config/supervision-thresholds.ts';
 import {
   classifyTaskFailure,
   extractChatFailureText,
@@ -655,12 +656,8 @@ function recordFixerStallStopForTests(taskId: string, chatId: string): void {
 const fixerFinalizeInFlight = new Set<string>();
 
 function refreshHeartbeatThresholds(): void {
-  const meta = getAutopilotMetaSync();
-  setHeartbeatConfig({
-    heartbeatIntervalMs: meta.heartbeatIntervalMs,
-    progressStallMs: meta.progressStallMs,
-    heartbeatDeadMs: meta.heartbeatDeadMs,
-  });
+  // Shared singleton with the sub-agent watchdog — both sides must resolve identically.
+  setHeartbeatConfig(resolveSupervisionThresholds());
 }
 
 /** How a linked task chat ended its latest assistant turn. */
@@ -1257,7 +1254,7 @@ function startTaskChatSupervision(chatId: string): void {
 
     const sup = getRunSupervision(runId);
     if (!sup) return;
-    const meta = getAutopilotMetaSync();
+    const thresholds = resolveSupervisionThresholds();
     const progressAge = getProgressAgeMs(runId);
     if (progressAge == null) return;
 
@@ -1269,7 +1266,7 @@ function startTaskChatSupervision(chatId: string): void {
 
     const stallTask = group.orchestrateBoard.tasks.find((t) => t.id === taskId);
 
-    const stallMs = meta.progressStallMs * TASK_CHAT_STALL_MULTIPLIER;
+    const stallMs = thresholds.progressStallMs * TASK_CHAT_STALL_MULTIPLIER;
     if (progressAge < stallMs) return;
 
     const restarts = taskChatStallRestarts.get(chatId) ?? 0;

--- a/src/ui/settings-agent-center.ts
+++ b/src/ui/settings-agent-center.ts
@@ -9,7 +9,6 @@ import '../styles/settings-agent-center.css';
 import { fetchWorkAgentsList } from '../agents/work-agent-prompt-api';
 import type { WorkAgentDefinition } from '../agents/work-agent-types';
 import {
-  clampDuplicateToolCallThreshold,
   getSubAgentUserOverridesSync,
   loadSubAgentConfig,
   saveSubAgentConfigToServer,
@@ -440,7 +439,7 @@ async function mountGlobalSubAgentLimits(mount: HTMLElement): Promise<void> {
   const groupBody = appendSettingsGroup(
     mount,
     'Sub-agent limits',
-    'Global concurrency, timeouts, check-in nudges, and watchdog repetition limits for all sub-agent types.',
+    'Concurrency, wall-clock timeout, and parent check-in nudges for every sub-agent type.',
     'agents.subAgents.limits',
     { emphasis: true },
   );
@@ -453,7 +452,6 @@ async function mountGlobalSubAgentLimits(mount: HTMLElement): Promise<void> {
         | 'globalMaxConcurrent'
         | 'defaultTimeoutMs'
         | 'checkInNudgeMs'
-        | 'duplicateToolCallThreshold'
       >
     >,
   ): Promise<void> => {
@@ -501,21 +499,6 @@ async function mountGlobalSubAgentLimits(mount: HTMLElement): Promise<void> {
   nudgeWrap.appendChild(nudgeInput);
   nudgeWrap.appendChild(el('span', 'settings-kv-suffix', 'sec'));
 
-  const duplicateToolInput = document.createElement('input');
-  duplicateToolInput.type = 'number';
-  duplicateToolInput.className = 'settings-select settings-kv-input';
-  duplicateToolInput.min = '0';
-  duplicateToolInput.max = '256';
-  duplicateToolInput.step = '1';
-  duplicateToolInput.value = String(
-    config.duplicateToolCallThreshold ??
-      clampDuplicateToolCallThreshold(undefined),
-  );
-  duplicateToolInput.setAttribute(
-    'aria-label',
-    'Identical tool calls before watchdog flags repetition (0 disables)',
-  );
-
   groupBody.appendChild(
     createSettingsKvList(
       [
@@ -523,11 +506,18 @@ async function mountGlobalSubAgentLimits(mount: HTMLElement): Promise<void> {
         { term: 'Max concurrent', value: maxInput },
         { term: 'Default timeout', value: timeoutWrap },
         { term: 'Check-in nudge', value: nudgeWrap },
-        { term: 'Duplicate tool limit', value: duplicateToolInput },
       ],
       { className: 'settings-kv settings-kv--row' },
     ),
   );
+
+  const limitsHint = el('p', 'settings-field-hint');
+  limitsHint.append(
+    'Default timeout is the wall-clock budget for one sub-agent run; a caller that passes its own timeout wins. Check-in nudge reminds the parent agent once while a sub-agent runs (Build, General, and Research only; 0 turns it off). Neither affects stall detection — that lives under ',
+    linkToSettingsSection('Watchdog', 'watchdog'),
+    ' → Agent supervision.',
+  );
+  groupBody.appendChild(limitsHint);
 
   enabledCb.addEventListener('change', () => {
     void persistGlobal({ enabled: enabledCb.checked });
@@ -548,13 +538,6 @@ async function mountGlobalSubAgentLimits(mount: HTMLElement): Promise<void> {
       rawSec <= 0 ? 0 : Math.min(1_800, Math.max(10, rawSec));
     nudgeInput.value = String(seconds);
     void persistGlobal({ checkInNudgeMs: secondsToMs(seconds) });
-  });
-  duplicateToolInput.addEventListener('change', () => {
-    const value = clampDuplicateToolCallThreshold(
-      Number(duplicateToolInput.value),
-    );
-    duplicateToolInput.value = String(value);
-    void persistGlobal({ duplicateToolCallThreshold: value });
   });
 }
 

--- a/src/ui/settings-autopilot.ts
+++ b/src/ui/settings-autopilot.ts
@@ -5,11 +5,6 @@
 import '../styles/settings-general.css';
 
 import {
-  clampHeartbeatDeadMs,
-  clampHeartbeatIntervalMs,
-  clampProgressStallMs,
-} from '../agents/sub-agent-config';
-import {
   loadAutopilotMeta,
   saveAutopilotMeta,
   type AutopilotContinueSmartRoute,
@@ -102,7 +97,9 @@ export async function renderAutopilotSettingsSection(mount: HTMLElement): Promis
 
   const lead = el('p', 'settings-section-lead');
   lead.append(
-    'Global defaults for orchestrate boards: execution mode, concurrency, isolation, test retries, heartbeat thresholds, and planner model fallback. Per-board overrides stay on the board header. Work agents live under ',
+    'Global defaults for orchestrate boards: execution mode, concurrency, isolation, test retries, and planner model fallback. Per-board overrides stay on the board header. Stall and heartbeat thresholds live under ',
+    linkToSettingsSection('Watchdog', 'watchdog'),
+    '; work agents under ',
     linkToSettingsSection('Agents', 'agent-center'),
     '; provider models under ',
     linkToSettingsSection('Providers', 'providers'),
@@ -256,44 +253,12 @@ export async function renderAutopilotSettingsSection(mount: HTMLElement): Promis
   const heartbeatBody = appendSettingsGroup(
     content,
     'Heartbeat & stall',
-    'Supervision thresholds for orchestrate task chats (build, test, fix, final).',
+    'Stall and heartbeat thresholds now live on the Watchdog page — they apply to sub-agents and task chats alike.',
     'agents.autopilot.heartbeat',
-    { emphasis: true },
   );
-
-  const heartbeat = createKvSecondsInput(meta.heartbeatIntervalMs, {
-    minSeconds: 1,
-    maxSeconds: 60,
-    ariaLabel: 'Heartbeat interval in seconds',
-  });
-  const stall = createKvSecondsInput(meta.progressStallMs, {
-    minSeconds: 10,
-    maxSeconds: 1800,
-    ariaLabel: 'Progress stall in seconds',
-  });
-  const dead = createKvSecondsInput(meta.heartbeatDeadMs, {
-    minSeconds: 5,
-    maxSeconds: 300,
-    ariaLabel: 'Heartbeat dead threshold in seconds',
-  });
-
-  heartbeatBody.appendChild(
-    createSettingsKvList(
-      [
-        { term: 'Heartbeat interval', value: heartbeat.wrap },
-        { term: 'Progress stall', value: stall.wrap },
-        { term: 'Heartbeat dead', value: dead.wrap },
-      ],
-      { className: 'settings-kv settings-kv--row' },
-    ),
-  );
-  heartbeatBody.appendChild(
-    el(
-      'p',
-      'settings-field-hint',
-      'Progress stall marks a task as stalled when no progress arrives for that duration. Heartbeat dead treats the supervisor as unresponsive after prolonged silence.',
-    ),
-  );
+  const heartbeatMoved = el('p', 'settings-field-hint');
+  heartbeatMoved.append('Open ', linkToSettingsSection('Watchdog', 'watchdog'), ' → Agent supervision.');
+  heartbeatBody.appendChild(heartbeatMoved);
 
   const plannerBody = appendSettingsGroup(
     content,
@@ -433,24 +398,6 @@ export async function renderAutopilotSettingsSection(mount: HTMLElement): Promis
     void persist({
       continueSmartRoute: smartRouteSelect.value as AutopilotContinueSmartRoute,
     });
-  });
-  heartbeat.input.addEventListener('change', () => {
-    const ms = clampHeartbeatIntervalMs(
-      secondsToMs(Number(heartbeat.input.value)),
-      meta.heartbeatIntervalMs,
-    );
-    heartbeat.input.value = String(msToSeconds(ms));
-    void persist({ heartbeatIntervalMs: ms });
-  });
-  stall.input.addEventListener('change', () => {
-    const ms = clampProgressStallMs(secondsToMs(Number(stall.input.value)), meta.progressStallMs);
-    stall.input.value = String(msToSeconds(ms));
-    void persist({ progressStallMs: ms });
-  });
-  dead.input.addEventListener('change', () => {
-    const ms = clampHeartbeatDeadMs(secondsToMs(Number(dead.input.value)), meta.heartbeatDeadMs);
-    dead.input.value = String(msToSeconds(ms));
-    void persist({ heartbeatDeadMs: ms });
   });
   providerSelect.addEventListener('change', async () => {
     await fillModelSelect(modelSelect, providerSelect.value, modelSelect.value);

--- a/src/ui/settings-catalog.ts
+++ b/src/ui/settings-catalog.ts
@@ -344,12 +344,31 @@ const SETTINGS_FIELD_CATALOG_ALL: SettingsFieldEntry[] = [
   field('agents.autopilot.plannerModel', 'Default planner model', 'agents', 'autopilot'),
   field('agents.watchdog', 'Watchdog', 'agents', 'watchdog', {
     keywords: ['timeout', 'stall', 'generation', 'streaming', 'heartbeat', 'recovery'],
-    description: 'Server-side generation limits while models and agents stream.',
+    description:
+      'Limits that stop a hung run: generation timeouts plus agent stall and loop detection.',
   }),
   field('agents.watchdog.generation', 'Generation timeouts', 'agents', 'watchdog', {
     keywords: ['idle timeout', 'max duration', 'streaming', 'upstream'],
     description:
       'Idle and max-duration limits while streaming from the model. Idle timeout resets when new tokens arrive.',
+  }),
+  field('agents.watchdog.supervision', 'Agent supervision', 'agents', 'watchdog', {
+    keywords: [
+      'stall',
+      'progress stall',
+      'heartbeat',
+      'heartbeat dead',
+      'unresponsive',
+      'duplicate tool',
+      'repeated tool',
+      'loop',
+      'repetition',
+      'recovery',
+      'sub-agent',
+      'plan review',
+    ],
+    description:
+      'Stall timeout, heartbeat liveness, and repeated-tool loop detection for sub-agents and orchestrate task chats.',
   }),
   field('agents.autopilot.selfHeal', 'Self-heal & provisioning', 'agents', 'autopilot', {
     keywords: ['self-heal', 'provision', 'quarantine', 'infra', 'worktree', 'stall'],

--- a/src/ui/settings-sections.ts
+++ b/src/ui/settings-sections.ts
@@ -57,6 +57,7 @@ import { renderFilesystemAccessSettings } from './settings-filesystem';
 import { renderAppUpdatesSettings } from './settings-updates';
 import { renderAgentPacksSettingsSection } from './settings-agent-packs';
 import { renderAutopilotSettingsSection } from './settings-autopilot';
+import { renderAgentSupervisionSection } from './settings-watchdog';
 import { renderSkillsSettingsSection } from './settings-skills';
 import { renderSkillsLibrarySettingsSection } from './settings-skills-library';
 import {
@@ -1366,6 +1367,7 @@ async function appendGenerationTimeoutsSection(
 }
 
 async function renderWatchdogSection(): Promise<void> {
+  const generation = beginAsyncSectionRender('watchdog');
   const mount = clearMount('settingsWatchdogBody');
   if (!mount) return;
 
@@ -1374,13 +1376,15 @@ async function renderWatchdogSection(): Promise<void> {
 
   const lead = el('p', 'settings-section-lead');
   lead.textContent =
-    'Server-side limits while models and agents stream. Applies to the next generation; no restart needed.';
+    'Limits that stop a run when it hangs: how long the model may stream without output, and how long an agent may go without visible progress before the watchdog recovers or blocks it. Applies to the next run; no restart needed.';
   shell.appendChild(lead);
 
   const content = el('div', 'settings-general__content');
   shell.appendChild(content);
 
   await appendGenerationTimeoutsSection(content, { emphasis: true });
+  if (isAsyncSectionRenderStale('watchdog', generation)) return;
+  await renderAgentSupervisionSection(content, { emphasis: true });
 }
 
 let toolsSectionInitialized = false;

--- a/src/ui/settings-watchdog.ts
+++ b/src/ui/settings-watchdog.ts
@@ -1,0 +1,191 @@
+/**
+ * Settings → Agents → Watchdog: agent supervision thresholds.
+ *
+ * These used to be split between Autopilot ("Heartbeat & stall") and the Agents page
+ * ("Duplicate tool limit"), which hid the fact that they are one policy applied to both
+ * sub-agents and orchestrate task chats.
+ */
+
+import {
+  clampDuplicateToolCallThreshold,
+  loadSubAgentConfig,
+  saveSubAgentConfigToServer,
+} from '../agents/sub-agent-config';
+import { resolveSelfHealMaxRounds } from '../config/autopilot-meta';
+import {
+  loadSupervisionThresholds,
+  saveSupervisionThresholds,
+  type SupervisionThresholds,
+} from '../config/supervision-thresholds';
+import { appendSettingsGroup, linkToSettingsSection } from './settings-layout';
+import { createSettingsKvList } from './settings-controls';
+import { msToSeconds, secondsToMs } from './settings-duration';
+import { setStatus } from './status';
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function createSecondsInput(
+  valueMs: number,
+  options: { minSeconds: number; maxSeconds: number; ariaLabel: string },
+): { wrap: HTMLElement; input: HTMLInputElement } {
+  const wrap = el('span', 'settings-kv-input-wrap');
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.className = 'settings-select settings-kv-input';
+  input.min = String(options.minSeconds);
+  input.max = String(options.maxSeconds);
+  input.step = '1';
+  input.value = String(msToSeconds(valueMs));
+  input.setAttribute('aria-label', options.ariaLabel);
+  wrap.appendChild(input);
+  wrap.appendChild(el('span', 'settings-kv-suffix', 'sec'));
+  return { wrap, input };
+}
+
+/** Mount the supervision thresholds panel (Settings → Agents → Watchdog). */
+export async function renderAgentSupervisionSection(
+  mount: HTMLElement,
+  options?: { emphasis?: boolean },
+): Promise<void> {
+  const [thresholds, subAgents] = await Promise.all([
+    loadSupervisionThresholds(),
+    loadSubAgentConfig(),
+  ]);
+
+  const body = appendSettingsGroup(
+    mount,
+    'Agent supervision',
+    'When a running agent looks stuck, the watchdog steps in. Applies to sub-agents and to orchestrate task chats.',
+    'agents.watchdog.supervision',
+    options?.emphasis ? { emphasis: true } : undefined,
+  );
+
+  const persistThresholds = async (
+    patch: Partial<SupervisionThresholds>,
+  ): Promise<void> => {
+    try {
+      await saveSupervisionThresholds(patch);
+      setStatus('ok', 'Supervision thresholds saved');
+    } catch {
+      setStatus('err', 'Could not save. Open or restart Minnow and try again.');
+    }
+  };
+
+  const stall = createSecondsInput(thresholds.progressStallMs, {
+    minSeconds: 10,
+    maxSeconds: 1800,
+    ariaLabel: 'Stall timeout in seconds',
+  });
+  const dead = createSecondsInput(thresholds.heartbeatDeadMs, {
+    minSeconds: 5,
+    maxSeconds: 300,
+    ariaLabel: 'Unresponsive threshold in seconds',
+  });
+  const heartbeat = createSecondsInput(thresholds.heartbeatIntervalMs, {
+    minSeconds: 1,
+    maxSeconds: 60,
+    ariaLabel: 'Heartbeat interval in seconds',
+  });
+
+  const duplicateInput = document.createElement('input');
+  duplicateInput.type = 'number';
+  duplicateInput.className = 'settings-select settings-kv-input';
+  duplicateInput.min = '0';
+  duplicateInput.max = '256';
+  duplicateInput.step = '1';
+  duplicateInput.value = String(
+    subAgents.duplicateToolCallThreshold ?? clampDuplicateToolCallThreshold(undefined),
+  );
+  duplicateInput.setAttribute(
+    'aria-label',
+    'Repeated tool calls before the run counts as looping (0 disables)',
+  );
+
+  body.appendChild(
+    createSettingsKvList([
+      { term: 'Stall timeout', value: stall.wrap },
+      { term: 'Unresponsive after', value: dead.wrap },
+      { term: 'Heartbeat interval', value: heartbeat.wrap },
+      { term: 'Repeated tool limit', value: duplicateInput },
+    ]),
+  );
+
+  const explain = el('div', 'settings-field-hint');
+  explain.appendChild(
+    el(
+      'p',
+      undefined,
+      'Stall timeout — how long an agent may go without producing anything observable (streamed text, reasoning, or a tool call) before it counts as stuck. Long single-shot reasoning is the usual false positive; raise this if your reviewer model thinks for minutes at a time.',
+    ),
+  );
+  explain.appendChild(
+    el(
+      'p',
+      undefined,
+      'Unresponsive after — how long without any heartbeat at all before the run is treated as dead. This is process-level liveness, not model output, so it should stay well below the stall timeout.',
+    ),
+  );
+  explain.appendChild(
+    el(
+      'p',
+      undefined,
+      'Heartbeat interval — how often a running agent reports in. Lower values detect a dead run sooner at the cost of more timer wakeups.',
+    ),
+  );
+  explain.appendChild(
+    el(
+      'p',
+      undefined,
+      'Repeated tool limit — how many identical tool calls (same name and arguments) may occur close together before the run counts as looping. Repeats spread across a long run are ignored. Set 0 to turn loop detection off.',
+    ),
+  );
+  body.appendChild(explain);
+
+  const recovery = el('p', 'settings-field-hint');
+  recovery.append(
+    `When a run trips any of these, read-only agents are restarted from scratch, up to ${resolveSelfHealMaxRounds()} attempts per task. Agents that can write files are not auto-restarted — the task is marked blocked so you can look at it. Change the attempt cap under `,
+    linkToSettingsSection('Autopilot', 'autopilot'),
+    ' → Self-heal & provisioning.',
+  );
+  body.appendChild(recovery);
+
+  stall.input.addEventListener('change', () => {
+    const seconds = Math.min(1800, Math.max(10, Math.round(Number(stall.input.value) || 0)));
+    stall.input.value = String(seconds);
+    void persistThresholds({ progressStallMs: secondsToMs(seconds) });
+  });
+  dead.input.addEventListener('change', () => {
+    const seconds = Math.min(300, Math.max(5, Math.round(Number(dead.input.value) || 0)));
+    dead.input.value = String(seconds);
+    void persistThresholds({ heartbeatDeadMs: secondsToMs(seconds) });
+  });
+  heartbeat.input.addEventListener('change', () => {
+    const seconds = Math.min(60, Math.max(1, Math.round(Number(heartbeat.input.value) || 0)));
+    heartbeat.input.value = String(seconds);
+    void persistThresholds({ heartbeatIntervalMs: secondsToMs(seconds) });
+  });
+  duplicateInput.addEventListener('change', () => {
+    void (async () => {
+      const value = clampDuplicateToolCallThreshold(Number(duplicateInput.value));
+      duplicateInput.value = String(value);
+      const fresh = await loadSubAgentConfig();
+      const ok = await saveSubAgentConfigToServer({
+        ...fresh,
+        duplicateToolCallThreshold: value,
+      });
+      setStatus(
+        ok ? 'ok' : 'err',
+        ok ? 'Repeated tool limit saved' : 'Could not save. Open or restart Minnow and try again.',
+      );
+    })();
+  });
+}

--- a/src/ui/super-plan-settings.ts
+++ b/src/ui/super-plan-settings.ts
@@ -175,6 +175,15 @@ export function mountSuperPlanSettings(container: HTMLElement): void {
     4,
   );
 
+  const reviewTimeoutInput = appendNumberField(
+    wrap,
+    'Review timeout (minutes)',
+    'superPlanReviewTimeout',
+    'How long one review pass may run before the stage gives up (5–120; default 20). Raise this for slow reviewer models or large plans.',
+    5,
+    120,
+  );
+
   const grillBudgetInput = appendNumberField(
     wrap,
     'Grill question budget',
@@ -282,6 +291,7 @@ export function mountSuperPlanSettings(container: HTMLElement): void {
   const persist = async (): Promise<void> => {
     await saveSuperPlanConfig({
       reviewRounds: Number(reviewRoundsInput.value),
+      reviewTimeoutMs: Number(reviewTimeoutInput.value) * 60_000,
       grillEnabled: grillEnabledInput.checked,
       researchEnabled: researchEnabledInput.checked,
       grillQuestionBudget: Number(grillBudgetInput.value),
@@ -307,6 +317,7 @@ export function mountSuperPlanSettings(container: HTMLElement): void {
   grillEnabledInput.addEventListener('change', () => void persist());
   researchEnabledInput.addEventListener('change', () => void persist());
   reviewRoundsInput.addEventListener('change', () => void persist());
+  reviewTimeoutInput.addEventListener('change', () => void persist());
   grillBudgetInput.addEventListener('change', () => void persist());
   impeccableSelect.addEventListener('change', () => void persist());
   researchScopeSelect.addEventListener('change', () => void persist());
@@ -335,6 +346,7 @@ export function mountSuperPlanSettings(container: HTMLElement): void {
     grillEnabledInput.checked = config.grillEnabled;
     researchEnabledInput.checked = config.researchEnabled;
     reviewRoundsInput.value = String(config.reviewRounds);
+    reviewTimeoutInput.value = String(Math.round(config.reviewTimeoutMs / 60_000));
     grillBudgetInput.value = String(config.grillQuestionBudget);
     impeccableSelect.value = config.impeccable;
     researchScopeSelect.value = config.researchScope;

--- a/test/agents/controller-watchdog.test.mts
+++ b/test/agents/controller-watchdog.test.mts
@@ -258,6 +258,62 @@ describe('controller watchdog', () => {
     assert.equal(active[0]?.lifecycle, 'dispatching');
   });
 
+  test('tier-1 restarts stop at the recovery attempt cap', async () => {
+    setSubAgentRunnerFactory(() => hangingRunner());
+
+    await spawnSubAgent({
+      type: 'explore',
+      task: 'Repeated stall',
+      wait: false,
+      parentChatId: PARENT_CHAT,
+      parentTurnId: 'turn-watchdog-cap',
+      category: 'research',
+    });
+
+    const dispatched: string[] = [];
+    let currentId = FIXED_RUN_ID;
+    let surfaced = false;
+
+    for (let i = 0; i < 12 && !surfaced; i += 1) {
+      await waitForRunActive(currentId);
+      dispatched.push(currentId);
+
+      // executeRun resets the shared thresholds from config on every dispatch.
+      setHeartbeatConfig({
+        heartbeatIntervalMs: 100,
+        progressStallMs: 1_000,
+        heartbeatDeadMs: 10_000,
+      });
+
+      now += 2_000;
+      recordHeartbeat(currentId);
+      tickWatchdog();
+      await flushAsync();
+
+      const settled = getSubAgentRun(currentId);
+      assert.equal(settled?.status, 'cancelled');
+
+      if (settled?.error?.startsWith('watchdog_tier2:')) {
+        surfaced = true;
+        break;
+      }
+
+      assert.equal(settled?.error, 'watchdog_tier1_restart');
+      const next = settled?.supersededByRunId;
+      assert.ok(next, 'tier-1 restart must record a successor run');
+      currentId = next;
+    }
+
+    // selfHealMaxRounds defaults to 4: attempts 1-3 restart, attempt 4 surfaces.
+    assert.equal(surfaced, true, 'watchdog must stop restarting and surface');
+    assert.equal(dispatched.length, 4);
+    assert.equal(new Set(dispatched).size, 4);
+    assert.equal(
+      listActiveSubAgentRuns().filter((r) => r.status === 'running').length,
+      0,
+    );
+  });
+
   test('progress stall on shell triggers tier-2 surface', async () => {
     setSubAgentRunnerFactory(() => hangingRunner());
 

--- a/test/agents/repetition-detector.test.mts
+++ b/test/agents/repetition-detector.test.mts
@@ -1,0 +1,98 @@
+/**
+ * Sliding-window repetition detection — duplicates must be bunched, not merely frequent.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  detectRepetition,
+  resolveRepetitionWindow,
+  MIN_REPETITION_WINDOW,
+  type ToolCallLogEntry,
+} from '../../src/agents/self-healing/detector.ts';
+
+const THRESHOLDS = { duplicateToolCallThreshold: 5, sameErrorThreshold: 3 };
+
+function call(name: string, args: Record<string, unknown>): ToolCallLogEntry {
+  return { name, argsJson: JSON.stringify(args) };
+}
+
+/** n identical calls in a row. */
+function repeat(entry: ToolCallLogEntry, n: number): ToolCallLogEntry[] {
+  return Array.from({ length: n }, () => entry);
+}
+
+/** n distinct calls, so nothing in the filler can itself trip the detector. */
+function filler(n: number, prefix = 'f'): ToolCallLogEntry[] {
+  return Array.from({ length: n }, (_, i) => call('read_file', { path: `${prefix}${i}.ts` }));
+}
+
+describe('repetition detector window', () => {
+  test('resolveRepetitionWindow floors at MIN_REPETITION_WINDOW', () => {
+    assert.equal(resolveRepetitionWindow(1), MIN_REPETITION_WINDOW);
+    assert.equal(resolveRepetitionWindow(2), MIN_REPETITION_WINDOW);
+  });
+
+  test('resolveRepetitionWindow scales with the threshold', () => {
+    assert.equal(resolveRepetitionWindow(5), 20);
+    assert.equal(resolveRepetitionWindow(10), 40);
+  });
+
+  test('resolveRepetitionWindow honours an explicit size but never below the threshold', () => {
+    assert.equal(resolveRepetitionWindow(5, 30), 30);
+    assert.equal(resolveRepetitionWindow(8, 3), 8);
+  });
+
+  test('flags a tight loop of identical calls', () => {
+    const log = [...filler(6), ...repeat(call('grep', { pattern: 'todo' }), 5)];
+    const hit = detectRepetition(log, THRESHOLDS);
+    assert.equal(hit?.reason, 'duplicate_tool');
+  });
+
+  test('ignores repeats spread across a long run', () => {
+    // Five reads of the same plan file, 30 unrelated calls apart — normal reviewer work.
+    const same = call('read_file', { path: 'plan.md' });
+    const log: ToolCallLogEntry[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      log.push(same, ...filler(30, `w${i}_`));
+    }
+    assert.equal(detectRepetition(log, THRESHOLDS), null);
+  });
+
+  test('still flags the loop when it starts after a long clean run', () => {
+    const log = [
+      ...filler(200),
+      ...repeat(call('git_status', {}), 5),
+    ];
+    const hit = detectRepetition(log, THRESHOLDS);
+    assert.equal(hit?.reason, 'duplicate_tool');
+  });
+
+  test('does not flag when duplicates straddle the window edge', () => {
+    // 3 early + 2 late, with a full window of distinct calls in between.
+    const same = call('git_log', { limit: 5 });
+    const log = [...repeat(same, 3), ...filler(25), ...repeat(same, 2)];
+    assert.equal(detectRepetition(log, THRESHOLDS), null);
+  });
+
+  test('threshold 0 disables detection regardless of window', () => {
+    const log = repeat(call('grep', { pattern: 'x' }), 50);
+    assert.equal(
+      detectRepetition(log, { duplicateToolCallThreshold: 0, sameErrorThreshold: 3 }),
+      null,
+    );
+  });
+
+  test('argument order does not defeat the match', () => {
+    const log = [
+      ...filler(6),
+      ...Array.from({ length: 5 }, (_, i) =>
+        i % 2 === 0
+          ? { name: 'search_in_file', argsJson: '{"a":1,"b":2}' }
+          : { name: 'search_in_file', argsJson: '{"b":2,"a":1}' },
+      ),
+    ];
+    const hit = detectRepetition(log, THRESHOLDS);
+    assert.equal(hit?.reason, 'duplicate_tool');
+  });
+});

--- a/test/agents/supervision-thresholds.test.mts
+++ b/test/agents/supervision-thresholds.test.mts
@@ -1,0 +1,85 @@
+/**
+ * Supervision thresholds resolve from one store, so the sub-agent watchdog and
+ * orchestrate boards can never disagree about the shared heartbeat singleton.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  resetSubAgentConfigCache,
+  setRuntimeSubAgentOverrides,
+} from '../../src/agents/sub-agent-config.ts';
+import {
+  resetAutopilotMetaCache,
+  setAutopilotMetaForTests,
+} from '../../src/config/autopilot-meta.ts';
+import {
+  DEFAULT_SUPERVISION_THRESHOLDS,
+  resolveSupervisionThresholds,
+} from '../../src/config/supervision-thresholds.ts';
+
+describe('supervision thresholds', () => {
+  beforeEach(() => {
+    resetSubAgentConfigCache();
+    resetAutopilotMetaCache();
+  });
+
+  afterEach(() => {
+    resetSubAgentConfigCache();
+    resetAutopilotMetaCache();
+  });
+
+  test('falls back to shipped defaults', () => {
+    setRuntimeSubAgentOverrides(null);
+    setAutopilotMetaForTests({});
+    assert.deepEqual(resolveSupervisionThresholds(), DEFAULT_SUPERVISION_THRESHOLDS);
+  });
+
+  test('sub-agents overrides apply', () => {
+    setRuntimeSubAgentOverrides({
+      progressStallMs: 600_000,
+      heartbeatDeadMs: 120_000,
+      heartbeatIntervalMs: 15_000,
+    });
+    setAutopilotMetaForTests({});
+
+    const resolved = resolveSupervisionThresholds();
+    assert.equal(resolved.progressStallMs, 600_000);
+    assert.equal(resolved.heartbeatDeadMs, 120_000);
+    assert.equal(resolved.heartbeatIntervalMs, 15_000);
+  });
+
+  test('legacy autopilot values still apply when sub-agents has no override', () => {
+    setRuntimeSubAgentOverrides(null);
+    setAutopilotMetaForTests({ progressStallMs: 300_000, heartbeatDeadMs: 90_000 });
+
+    const resolved = resolveSupervisionThresholds();
+    assert.equal(resolved.progressStallMs, 300_000);
+    assert.equal(resolved.heartbeatDeadMs, 90_000);
+    // Untouched autopilot fields must not shadow the shipped default.
+    assert.equal(
+      resolved.heartbeatIntervalMs,
+      DEFAULT_SUPERVISION_THRESHOLDS.heartbeatIntervalMs,
+    );
+  });
+
+  test('sub-agents override beats the legacy autopilot value', () => {
+    setRuntimeSubAgentOverrides({ progressStallMs: 600_000 });
+    setAutopilotMetaForTests({ progressStallMs: 300_000 });
+    assert.equal(resolveSupervisionThresholds().progressStallMs, 600_000);
+  });
+
+  test('out-of-range values are clamped, not dropped', () => {
+    setRuntimeSubAgentOverrides({
+      progressStallMs: 999_999_999,
+      heartbeatDeadMs: 1,
+      heartbeatIntervalMs: 999_999,
+    });
+    setAutopilotMetaForTests({});
+
+    const resolved = resolveSupervisionThresholds();
+    assert.equal(resolved.progressStallMs, 1_800_000);
+    assert.equal(resolved.heartbeatDeadMs, 5_000);
+    assert.equal(resolved.heartbeatIntervalMs, 60_000);
+  });
+});


### PR DESCRIPTION
## Why

The Super Plan review stage kept getting stopped by the sub-agent watchdog, even with the sub-agent timeout, check-in nudge, and tool limit all set high. None of those are inputs the watchdog reads — it only looks at `heartbeatDeadMs` (30 s), `progressStallMs` (90 s), and `duplicateToolCallThreshold` (5).

Investigating turned up five compounding causes.

## What changed

**1. One store for supervision thresholds.** `heartbeatConfig` in `agents/controller/wrapper` is a single global singleton, written by two subsystems from two different stores — the sub-agent controller from `sub-agents.json`, orchestrate boards from the `autopilot` block in `config.json`. Whichever dispatched last silently won. Because the controller re-writes it on *every* sub-agent dispatch, the Autopilot sliders never took effect for sub-agents at all.

New `src/config/supervision-thresholds.ts` is the single resolver; both writers go through it. `sub-agents.json` is now the only writable store, and the `autopilot` keys are read as a fallback (and marked `@deprecated`) so values saved before the merge keep applying until next changed.

**2. Loop detection counted cumulatively, not consecutively.** `detectRepetition` built its count map over the entire append-only tool log, so a reviewer that re-read the same plan file five times across a 20-minute run was flagged as looping. It now counts within a sliding window of `max(4× threshold, 12)` recent calls — tight repetition still trips, spread-out repeats don't.

**3. Tier-1 restarts were uncapped.** `tier1Attempted` is keyed by run id, and a tier-1 restart mints a new one, so the flag reset every time. A structurally-stalled task restarted from scratch forever until the stage deadline fired. Now gated on `run.attempt`, which survives the supersession chain, bounded by `autopilot.selfHealMaxRounds` (default 4).

**4. The review deadline was hardcoded.** `REVIEW_SUB_AGENT_TIMEOUT_MS` (20 min) was passed as both the spawn timeout and the stage `AbortSignal`, and a spawn-site timeout overrides type config — so raising the plan-reviewer timeout in settings did literally nothing for this stage. Now `superPlan.reviewTimeoutMs`, 5–120 min, default 20.

**5. Watchdog respawns dropped the model.** `tier1RestartSubAgent` and `tier2AutoRecover` didn't forward `providerId` / `modelId` / `timeoutMs`, so every recovery run silently abandoned the configured Super Plan reviewer model and fell back to the type/parent binding.

## Settings reorganization

The thresholds were spread across two pages and mislabelled — Autopilot's group described itself as covering "orchestrate task chats (build, test, fix, final)", giving no hint it governed sub-agents too.

Stall / heartbeat / dead move off Autopilot, and the repeated-tool limit off the Agents page, into a new **Agent supervision** panel under **Agents → Watchdog** (`src/ui/settings-watchdog.ts`). Each field explains what it measures and what happens when it trips, and the panel states the recovery behavior with the live attempt cap interpolated. Both old locations now link to the new home instead of showing a control that didn't work.

## Notes for the reviewer

- **Defaults are unchanged.** This fixes the plumbing so the knobs work; anyone hitting a stall on a slow reviewer model still needs to raise **Stall timeout**. That's deliberate — silently loosening supervision for everyone seemed worse than making it adjustable.
- **`selfHealMaxRounds` now does double duty** as the watchdog recovery-attempt cap. It's wired through a `resolveMaxRecoveryAttempts` handler rather than importing autopilot config into `watchdog.ts`, to keep the watchdog dependency-free.
- **Unrelated diff line:** regenerating the settings registry picked up a stale `general.desktop.zoom` description from 3e4a6731 — the checked-in manifest was already out of date with the catalog.
- `server/session/engine-bundle/engine-bundle.mjs` contains a stale compiled copy of this controller code, but nothing imports or builds it (leftover from the reverted MIN-354 v1), so it's untouched.

## Verification

- `tsc --noEmit` clean; settings registry regenerated.
- Tests: controller-watchdog 10/10 (including a new test asserting exactly 4 dispatches then blocked), new repetition-detector 9/9, new supervision-thresholds 5/5, board 454/454, sub-agents 69/69, settings 22/22, super-plan 34/34, settings-page-html 78/78.
- In the running app: the Watchdog panel renders with correct values and ranges; setting stall to 600 s wrote `progressStallMs: 600000` into `sub-agents.json` — the store the watchdog actually reads — and both `resolveSupervisionThresholds()` and the shared singleton returned 600000. Config restored afterward. Console errors seen during verification were pre-existing and unrelated (board kanban history loading, boot generation-resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
