### PR TITLE
🐛 Fix Intent mode: restore line chrome, idle auto-trigger, and accept range

### DIFF
--- a/src/styles/editor-intent-mode.css
+++ b/src/styles/editor-intent-mode.css
@@ -1,5 +1,25 @@
 /* Editor Intent mode — proposal preview and toolbar toggle (MIN-131) */
 
+/* Cursor line recognised as intent — the only signal that Intent mode is live. */
+.cm-intent-line--pending {
+  font-style: italic;
+  color: var(--mn-fg-muted);
+}
+
+/* A line whose intent was accepted, and the same line once its context drifts. */
+.cm-intent-line--resolved {
+  border-left: 2px solid var(--mn-accent);
+  padding-left: 4px;
+  margin-left: -6px;
+}
+
+.cm-intent-line--stale {
+  border-left: 2px solid var(--mn-warning);
+  padding-left: 4px;
+  margin-left: -6px;
+  background: var(--mn-warning-soft);
+}
+
 /* The line about to be replaced, dimmed while a proposal is on screen. */
 .cm-intent-source {
   opacity: 0.6;

--- a/src/ui/editor-suggestions/engine.ts
+++ b/src/ui/editor-suggestions/engine.ts
@@ -1,8 +1,8 @@
 /**
  * The single suggestion engine: one debounce timer, one AbortController, and
  * one place that decides whether the cursor wants a completion or an intent
- * resolve. Mod+Enter is the primary intent trigger; optional line-leave resolve
- * is gated by `autoResolveOnLineLeave` (default off).
+ * resolve. Idling on an intent line proposes for it and Mod+Enter forces one;
+ * the extra line-leave/blur resolve is gated by `autoResolveOnLineLeave`.
  */
 
 import type { EditorState, Transaction } from '@codemirror/state';
@@ -186,28 +186,6 @@ export class SuggestionEnginePlugin {
       }
     }
 
-    if (isIntentEnabled(state)) {
-      const head = state.selection.main.head;
-      const lineNumber = state.doc.lineAt(head).number;
-      if (update.selectionSet && lineNumber !== this.lastLineNumber) {
-        if (this.resolveIntentConfig().autoResolveOnLineLeave) {
-          this.scheduleLineLeaveResolve(this.lastLineNumber);
-        }
-        this.lastLineNumber = lineNumber;
-      }
-      if (update.docChanged) {
-        const prevHead = update.startState.selection.main.head;
-        const prevLine = update.startState.doc.lineAt(prevHead).number;
-        if (
-          this.resolveIntentConfig().autoResolveOnLineLeave &&
-          prevLine !== lineNumber
-        ) {
-          this.scheduleLineLeaveResolve(prevLine);
-        }
-        this.lastLineNumber = lineNumber;
-      }
-    }
-
     if (update.selectionSet && !update.docChanged) {
       const ghostSurvived = getCompletionSuggestion(state) !== null;
       this.cancelInFlight(!ghostSurvived);
@@ -249,8 +227,13 @@ export class SuggestionEnginePlugin {
     }
     this.opts.onStatus?.(null);
 
-    const intentConfig = this.resolveIntentConfig();
-    if (intentConfig.autoResolveOnLineLeave && this.wantsIntent(state)) {
+    // Scheduled after the cancellations above, which would otherwise clear the
+    // line-leave timer in the very update that set it.
+    this.trackIntentLineLeave(update);
+
+    // Idling on an intent line proposes for that line — the behaviour Settings
+    // describes. `autoResolveOnLineLeave` gates only the leave/blur resolves.
+    if (this.wantsIntent(state)) {
       this.scheduleIntent(this.anchorAtCursor(state), false);
       return;
     }
@@ -277,6 +260,32 @@ export class SuggestionEnginePlugin {
     }
 
     this.scheduleCompletion(state.selection.main.head);
+  }
+
+  /**
+   * Track the line the cursor sits on and, when `autoResolveOnLineLeave` is set,
+   * queue a resolve for the line it just left.
+   */
+  private trackIntentLineLeave(update: ViewUpdate): void {
+    const { state } = update;
+    if (!isIntentEnabled(state)) return;
+    const lineNumber = state.doc.lineAt(state.selection.main.head).number;
+    const autoResolve = this.resolveIntentConfig().autoResolveOnLineLeave;
+
+    if (update.docChanged) {
+      const prevHead = update.startState.selection.main.head;
+      const prevLine = update.startState.doc.lineAt(prevHead).number;
+      if (autoResolve && prevLine !== lineNumber) {
+        this.scheduleLineLeaveResolve(prevLine);
+      }
+      this.lastLineNumber = lineNumber;
+      return;
+    }
+
+    if (update.selectionSet && lineNumber !== this.lastLineNumber) {
+      if (autoResolve) this.scheduleLineLeaveResolve(this.lastLineNumber);
+      this.lastLineNumber = lineNumber;
+    }
   }
 
   /** Mod-Enter: resolve the current line as intent regardless of the heuristic. */
@@ -352,7 +361,7 @@ export class SuggestionEnginePlugin {
       const anchor: IntentAnchor = { from: line.from, to: line.to, intentText: line.text };
       if (!anchor.intentText.trim()) return;
       if (classifyIntentLine(line.text, this.classifyOptions()) !== 'intent') return;
-      void this.requestIntent(anchor, false);
+      void this.requestIntent(anchor, false, false);
     }, delay);
   }
 
@@ -400,11 +409,19 @@ export class SuggestionEnginePlugin {
     return head >= anchor.from && head <= anchor.to;
   }
 
-  /** Paint an intent proposal after re-checking every guard. */
-  private showIntent(anchor: IntentAnchor, text: string, streaming: boolean): boolean {
+  /**
+   * Paint an intent proposal after re-checking every guard. A line-leave resolve
+   * is for the line the cursor just left, so it does not require the cursor.
+   */
+  private showIntent(
+    anchor: IntentAnchor,
+    text: string,
+    streaming: boolean,
+    requireCursorInside = true,
+  ): boolean {
     if (isLspBusy(this.view.state)) return false;
     if (!this.anchorStillValid(anchor)) return false;
-    if (!this.cursorInsideAnchor(anchor)) return false;
+    if (requireCursorInside && !this.cursorInsideAnchor(anchor)) return false;
 
     const cleaned = text.replace(/\s+$/, '');
     if (!cleaned.trim()) return false;
@@ -441,13 +458,17 @@ export class SuggestionEnginePlugin {
     return true;
   }
 
-  private async requestIntent(anchor: IntentAnchor, force: boolean): Promise<void> {
+  private async requestIntent(
+    anchor: IntentAnchor,
+    force: boolean,
+    requireCursorInside = true,
+  ): Promise<void> {
     const state = this.view.state;
     if (state.readOnly) return;
     if (!force && !isIntentEnabled(state)) return;
     if (!this.opts.canRequest()) return;
     if (!this.anchorStillValid(anchor)) return;
-    if (!this.cursorInsideAnchor(anchor)) return;
+    if (requireCursorInside && !this.cursorInsideAnchor(anchor)) return;
     if (!anchor.intentText.trim()) return;
 
     // A settled proposal for this exact anchor is already on screen.
@@ -509,7 +530,7 @@ export class SuggestionEnginePlugin {
           if (!pending) return;
           const liveAnchor = pendingToAnchor(pending);
           if (!this.shouldPaintPartial(partial)) return;
-          this.showIntent(liveAnchor, partial, true);
+          this.showIntent(liveAnchor, partial, true, requireCursorInside);
         },
       });
 
@@ -522,7 +543,7 @@ export class SuggestionEnginePlugin {
         if (result.error) this.opts.onStatus?.(result.error);
         return;
       }
-      if (this.showIntent(liveAnchor, result.text, false)) {
+      if (this.showIntent(liveAnchor, result.text, false, requireCursorInside)) {
         this.opts.onStatus?.(INTENT_READY_MESSAGE);
       }
     } catch (err) {

--- a/src/ui/editor-suggestions/state.ts
+++ b/src/ui/editor-suggestions/state.ts
@@ -355,7 +355,8 @@ export function acceptCompletionGhost(view: EditorView): boolean {
     filePath,
     config,
   );
-  const afterInsertEnd = stateBefore.update({ changes }).state.doc.length;
+  // Reindent the inserted text only — never from the anchor to end of document.
+  const insertedEnd = insertPos + ghost.text.length;
   view.dispatch({
     changes,
     effects: setSuggestion.of(null),
@@ -363,7 +364,7 @@ export function acceptCompletionGhost(view: EditorView): boolean {
   dispatchReindentAfterAccept(
     view,
     insertPos,
-    afterInsertEnd,
+    insertedEnd,
     filePath,
     config,
     ghost.text,
@@ -386,7 +387,7 @@ export function acceptPartialCompletionGhost(view: EditorView): boolean {
   const filePath = ctx?.filePath ?? '';
   const stateBefore = view.state;
   const changes = completionInsertChangeSpecs(view.state, insertPos, chunk, filePath, config);
-  const afterInsertEnd = stateBefore.update({ changes }).state.doc.length;
+  const insertedEnd = insertPos + chunk.length;
   view.dispatch({
     changes,
     effects: setSuggestion.of(
@@ -395,7 +396,7 @@ export function acceptPartialCompletionGhost(view: EditorView): boolean {
             ...ghost,
             consumed: ghost.consumed + chunk,
             text: remainder,
-            pos: afterInsertEnd,
+            pos: insertedEnd,
           }
         : null,
     ),
@@ -403,7 +404,7 @@ export function acceptPartialCompletionGhost(view: EditorView): boolean {
   dispatchReindentAfterAccept(
     view,
     insertPos,
-    afterInsertEnd,
+    insertedEnd,
     filePath,
     config,
     chunk,
@@ -457,8 +458,6 @@ export function acceptIntentProposal(view: EditorView): boolean {
     intentConfig.contextWindow,
   );
   const changes = intentReplaceChangeSpecs(view.state, from, to, text, filePath, config);
-  const stateBefore = view.state;
-  const afterReplaceEnd = stateBefore.update({ changes }).state.doc.length;
   view.dispatch({
     annotations: intentSystemTransaction.of(true),
     changes,
@@ -474,8 +473,12 @@ export function acceptIntentProposal(view: EditorView): boolean {
     ],
     userEvent: 'input.complete',
   });
-  dispatchReindentAfterAccept(view, from, afterReplaceEnd, filePath, config, text);
-  const mappedEnd = view.state.doc.length;
+  // Reindent only the block just written, then land the cursor at its end —
+  // measuring the reindent's own growth, which all falls inside that block.
+  const replacedEnd = from + text.length;
+  const lengthAfterReplace = view.state.doc.length;
+  dispatchReindentAfterAccept(view, from, replacedEnd, filePath, config, text);
+  const mappedEnd = replacedEnd + (view.state.doc.length - lengthAfterReplace);
   view.dispatch({ selection: EditorSelection.cursor(mappedEnd) });
   return true;
 }

--- a/test/ui/editor-suggestions/intent-trigger.test.mts
+++ b/test/ui/editor-suggestions/intent-trigger.test.mts
@@ -1,0 +1,196 @@
+/**
+ * Intent mode has to be visible and has to fire. Both regressed at once: the
+ * line-decoration CSS was deleted while the decorations that emit it stayed,
+ * and the idle auto-trigger was gated behind a setting that defaults to off.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { Window } from 'happy-dom';
+import { DEFAULT_EDITOR_AI_COMPLETION } from '../../../src/config/editor-ai-completion.ts';
+import {
+  DEFAULT_EDITOR_INTENT_MODE,
+  type EditorIntentModeConfig,
+} from '../../../src/config/editor-intent-mode.ts';
+import {
+  editorSuggestionBaseExtensions,
+  editorSuggestionCompartmentExtension,
+  editorSuggestionExtensions,
+  mountEditorSuggestions,
+} from '../../../src/ui/editor-suggestions/index.ts';
+import type { ResolveIntentInput } from '../../../src/ui/editor-suggestions/intent-prompt.ts';
+import {
+  acceptIntentProposal,
+  setIntentSuggestionForTest,
+} from '../../../src/ui/editor-suggestions/state.ts';
+
+const INTENT_CSS = fileURLToPath(
+  new URL('../../../src/styles/editor-intent-mode.css', import.meta.url),
+);
+
+let domWindow: Window | null = null;
+
+function setupDom(): void {
+  const window = new Window();
+  domWindow = window;
+  globalThis.window = window as unknown as Window & typeof globalThis;
+  globalThis.document = window.document as unknown as Document;
+  globalThis.HTMLElement = window.HTMLElement as unknown as typeof HTMLElement;
+  globalThis.Node = window.Node as unknown as typeof Node;
+  globalThis.MutationObserver = window.MutationObserver as unknown as typeof MutationObserver;
+  globalThis.ResizeObserver = window.ResizeObserver as unknown as typeof ResizeObserver;
+}
+
+afterEach(() => {
+  domWindow?.close();
+  domWindow = null;
+});
+
+const DOC = 'const items = [];\ncount the items in the list\nconst b = 2;\n';
+
+interface Harness {
+  view: EditorView;
+  resolves: ResolveIntentInput[];
+}
+
+function mount(intentConfig: Partial<EditorIntentModeConfig> = {}): Harness {
+  setupDom();
+  const parent = document.createElement('div');
+  document.body.appendChild(parent);
+  const resolves: ResolveIntentInput[] = [];
+  const opts = {
+    filePath: 'demo.ts',
+    getConfig: () => ({ ...DEFAULT_EDITOR_AI_COMPLETION, enabled: true }),
+    getIntentConfig: () => ({
+      ...DEFAULT_EDITOR_INTENT_MODE,
+      debounceMs: 100,
+      ...intentConfig,
+    }),
+    canRequest: () => true,
+    resolveIntentFn: async (input: ResolveIntentInput) => {
+      resolves.push(input);
+      return { text: 'const total = items.length;' };
+    },
+  };
+  const view = new EditorView({
+    state: EditorState.create({
+      doc: DOC,
+      extensions: [
+        ...editorSuggestionBaseExtensions(),
+        editorSuggestionCompartmentExtension(editorSuggestionExtensions(opts)),
+      ],
+    }),
+    parent,
+  });
+  mountEditorSuggestions(view, true);
+  return { view, resolves };
+}
+
+function lineDecorationClasses(view: EditorView, pos: number): string[] {
+  const classes: string[] = [];
+  for (const source of view.state.facet(EditorView.decorations)) {
+    const set = typeof source === 'function' ? source(view) : source;
+    set.between(pos, pos, (_from, _to, value) => {
+      const spec = value.spec as { class?: string };
+      if (spec.class) classes.push(spec.class);
+    });
+  }
+  return classes;
+}
+
+describe('intent mode visibility', () => {
+  test('every line class the decorations emit has a rule in the stylesheet', () => {
+    const css = readFileSync(INTENT_CSS, 'utf8');
+    for (const cls of [
+      'cm-intent-line--pending',
+      'cm-intent-line--resolved',
+      'cm-intent-line--stale',
+      'cm-intent-source',
+      'cm-intent-proposal',
+    ]) {
+      assert.ok(css.includes(`.${cls}`), `${cls} has no rule in editor-intent-mode.css`);
+    }
+  });
+
+  test('an intent line under the cursor is marked pending', () => {
+    const { view } = mount();
+    const line = view.state.doc.line(2);
+    view.dispatch({ selection: EditorSelection.cursor(line.from + 2) });
+    assert.deepEqual(lineDecorationClasses(view, line.from), ['cm-intent-line--pending']);
+    view.destroy();
+  });
+
+  test('a code line under the cursor is not marked', () => {
+    const { view } = mount();
+    const line = view.state.doc.line(3);
+    view.dispatch({ selection: EditorSelection.cursor(line.from + 2) });
+    assert.deepEqual(lineDecorationClasses(view, line.from), []);
+    view.destroy();
+  });
+});
+
+describe('accepting an intent proposal', () => {
+  test('leaves the rest of the file alone and lands the cursor on the new block', () => {
+    const { view } = mount();
+    // Deliberately mis-indented trailing lines: reindent must not reach them.
+    const doc = 'function run() {\n  build the list\n        const tail = 1;\n}\n';
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: doc } });
+    const line = view.state.doc.line(2);
+    view.dispatch({ selection: EditorSelection.cursor(line.from + 2) });
+
+    const replacement = '  const list = [];\n  list.push(1);';
+    setIntentSuggestionForTest(view, {
+      from: line.from,
+      to: line.to,
+      intentText: line.text,
+      text: replacement,
+    });
+    assert.equal(acceptIntentProposal(view), true);
+
+    assert.equal(
+      view.state.doc.toString(),
+      'function run() {\n  const list = [];\n  list.push(1);\n        const tail = 1;\n}\n',
+    );
+    assert.equal(view.state.selection.main.head, line.from + replacement.length);
+    view.destroy();
+  });
+});
+
+describe('intent auto-trigger', () => {
+  test('idling on an intent line resolves without autoResolveOnLineLeave', async () => {
+    const { view, resolves } = mount({ autoResolveOnLineLeave: false });
+    const line = view.state.doc.line(2);
+    view.dispatch({ selection: EditorSelection.cursor(line.to) });
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(resolves.length, 1);
+    assert.equal(resolves[0]?.intentText, 'count the items in the list');
+    view.destroy();
+  });
+
+  test('idling on a code line does not resolve', async () => {
+    const { view, resolves } = mount();
+    const line = view.state.doc.line(3);
+    view.dispatch({ selection: EditorSelection.cursor(line.to) });
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(resolves.length, 0);
+    view.destroy();
+  });
+
+  test('leaving an intent line resolves it when autoResolveOnLineLeave is on', async () => {
+    const { view, resolves } = mount({ autoResolveOnLineLeave: true });
+    const intentLine = view.state.doc.line(2);
+    view.dispatch({ selection: EditorSelection.cursor(intentLine.to) });
+    const codeLine = view.state.doc.line(3);
+    view.dispatch({ selection: EditorSelection.cursor(codeLine.to) });
+    await new Promise((r) => setTimeout(r, 200));
+    assert.ok(
+      resolves.some((input) => input.intentText === 'count the items in the list'),
+      'the line the cursor left should still be resolved',
+    );
+    view.destroy();
+  });
+});


### PR DESCRIPTION
Intent mode had stopped showing anything and stopped proposing. Inline completion was unaffected, which is why this went unnoticed — the two features share one engine but diverge at exactly the points that broke.

Three separate regressions, from the last two Intent-mode commits.

## What was wrong

### 1. It was invisible

`c04fc41d` (Cursor-Tab rebuild) deleted the `.cm-intent-line--pending / --resolved / --stale` rules from `src/styles/editor-intent-mode.css`. The follow-up rework `964c0cc2` then added `intent-line-decorations.ts`, which emits **exactly those class names**.

The decorations were being applied to the right lines the whole time — they just had no styling attached, so Intent mode on looked pixel-identical to Intent mode off. Rules restored.

### 2. It never fired

`964c0cc2` gated the only auto-trigger behind `autoResolveOnLineLeave`, which defaults to `false` and is not exposed in Settings — while the Settings copy still promises *"Write plain intent on a line and idle — a proposal appears below it"* and offers an **"Idle pause before proposing"** knob for a debounce that could never elapse.

`Ctrl+Enter` was the sole surviving trigger, and nothing in the UI says so at the point of use.

Idling on an intent line proposes again. `autoResolveOnLineLeave` now gates only the *extra* line-leave/blur resolve, as its name says.

### 3. The line-leave path was dead twice over

- `requestIntent` / `showIntent` rejected any anchor the cursor was not inside — which is every line-leave resolve by definition.
- `cancelInFlight` ran *after* the scheduling block in the same `update()`, clearing the `lineLeaveTimer` in the very update that set it.

The cursor guard is now opt-out for leave resolves, and the tracking moved below the cancellations into a new `trackIntentLineLeave`.

## Also fixed while in there

`cb4fbccc` (most recent commit on `main`) passed the **whole document length** as the reindent range end in all three accept paths:

```ts
const afterInsertEnd = stateBefore.update({ changes }).state.doc.length;
dispatchReindentAfterAccept(view, insertPos, afterInsertEnd, ...);
```

With `reindentOnAccept: true` by default, accepting a multi-line proposal reindented from the intent line **to the end of the file**, then parked the cursor at EOF (`const mappedEnd = view.state.doc.length`).

Reindent now covers only the block just written, and the cursor lands at its end. The same one-line defect was in `acceptCompletionGhost` and `acceptPartialCompletionGhost` — corrected there too, since it is the identical misuse of `dispatchReindentAfterAccept`. That path is narrowing the reindent range, so it cannot affect the insert itself.

## Verification

- **163 tests pass** across the editor-suggestions, completion-policy, completion-indent, keymap and intent-config suites; `tsc --noEmit` clean.
- New `test/ui/editor-suggestions/intent-trigger.test.mts` covers all three regressions: every class the decorations emit has a rule in the stylesheet, the pending class lands on intent lines but not code lines, idle resolves without `autoResolveOnLineLeave`, line-leave resolves with it, and accept leaves mis-indented trailing lines untouched.
- Confirmed live in the dev server: `.cm-intent-line--pending` computes to italic + muted, `--resolved` to a 2px accent border, `--stale` to a warning border with soft background. No console errors.

## Reviewer notes

- The pre-existing test `accepting places the cursor at the end of the inserted block` **passed against the EOF bug** — its document *was* the inserted block, so `doc.length` and "end of block" coincided. The new test adds trailing content so it actually fails without the fix.
- Two ordering constraints in `engine.update()` are load-bearing and easy to undo by accident: `trackIntentLineLeave` must stay *below* both `cancelInFlight` calls, and the leave-resolve must not require the cursor inside its anchor.
- `autoResolveOnLineLeave` is still config-file-only, not surfaced in Settings. It now behaves correctly when set; adding a UI toggle felt like scope beyond the bug report. Happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
