### PR TITLE
🐛 Fix minnow-library provider ID for Minnow-hosted models (MIN-545)

### DIFF
--- a/server/models/serve.js
+++ b/server/models/serve.js
@@ -15,6 +15,7 @@ import {
 import {
   createProvider,
   LLAMA_CPP_LOCAL_ID,
+  MINNOW_LIBRARY_PROVIDER_ID,
   listProviders,
   setActiveProviderId,
   updateProvider,
@@ -356,7 +357,8 @@ export async function startServe(body) {
 
   const port = body.port ? validatePort(body.port) : await pickFreePort(8085);
   const baseUrl = `http://127.0.0.1:${port}`;
-  const providerId = LLAMA_CPP_LOCAL_ID;
+  // Picker + chat binding use minnow-library; llama-cpp-local is upserted for upstream HTTP.
+  const providerId = MINNOW_LIBRARY_PROVIDER_ID;
 
   const profileKey =
     typeof body.profile === 'string' && body.profile.trim() ? body.profile.trim() : 'balanced';

--- a/server/providers/store.js
+++ b/server/providers/store.js
@@ -25,6 +25,9 @@ import {
 const DEFAULT_LM_STUDIO_URL = 'http://localhost:1234';
 const LM_STUDIO_LOCAL_ID = 'lm-studio-local';
 export const LLAMA_CPP_LOCAL_ID = 'llama-cpp-local';
+
+/** Synthetic id on serve records / model picker for Minnow-hosted My Models (not a registry row). */
+export const MINNOW_LIBRARY_PROVIDER_ID = 'minnow-library';
 const DEFAULT_LLAMA_CPP_URL = 'http://127.0.0.1:8085';
 
 /** Best-effort restrictive permissions on secrets files (Unix). */

--- a/src/agents/resolve-work-agent-binding.ts
+++ b/src/agents/resolve-work-agent-binding.ts
@@ -4,6 +4,7 @@
 
 import { listProviders } from '../providers/store';
 import type { ProviderPublic } from '../providers/types';
+import { resolveUpstreamProviderId } from '../models/model-select-library';
 import type { Chat } from '../types';
 import type {
   WorkAgentBinding,
@@ -57,7 +58,10 @@ export async function resolveWorkAgentBinding(
 
   const providers =
     options?.providers ?? (await listProviders()).providers;
-  const provider = providers.find((p) => p.id === providerId && p.enabled !== false);
+  const registryProviderId = resolveUpstreamProviderId(providerId, modelId);
+  const provider = providers.find(
+    (p) => p.id === registryProviderId && p.enabled !== false,
+  );
 
   if (!provider) {
     throw new WorkAgentConfigError(`Unknown provider id: ${providerId}`);

--- a/src/agents/ui-designer/config.ts
+++ b/src/agents/ui-designer/config.ts
@@ -4,6 +4,7 @@
 
 import { listProviders } from '../../providers/store';
 import type { ProviderPublic } from '../../providers/types';
+import { resolveUpstreamProviderId } from '../../models/model-select-library';
 import type { Chat } from '../../types';
 import type { WorkAgentBinding } from '../work-agent-types';
 import { WorkAgentConfigError } from '../work-agent-types';
@@ -77,8 +78,12 @@ export async function resolveUiDesignerBinding(
 
   const providers =
     options?.providers ?? (await listProviders()).providers;
+  const registryProviderId = resolveUpstreamProviderId(
+    resolved.providerId,
+    resolved.modelId,
+  );
   const provider = providers.find(
-    (p) => p.id === resolved.providerId && p.enabled !== false,
+    (p) => p.id === registryProviderId && p.enabled !== false,
   );
 
   if (!provider) {

--- a/src/api/ensure-chat-model-loaded.ts
+++ b/src/api/ensure-chat-model-loaded.ts
@@ -10,10 +10,7 @@ import { providerSupportsModelLoadUnload } from '../providers/capabilities';
 import {
   isLibraryModelBinding,
   loadLibraryModelFromPicker,
-  resolveServedBindingForLibraryId,
 } from '../models/model-select-library';
-import { fetchCachedModels, listModelServes } from '../models/api-client';
-import { buildLibrary, loadableLibrary } from '../models/library';
 import { listProviders } from '../providers/store';
 import type { ProviderPublic } from '../providers/types';
 import {
@@ -136,17 +133,6 @@ export async function ensureChatModelLoadedForTurn(
       syncModelSelectPicker();
     }
 
-    const cached = await fetchCachedModels();
-    const library = loadableLibrary(buildLibrary(cached));
-    const serves = await listModelServes().catch(() => []);
-    const served = resolveServedBindingForLibraryId(mid, library, serves);
-    if (served) {
-      const chat = (await import('../state/sessions')).getActiveChat();
-      chat.providerId = served.providerId;
-      chat.modelId = served.modelId;
-      (await import('../state/sessions')).touchChat(chat);
-      (await import('../state/sessions')).scheduleSaveSessions();
-    }
     return;
   }
 

--- a/src/models/model-select-library.ts
+++ b/src/models/model-select-library.ts
@@ -39,6 +39,20 @@ export function isLibraryModelBinding(providerId: string | undefined, modelId: s
   return isLibraryModelProviderId(pid) && mid.startsWith('gguf:');
 }
 
+/**
+ * Map synthetic My Models provider id to the ~/.minnow provider used for upstream HTTP.
+ */
+export function resolveUpstreamProviderId(
+  providerId: string | undefined,
+  modelId: string | undefined,
+): string {
+  const pid = providerId?.trim() ?? '';
+  if (isLibraryModelBinding(pid, modelId)) {
+    return LLAMA_CPP_LOCAL_PROVIDER_ID;
+  }
+  return pid;
+}
+
 export function encodeLibraryModelSelectKey(libraryId: string): string {
   return encodeModelSelectKey(LIBRARY_MODEL_PROVIDER_ID, libraryId.trim());
 }
@@ -107,7 +121,7 @@ export function resolveServedBindingForLibraryId(
     }
   }
 
-  return { providerId: serve.providerId || LLAMA_CPP_LOCAL_PROVIDER_ID, modelId: label };
+  return { providerId: LLAMA_CPP_LOCAL_PROVIDER_ID, modelId: label };
 }
 
 /** True when a My Models row is not loaded in a Minnow serve yet. */

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -1390,17 +1390,15 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
     if (served) {
       sendProviderId = served.providerId;
       sendModelId = served.modelId;
-      chat.providerId = served.providerId;
-      chat.modelId = served.modelId;
     } else {
       sendProviderId = LLAMA_CPP_LOCAL_PROVIDER_ID;
     }
   }
 
   const sendProvider = await getActiveProvider(sendProviderId);
-  const libraryBinding = isLibraryModelBinding(chat.providerId, sendModelId);
+  const libraryBinding = isLibraryModelBinding(chat.providerId, chat.modelId);
   const pendingModelLoad = libraryBinding
-    ? libraryModelNeedsLoad(sendModelId, modelCache)
+    ? libraryModelNeedsLoad(chat.modelId, modelCache)
     : chatTurnNeedsModelLoad(sendProvider, sendModelId);
   const sendCaps = resolveSendCapabilities(sendProviderId, sendModelId, sendProvider.apiKind);
   const turnReasoningEffort =

--- a/src/ui/models/store.ts
+++ b/src/ui/models/store.ts
@@ -8,6 +8,10 @@
 
 import { selectProviderModel } from '../../api/models';
 import {
+  isLibraryModelProviderId,
+  LIBRARY_MODEL_PROVIDER_ID,
+} from '../../models/model-select-library';
+import {
   getLibrarySamplerForId,
   saveLibraryInferenceSampler,
 } from '../../config/library-inference-meta';
@@ -254,7 +258,11 @@ function trackLoad(serve: ServeRecord, modelId: string | null): void {
         stopTracking(serve.id);
         if (next.status === 'running') {
           state.loads = state.loads.filter((l) => l.serveId !== serve.id);
-          await selectProviderModel(next.providerId, next.modelLabel).catch(() => false);
+          if (isLibraryModelProviderId(next.providerId) && modelId?.trim()) {
+            await selectProviderModel(LIBRARY_MODEL_PROVIDER_ID, modelId).catch(() => false);
+          } else {
+            await selectProviderModel(next.providerId, next.modelLabel).catch(() => false);
+          }
         } else {
           updateLoad(serve.id, { error: next.error ?? 'Model failed to load' });
         }

--- a/test/models/llama-cpp-provider.test.mjs
+++ b/test/models/llama-cpp-provider.test.mjs
@@ -12,6 +12,7 @@ import {
   ensureProviderRegistry,
   listProviders,
   LLAMA_CPP_LOCAL_ID,
+  MINNOW_LIBRARY_PROVIDER_ID,
   migrateLegacyModelServeProviders,
 } from '../../server/providers/store.js';
 import {
@@ -102,7 +103,7 @@ describe('llama-cpp single provider', () => {
       runtime: 'llama-cpp',
       modelLabel: 'test-model.gguf',
     });
-    assert.equal(serveA.providerId, LLAMA_CPP_LOCAL_ID);
+    assert.equal(serveA.providerId, MINNOW_LIBRARY_PROVIDER_ID);
 
     let { providers } = await listProviders();
     const llamaProv = providers.find((p) => p.id === LLAMA_CPP_LOCAL_ID);

--- a/test/models/model-select-library.test.mts
+++ b/test/models/model-select-library.test.mts
@@ -8,6 +8,7 @@ import {
   dedupLlamaCppModelsAgainstLibrary,
   encodeLibraryModelSelectKey,
   isLibraryModelBinding,
+  resolveUpstreamProviderId,
   LIBRARY_MODEL_PROVIDER_ID,
   libraryModelNeedsLoad,
 } from '../../src/models/model-select-library.ts';
@@ -20,6 +21,14 @@ describe('model-select-library', () => {
     const decoded = encodeModelSelectKey(LIBRARY_MODEL_PROVIDER_ID, 'gguf:org/repo:weights.gguf');
     assert.equal(key, decoded);
     assert.equal(isLibraryModelBinding(LIBRARY_MODEL_PROVIDER_ID, 'gguf:org/repo:weights.gguf'), true);
+  });
+
+  test('resolveUpstreamProviderId maps minnow-library to llama-cpp-local', () => {
+    assert.equal(
+      resolveUpstreamProviderId(LIBRARY_MODEL_PROVIDER_ID, 'gguf:org/repo:weights.gguf'),
+      LLAMA_CPP_LOCAL_PROVIDER_ID,
+    );
+    assert.equal(resolveUpstreamProviderId('openai', 'gpt-4o'), 'openai');
   });
 
   test('dedupLlamaCppModelsAgainstLibrary removes duplicate served labels', () => {

--- a/test/work-agents/binding.test.mjs
+++ b/test/work-agents/binding.test.mjs
@@ -22,6 +22,15 @@ const MOCK_PROVIDERS = [
     hasApiKey: false,
     hasBearer: false,
   },
+  {
+    id: 'llama-cpp-local',
+    label: 'llama.cpp (local)',
+    baseUrl: 'http://127.0.0.1:8085',
+    apiKind: 'openai-v1',
+    enabled: true,
+    hasApiKey: false,
+    hasBearer: false,
+  },
 ];
 
 const CHAT_BASE = {
@@ -142,5 +151,21 @@ describe('resolveWorkAgentBinding', () => {
     assert.equal(binding.agentId, 'default');
     assert.equal(binding.modelId, 'local-model');
     assert.equal(binding.providerId, 'lm-studio-local');
+  });
+
+  test('minnow-library chat binding resolves via llama-cpp-local registry row', async () => {
+    const chat = {
+      ...CHAT_BASE,
+      providerId: 'minnow-library',
+      modelId: 'gguf:org/repo:weights.gguf',
+    };
+    const binding = await resolveWorkAgentBinding(
+      null,
+      chat,
+      { providerId: 'lm-studio-local', modelId: 'fallback-model' },
+      { providers: MOCK_PROVIDERS },
+    );
+    assert.equal(binding.providerId, 'minnow-library');
+    assert.equal(binding.modelId, 'gguf:org/repo:weights.gguf');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **MIN-545**: selecting a Minnow-hosted (My Models) GGUF could fail with `Unknown provider id: minnow-library`, and llama.cpp serves were tagged with `llama-cpp-local` instead of the synthetic picker id.

## Root cause

- `minnow-library` is a **synthetic** provider id for the model picker and chat binding, not a row in `~/.minnow/providers`.
- Work agent / UI Designer binding resolution required a registry match and threw when `chat.providerId` was `minnow-library`.
- llama.cpp serve records used `llama-cpp-local`, so post-serve model selection did not match My Models options.

## Changes

- Set `providerId` to `minnow-library` on llama.cpp serve records; continue upserting `llama-cpp-local` for upstream HTTP.
- Add `resolveUpstreamProviderId()` and use it in work agent + UI Designer binding lookup.
- After serve completes, select the library row by `libraryId` in the picker.
- Keep chat on `minnow-library` after auto-load; resolve to `llama-cpp-local` only for the generation request.
- Tests + `documentation/context.md` update.

## Testing

- `node --test test/models/llama-cpp-provider.test.mjs`
- `npx tsx --import ./test/test-loader.mjs --test test/models/model-select-library.test.mts test/work-agents/binding.test.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-545](https://linear.app/minnowai/issue/MIN-545/bug-my-models-selection-is-broken-minnow-hosted)

<div><a href="https://cursor.com/agents/bc-d5525b51-5da2-4a4e-8599-091784fc67b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5525b51-5da2-4a4e-8599-091784fc67b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

