### PR TITLE
feat: Ctrl + scroll wheel zooms the desktop shell in/out

### DIFF
--- a/documentation/manual/reference/keyboard-shortcuts.md
+++ b/documentation/manual/reference/keyboard-shortcuts.md
@@ -15,6 +15,7 @@ Single-key shortcuts — **?**, the tool-approval digits — are suppressed whil
 | **Ctrl+Tab** / **Ctrl+Shift+Tab** | Cycle between the desktop and recent apps (Ctrl even on macOS, since Cmd+Tab belongs to the OS) |
 | **Alt+`** | Cycle focus among open floating windows |
 | **Tab** / **Shift+Tab** | Move focus through the dock, menubar and app chrome |
+| **Ctrl+Scroll wheel** | Zoom the interface in / out (desktop app; Ctrl+ / Ctrl− also adjust zoom) |
 
 In Code, **Ctrl+Tab** cycles editor tabs when the editor has focus.
 

--- a/documentation/plans/ctrl-wheel-shell-zoom.md
+++ b/documentation/plans/ctrl-wheel-shell-zoom.md
@@ -1,0 +1,111 @@
+---
+name: ctrl-wheel-shell-zoom
+overview: Make Ctrl + mouse wheel zoom the Minnow desktop interface in/out by actively handling Electron's `zoom-changed` request event in the existing shell-zoom pipeline (preset steps, config persistence, live Settings select sync), plus docs/copy updates. Browser mode keeps native browser zoom.
+todos:
+  - id: w1-zoom-handler
+    content: "Wave 1: Actively apply shell zoom on zoom-changed (Ctrl+wheel) with preset steps"
+    status: pending
+  - id: w2-zoom-docs
+    content: "Wave 2: Document the Ctrl+scroll-wheel shortcut (manual, ? overlay, settings copy)"
+    status: pending
+isProject: true
+---
+
+# Ctrl + Scroll Wheel Shell Zoom
+
+**Date:** 2026-08-04
+**Goal:** Ctrl + mouse wheel zooms the Minnow desktop window in/out using the existing shell-zoom pipeline (config-persisted, clamped 50–300%, live Settings sync).
+**Granularity:** medium
+
+## Context
+
+The desktop shell already has a complete zoom system:
+
+- `electron/shell-zoom.ts` — `DEFAULT_SHELL_ZOOM_PERCENT = 80`, `MIN/MAX = 50/300`, `SHELL_ZOOM_PRESET_PERCENTS = [50, 67, 75, 80, 90, 100, 110, 125, 150, 200]`, `clampShellZoomPercent`, `shellZoomFactorFromPercent`, `shellZoomPercentFromFactor`, `applyShellZoom` (sets `applyingShellZoom` to guard re-entry), and `wireShellZoom(win, deps)`.
+- `wireShellZoom` applies the configured percent on load / `did-finish-load` and already listens to Electron's `zoom-changed` event — **but the handler only reads back `contents.getZoomFactor()` and writes it to config** (`electron/shell-zoom.ts:75`). Per the Electron docs (webContents `zoom-changed`: *"Emitted when the user is requesting to change the zoom level using the mouse wheel"*), the event is a **request**; Electron does not apply the zoom itself. So Ctrl+wheel is currently a no-op, and the mirror handler writes the unchanged percent back to config.
+- Ctrl + plus/minus/0 already work via Electron's default application menu roles (no custom `Menu` in `electron/main.ts`); those natively change the factor but do **not** fire `zoom-changed` (electron/electron#33572), so they are not persisted — pre-existing gap, explicitly out of scope.
+- Persistence + UI are fully wired: `SHELL_SET_ZOOM_PERCENT` IPC → `writeShellZoomPercent` (config.json `desktopShell.zoomPercent`) → `applyShellZoom` → `SHELL_ZOOM_PERCENT_CHANGED` → Settings → General → Desktop app "Interface zoom" select updates via `api.onZoomPercentChanged` (`src/ui/settings-desktop-shell.ts:111`).
+- No zoom rows exist in `documentation/manual/reference/keyboard-shortcuts.md` (grep: no matches) or the `?` shortcut overlay (`src/ui/shell-keyboard-help.ts`).
+- Editor is CodeMirror 6 — no default Ctrl+wheel font zoom, no conflict. No renderer wheel interceptor exists.
+
+**Decision — main process, not renderer:** handle `zoom-changed` in `electron/shell-zoom.ts`. It is the smallest correct change, covers mouse wheel *and* touchpad pinch, requires no renderer/bundle changes, and reuses the existing persistence + notification deps already passed to `wireShellZoom`. Renderer-side wheel interception is unnecessary (Electron applies nothing by default, so nothing to `preventDefault`).
+
+**Step semantics:** snap to the next/previous entry of `SHELL_ZOOM_PRESET_PERCENTS` (clamped at MIN/MAX). Every wheel step therefore lands on a preset that exists in the Settings dropdown, so the select never shows an empty value.
+
+**Browser mode (`MINNOW_BROWSER=1`):** intentionally untouched — the browser's native Ctrl+wheel page zoom applies there.
+
+## Architecture / Key Files
+
+| File | Role | Action |
+|------|------|--------|
+| `electron/shell-zoom.ts` | Main-process zoom pipeline; `wireShellZoom` zoom-changed handler | MODIFY |
+| `test/electron/shell-zoom.test.mjs` | Unit tests for the pure zoom helpers | MODIFY |
+| `documentation/manual/reference/keyboard-shortcuts.md` | Shipped user manual keyboard reference | MODIFY |
+| `src/ui/shell-keyboard-help.ts` | `?` shortcut overlay entries (`SHELL_SHORTCUTS`) | MODIFY |
+| `src/ui/settings-desktop-shell.ts` | Desktop shell settings zoom row copy | MODIFY |
+
+## Wave Breakdown
+
+### Wave 1 — Shell zoom handler
+
+#### Task W1-A: Actively apply shell zoom on `zoom-changed` (Ctrl+wheel)
+- **Build:** In `electron/shell-zoom.ts`:
+  1. Add an exported pure helper (place after `shellZoomPercentFromFactor`, ~line 36):
+     ```ts
+     export function nextShellZoomPercent(current: number, direction: 'in' | 'out'): number {
+       const clamped = clampShellZoomPercent(current);
+       if (direction === 'in') {
+         return SHELL_ZOOM_PRESET_PERCENTS.find((p) => p > clamped) ?? MAX_SHELL_ZOOM_PERCENT;
+       }
+       return [...SHELL_ZOOM_PRESET_PERCENTS].reverse().find((p) => p < clamped) ?? MIN_SHELL_ZOOM_PERCENT;
+     }
+     ```
+  2. Replace the body of the existing `contents.on('zoom-changed', …)` listener in `wireShellZoom` (currently `electron/shell-zoom.ts:75`) — keep the listener registration, change the handler to actively zoom:
+     ```ts
+     contents.on('zoom-changed', (_event, zoomDirection) => {
+       if (applyingShellZoom || contents.isDestroyed()) return;
+       if (zoomDirection !== 'in' && zoomDirection !== 'out') return;
+       const current = shellZoomPercentFromFactor(contents.getZoomFactor());
+       const next = nextShellZoomPercent(current, zoomDirection);
+       if (next === current) return;
+       applyShellZoom(contents, next);
+       void deps.writePercent(next).then((saved) => deps.notifyPercentChanged(saved));
+     });
+     ```
+     The old read-back-and-persist body is removed entirely (it was a no-op — it wrote the unchanged percent back). `applyShellZoom` already sets `applyingShellZoom`, so the guard prevents re-entry.
+  3. No changes to `electron/main.ts` (deps already wired), `electron/preload.ts`, `electron/ipc-channels.ts`, `src/`, or `webPreferences.zoomFactor` (`electron/main.ts:429`).
+- **Test:** Extend `test/electron/shell-zoom.test.mjs` — import `nextShellZoomPercent` from `../../electron/shell-zoom.ts` and add a `describe('nextShellZoomPercent')` block asserting: in@80→90, in@200→300, in@300→300, in@72→75, out@80→75, out@67→50, out@50→50, out@90→80, out@72→67, out@300→200. Scoped run (exact `tsx-mocks-loader` profile from `test/test-config.mjs`, which auto-discovery assigns to `.test.mjs` files):
+  ```
+  node --experimental-test-module-mocks --import tsx --import ./test/test-loader.mjs --import ./test/assert-dom-safe.mjs --test --test-force-exit --test-timeout=120000 test/electron/shell-zoom.test.mjs
+  ```
+  Then `npx tsc --noEmit -p electron/tsconfig.json` (the `zoomDirection` listener param must type-check against Electron 43's `'in' | 'out'` — root `tsconfig.json` includes only `src/` and does not cover `electron/`).
+- **Accept:** In the running Electron app (`npm start`): Ctrl + wheel up zooms the window in, Ctrl + wheel down zooms out, each notch stepping through the preset list; Settings → General → Desktop app "Interface zoom" select follows each notch live; after restart the zoom persists (config.json `desktopShell.zoomPercent`).
+- **Depends on:** —
+
+### Wave 2 — Shortcut docs & copy
+
+#### Task W2-A: Document the Ctrl+scroll-wheel shortcut
+- **Build:**
+  1. `documentation/manual/reference/keyboard-shortcuts.md` — add one row in the appropriate shell/window shortcuts table matching the file's existing row format, e.g. `Ctrl + Scroll wheel — Zoom the interface in / out (desktop app)`. (Grep confirms the file currently has no zoom row.)
+  2. `src/ui/shell-keyboard-help.ts` — add a `ShortcutDoc` entry to the `SHELL_SHORTCUTS` array (`src/ui/shell-keyboard-help.ts:19`), e.g. `{ section: 'Shell', keys: 'Ctrl + Scroll wheel', label: 'Zoom the interface in / out' }`, matching adjacent entries' shape.
+  3. `src/ui/settings-desktop-shell.ts:63` — extend the "Interface zoom" description to mention the gesture, e.g. "Scale the Minnow desktop window. Ctrl/Cmd + and − adjust zoom; Ctrl + scroll wheel zooms in and out; the value here updates to match."
+  4. Grep `test/` for `shell-keyboard-help` — if a snapshot test asserts the full `SHELL_SHORTCUTS` list, update it to include the new entry.
+- **Test:** `npx tsc --noEmit` passes (covers `src/ui/shell-keyboard-help.ts` and `settings-desktop-shell.ts`). Grep assertions: `documentation/manual/reference/keyboard-shortcuts.md`, `src/ui/shell-keyboard-help.ts`, and `src/ui/settings-desktop-shell.ts` each contain the new "Scroll wheel" text. No new unit tests required (copy/docs).
+- **Accept:** In the running app, pressing `?` lists the new Ctrl + Scroll wheel row; Settings → General → Desktop app shows the updated description; the shipped keyboard-shortcuts manual includes the row.
+- **Depends on:** w1-zoom-handler
+
+## Verification Checklist
+- [ ] Scoped shell-zoom test file passes (command in W1-A) and `npm test` passes (auto-discovers `test/electron/shell-zoom.test.mjs`)
+- [ ] `npx tsc --noEmit` passes (src)
+- [ ] `npx tsc --noEmit -p electron/tsconfig.json` passes (electron)
+- [ ] `npm run build` passes
+- [ ] Manual smoke (`npm start`): Ctrl+wheel in/out scales the window; Settings select tracks; `desktopShell.zoomPercent` persists in `~/.minnow/config.json` across restart
+- [ ] `npm run test:check-coverage` passes (no orphaned test files)
+
+## Notes for Build Agents
+- `electron/shell-zoom.ts` compiles under `electron/tsconfig.json` (NodeNext ESM, `types: ["node", "electron"]`) — root `npx tsc --noEmit` does **not** cover it; always run `npx tsc --noEmit -p electron/tsconfig.json` after editing.
+- Windows CRLF repo: use surgical edits via `replace_text_in_file`/`save_file` (line endings auto-match); never rewrite whole files.
+- `zoom-changed` fires only for wheel / touchpad-pinch *requests* — not for menu-role zoom shortcuts (electron/electron#33572). Ctrl+plus/minus/0 keep working natively via the default menu; their non-persistence is pre-existing and out of scope.
+- Do not touch `webPreferences.zoomFactor` (`electron/main.ts:429`) — it stays the initial factor.
+- No renderer bundle impact (no `src/` logic changes), so `budgets.json` performance budgets are unaffected.
+- In-app browser previews (`electron/preview-host.ts`) are separate `WebContents`/windows and read their own zoom factors — unaffected by main-window zoom changes; do not add per-preview handling in this plan.

--- a/electron/shell-zoom.ts
+++ b/electron/shell-zoom.ts
@@ -35,6 +35,18 @@ export function shellZoomPercentFromFactor(factor: number): number {
   return clampShellZoomPercent(Math.round(factor * 100));
 }
 
+/**
+ * Next zoom percent for a wheel/pinch `zoom-changed` request. Snaps to the
+ * neighboring preset so Settings' dropdown always has a matching option.
+ */
+export function nextShellZoomPercent(current: number, direction: 'in' | 'out'): number {
+  const clamped = clampShellZoomPercent(current);
+  if (direction === 'in') {
+    return SHELL_ZOOM_PRESET_PERCENTS.find((p) => p > clamped) ?? MAX_SHELL_ZOOM_PERCENT;
+  }
+  return [...SHELL_ZOOM_PRESET_PERCENTS].reverse().find((p) => p < clamped) ?? MIN_SHELL_ZOOM_PERCENT;
+}
+
 export function isApplyingShellZoom(): boolean {
   return applyingShellZoom;
 }
@@ -72,10 +84,14 @@ export function wireShellZoom(win: BrowserWindow, deps: ShellZoomWireDeps): void
   applyConfigured();
   contents.on('did-finish-load', applyConfigured);
 
-  contents.on('zoom-changed', () => {
+  contents.on('zoom-changed', (_event, zoomDirection) => {
     if (applyingShellZoom || contents.isDestroyed()) return;
-    const percent = shellZoomPercentFromFactor(contents.getZoomFactor());
-    void deps.writePercent(percent).then((saved) => {
+    if (zoomDirection !== 'in' && zoomDirection !== 'out') return;
+    const current = shellZoomPercentFromFactor(contents.getZoomFactor());
+    const next = nextShellZoomPercent(current, zoomDirection);
+    if (next === current) return;
+    applyShellZoom(contents, next);
+    void deps.writePercent(next).then((saved) => {
       deps.notifyPercentChanged(saved);
     });
   });

--- a/server/product-wiki/catalog.json
+++ b/server/product-wiki/catalog.json
@@ -448,7 +448,7 @@
         "Related"
       ],
       "section": "Reference",
-      "hash": "f4941275d392b7143009b69db1a0c4281d0256a50aeaf262c151dd38bbe1d8ff"
+      "hash": "2105052745e74d2371169f3dd7a75b2acc9025a5f79fd49202823960928e93eb"
     },
     {
       "path": "documentation/manual/reference/configuration.md",

--- a/src/ui/settings-desktop-shell.ts
+++ b/src/ui/settings-desktop-shell.ts
@@ -60,7 +60,7 @@ export async function renderDesktopShellSettings(mount: HTMLElement): Promise<vo
   const { row: zoomRow, select: zoomSelect } = createSettingsSelectRow('Interface zoom', {
     searchKey: 'general.desktop.zoom',
     description:
-      'Scale the Minnow desktop window. Ctrl/Cmd + and − adjust zoom; the value here updates to match.',
+      'Scale the Minnow desktop window. Ctrl/Cmd + and − adjust zoom; Ctrl + scroll wheel zooms in and out; the value here updates to match.',
     options: zoomOptions,
     value: zoomKey,
     disabled: serverUp !== 'server',

--- a/src/ui/shell-keyboard-help.ts
+++ b/src/ui/shell-keyboard-help.ts
@@ -19,6 +19,7 @@ export interface ShortcutDoc {
 const SHELL_SHORTCUTS: ShortcutDoc[] = [
   { section: 'Shell', keys: '?', label: 'Open this keyboard shortcuts list' },
   { section: 'Shell', keys: 'Escape', label: 'Close overlays, popovers, and side panels' },
+  { section: 'Shell', keys: 'Ctrl + Scroll wheel', label: 'Zoom the interface in / out' },
   { section: 'Shell', keys: 'Alt + `', label: 'Cycle focus among open floating windows' },
   {
     section: 'Shell',

--- a/test/electron/shell-zoom.test.mjs
+++ b/test/electron/shell-zoom.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   clampShellZoomPercent,
+  nextShellZoomPercent,
   shellZoomFactorFromPercent,
   shellZoomPercentFromFactor,
 } from '../../electron/shell-zoom.ts';
@@ -21,5 +22,36 @@ describe('shell zoom helpers', () => {
   test('factor and percent round-trip', () => {
     assert.equal(shellZoomFactorFromPercent(80), 0.8);
     assert.equal(shellZoomPercentFromFactor(0.8), 80);
+  });
+});
+
+describe('nextShellZoomPercent', () => {
+  test('zooming in snaps to the next preset', () => {
+    assert.equal(nextShellZoomPercent(80, 'in'), 90);
+    assert.equal(nextShellZoomPercent(90, 'in'), 100);
+  });
+
+  test('zooming in from a non-preset value snaps to the next preset', () => {
+    assert.equal(nextShellZoomPercent(72, 'in'), 75);
+  });
+
+  test('zooming in clamps at the max', () => {
+    assert.equal(nextShellZoomPercent(200, 'in'), 300);
+    assert.equal(nextShellZoomPercent(300, 'in'), 300);
+  });
+
+  test('zooming out snaps to the previous preset', () => {
+    assert.equal(nextShellZoomPercent(80, 'out'), 75);
+    assert.equal(nextShellZoomPercent(90, 'out'), 80);
+    assert.equal(nextShellZoomPercent(67, 'out'), 50);
+  });
+
+  test('zooming out from a non-preset value snaps to the previous preset', () => {
+    assert.equal(nextShellZoomPercent(72, 'out'), 67);
+  });
+
+  test('zooming out clamps at the min', () => {
+    assert.equal(nextShellZoomPercent(50, 'out'), 50);
+    assert.equal(nextShellZoomPercent(300, 'out'), 200);
   });
 });


### PR DESCRIPTION
## What

Ctrl + mouse wheel now zooms the Minnow desktop interface in/out using the existing shell-zoom pipeline (clamped 50-300%, preset steps), persisting to config.json → desktopShell.zoomPercent. Settings → General → Desktop app "Interface zoom" tracks each notch live.

## Why

Electron only *reports* Ctrl+wheel via the `zoom-changed` event — it does not apply the zoom itself; the app must. The old handler in `wireShellZoom` read the zoom factor back and wrote it to config but never changed it, so Ctrl+wheel was a silent no-op. This makes the wheel behave like a browser, consistent with the existing Ctrl/Cmd + and − shortcuts and the Settings dropdown.

## How

- `electron/shell-zoom.ts` — new pure helper `nextShellZoomPercent(current, direction)` snaps to the neighboring `SHELL_ZOOM_PRESET_PERCENTS` entry (clamped at MIN/MAX), so every wheel step lands on a value the Settings dropdown offers. The `zoom-changed` handler now applies the zoom, persists it, and notifies the renderer (Settings select updates live). Touchpad pinch requests are covered too.
- `test/electron/shell-zoom.test.mjs` — 6 new cases: preset stepping, clamping at 50/300, non-preset inputs.
- Docs/copy: keyboard-shortcuts manual row, `?` overlay entry (`src/ui/shell-keyboard-help.ts`), Settings zoom-row description, and regenerated `server/product-wiki/catalog.json` (manual-page hash gate).
- Browser mode (`MINNOW_BROWSER=1`) is intentionally untouched — native browser Ctrl+wheel zoom applies there.

## Verification

- Scoped shell-zoom suite: 9/9 pass
- `npx tsc --noEmit` and `npx tsc --noEmit -p electron/tsconfig.json`: clean
- Full `npm test`: pass · `npm run build`: pass · `npm run test:check-coverage`: pass

## Out of scope (pre-existing)

Ctrl/Cmd + / − via Electron's default menu roles still change zoom but are not persisted (`zoom-changed` does not fire for menu roles — electron/electron#33572). The manual visual smoke test (Ctrl+wheel scaling in the running app) is the only step not yet performed.