### PR TITLE
📝 Document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,14 @@ Perf regressions fail CI the same way as `impeccable:detect` — loudly and with
 - Match the surrounding code's style, naming, and comment density.
 - Application CSS uses `--mn-*` tokens; hex/rgba literals live only in [`src/styles/tokens.css`](src/styles/tokens.css). See [`DESIGN.md`](DESIGN.md).
 - Keep [`documentation/context.md`](documentation/context.md) updated when you ship a feature that changes architecture, APIs, or storage.
+
+## Cursor Cloud specific instructions
+
+Dependencies are already installed by the startup update script (`npm install`). Notes below are non-obvious caveats for running/testing in the headless cloud VM; standard commands live in [setup-from-source.md](documentation/contributor/setup-from-source.md) and [commands.md](documentation/contributor/commands.md).
+
+- **Headless startup:** the VM has no display/Electron GUI. Start the stack with `MINNOW_HEADLESS=1 BROWSER=none npm start` and open the SPA at `http://localhost:9473` in the in-VM browser. Plain `npm start` tries to launch the Electron desktop shell.
+- **API auth gate:** every `/api/*` call needs the per-boot token — `curl -H "X-Minnow-Token: $(cat ~/.minnow/session-token)" http://localhost:9473/api/tools/ping`. A tokenless request returns `401` (the gate working), not a broken server.
+- **Chatting without LM Studio:** run `node scripts/fake-model-server.mjs --port 18765` for an OpenAI-v1 stub. The reserved `fake-board` provider id is intentionally inert in the UI — `proxyModels` in [`server/providers/proxy.js`](server/providers/proxy.js) returns an empty model list for it unless the in-server board-testing fake host is running (needs `MINNOW_DEBUG=1`). To get a UI-selectable model, register the stub under a **different** provider id and set it active: `POST /api/providers` with `{"id":"local-fake","label":"Local Fake (dev)","baseUrl":"http://127.0.0.1:18765","apiKind":"openai-v1"}`, then `POST /api/providers/local-fake/set-active`. A general-mode chat then streams the stub's default reply (`Done.`).
+- **Benign startup noise:** `[servers] auto-provision searxng failed: tar: This does not look like a tar archive` is expected in the network-restricted VM and does not block the server.
+- **Test suite reality:** `npm test` runs end to end, but a small number of tests currently fail on `main` for reasons unrelated to environment setup (in-code default/fixture spec drift — e.g. `test/config/editor-ai-completion-meta.test.js`, the fake LSP formatting fixture). Don't assume a fully green suite; scope expectations to the area you touch.
+- **Fixture side effects:** running the suite writes to git-tracked fixtures under `test/fixtures/**` (SQLite DBs, diagnostics logs). Reset before committing with `git checkout -- test/fixtures/ && git clean -fd test/fixtures/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Minnow in a Cursor Cloud VM and records the non-obvious startup/run caveats discovered during setup. No application source was modified — this PR only adds a `## Cursor Cloud specific instructions` section to `AGENTS.md`.

The startup update script is configured separately as `npm install` (minimal, idempotent). `postinstall` vendors the Impeccable skill and ensures the Electron binary — both expected.

## What was verified

- **Install:** `npm install` — 1036 packages, clean.
- **Typecheck (lint equivalent):** `npx tsc --noEmit` — passes (exit 0). AGENTS.md notes there is no separate ESLint config.
- **Run:** `MINNOW_HEADLESS=1 BROWSER=none npm start` — Vite + Node tool server healthy on port 9473 (`/api/tools/ping`, `/api/config/ping`, `/api/brain/ping` all `{"ok":true}`; tokenless request correctly returns 401).
- **Tests:** `npm test` runs the full suite end to end. A small number of tests fail on `main` for reasons unrelated to environment setup (in-code default/fixture spec drift, e.g. `test/config/editor-ai-completion-meta.test.js` expecting a `reindentOnAccept` default the server object omits, and a fake-LSP formatting fixture). These reproduce in isolation and are not caused by the environment.

## End-to-end "hello world"

Since chatting normally requires LM Studio, I used the built-in OpenAI-v1 stub (`scripts/fake-model-server.mjs`). Discovered gotcha: the reserved `fake-board` provider id is intentionally inert in the UI (`proxyModels` returns an empty model list unless the in-server board-testing fake host runs under `MINNOW_DEBUG`). Registering the stub under a **different** provider id (`local-fake`) makes the model UI-selectable.

- **Headless CLI:** `node bin/minnow.mjs run --start-server --provider fake-board --model fake-board-model --mode general --prompt "Say hello" --json` → real agent turn, `assistantFinal: "Done."`.
- **GUI chat:** opened the SPA at `http://localhost:9473`, selected `fake-board-model` (provider "Local Fake (dev)"), sent "Hello Minnow, please confirm you are working", and the assistant replied "Done." — full exchange rendered.

[minnow_chat_end_to_end_demo.mp4](https://cursor.com/agents/bc-f6608e08-3961-4a62-b7ef-0458fd3eb70f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fminnow_chat_end_to_end_demo.mp4)

[Minnow chat response](https://cursor.com/agents/bc-f6608e08-3961-4a62-b7ef-0458fd3eb70f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fminnow_chat_response.webp)

## AGENTS.md additions (durable notes for future agents)

- Headless startup flags and SPA URL.
- The `/api/*` per-boot token gate.
- How to chat without LM Studio via the stub + separate provider id (the `fake-board` gating gotcha).
- Benign searxng auto-provision failure on startup.
- The suite is not fully green on `main`; running it writes to `test/fixtures/**` (reset before committing).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6608e08-3961-4a62-b7ef-0458fd3eb70f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6608e08-3961-4a62-b7ef-0458fd3eb70f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

