### PR TITLE
🐛 Resolve chat workspace from the chat, not global UI state (MIN-573, MIN-576)

### DIFF
--- a/src/os/desktop-chat.ts
+++ b/src/os/desktop-chat.ts
@@ -8,6 +8,7 @@ import { sendMessage } from '../chat/messaging';
 import { isActiveChatStreaming, subscribeChatStreamEnd } from '../chat/streaming-state';
 import { copyChatModelBinding } from '../lib/model-select-key';
 import { getDesktopWorkspacePath } from '../lib/desktop-workspace';
+import { normalizeWorkspacePath } from '../lib/normalize-workspace-path';
 import { normalizeModeId } from '../chat/modes/types';
 import { isAssistantChat } from '../state/session-workspace-scope';
 import {
@@ -249,12 +250,38 @@ export function syncDesktopChatSessionSwitch(
   void resumeIncompleteToolBatchOnChatSwitch(chat);
 }
 
+/**
+ * True when a chat may be opened on the desktop surface: expert threads follow
+ * the user, everything else must be bound to the current desktop folder. Each
+ * desktop chat sends its own folder as the tool `workspaceRoot`, and the server
+ * allowlist only accepts the current desktop workspace — so a foreign-folder
+ * chat must never become active here.
+ */
+async function canOpenOnDesktop(chat: Chat): Promise<boolean> {
+  if (isExpertChat(chat)) return true;
+  if (!desktopWorkspacePath) {
+    try {
+      desktopWorkspacePath = await getDesktopWorkspacePath();
+    } catch {
+      /* server offline */
+    }
+  }
+  // Folder unknown (server unreachable): no writes can land anywhere, so don't
+  // block the switch — only a *known* mismatch is refused.
+  if (!desktopWorkspacePath) return true;
+  return (
+    normalizeWorkspacePath(chat.workspacePath ?? '') ===
+    normalizeWorkspacePath(desktopWorkspacePath)
+  );
+}
+
 /** Switch the active assistant thread on the desktop surface. */
 export async function activateDesktopChatSession(chatId: string): Promise<void> {
   if (!sessionState) return;
   const prevId = sessionState.activeId;
   const chat = sessionState.chats.find((c) => c.id === chatId);
   if (!chat) return;
+  if (!(await canOpenOnDesktop(chat))) return;
   if (chatId === prevId) {
     // Fast path when history is already resident; otherwise await hydrate then paint.
     if (chat.historyLoaded === false) {
@@ -323,7 +350,8 @@ export async function bootstrapDesktopChat(options?: DesktopChatActivateOptions)
     const state = sessionState;
     if (options?.chatId?.trim()) {
       try {
-        const chat = state.chats.find((c) => c.id === options.chatId?.trim());
+        const requested = state.chats.find((c) => c.id === options.chatId?.trim());
+        const chat = requested && (await canOpenOnDesktop(requested)) ? requested : null;
         if (chat) {
           state.activeId = chat.id;
           markSessionScalarsDirty();

--- a/src/state/worktree-isolation.ts
+++ b/src/state/worktree-isolation.ts
@@ -241,13 +241,26 @@ export function resolveChatWorktreeRoot(
 }
 
 /**
+ * Chats owned by a Minnow app surface (desktop, Email, …) run in their own bound
+ * folder, not the live Code workspace. `modeId === 'desktop'` is a safe
+ * discriminator: `desktop` is excluded from `listComposerModes()` so a user can
+ * never select it on a Code chat, and `createDesktopChat()` is its only producer.
+ */
+function isAppSurfaceChat(chat: Pick<Chat, 'appScope' | 'modeId'>): boolean {
+  return Boolean(chat.appScope) || chat.modeId === 'desktop';
+}
+
+/**
  * Tool workspace root for a chat: isolated worktree when present, otherwise the
- * chat's bound sandbox (~/.minnow/workspace or ~/.minnow/chats) or board project
- * workspace. Plain Code chats without a worktree return undefined so callers fall
- * back to the live top-bar workspace.
+ * chat's own bound folder — app-surface chats (desktop/Email), the
+ * ~/.minnow sandbox, or the board project workspace. Plain Code chats without a
+ * worktree return undefined so callers fall back to the live top-bar workspace.
  */
 export function resolveChatToolWorkspaceRoot(
-  chat: Pick<Chat, 'worktreeRoot' | 'boardTaskId' | 'boardGroupId' | 'workspacePath'>,
+  chat: Pick<
+    Chat,
+    'worktreeRoot' | 'boardTaskId' | 'boardGroupId' | 'workspacePath' | 'appScope' | 'modeId'
+  >,
   groups: ChatGroup[] | undefined,
 ): string | undefined {
   const worktree = resolveChatWorktreeRoot(chat, groups);
@@ -258,6 +271,7 @@ export function resolveChatToolWorkspaceRoot(
   const normalized = normalizeWorkspacePath(ws);
 
   if (chat.boardGroupId?.trim()) return normalized;
+  if (isAppSurfaceChat(chat)) return normalized;
   if (isMinnowSandboxWorkspacePath(normalized)) return normalized;
   return undefined;
 }

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -62,9 +62,8 @@ import {
 } from './permission-gate';
 import { getChatsWorkspacePath } from '../lib/chats-workspace';
 import { getDesktopWorkspacePath } from '../lib/desktop-workspace';
-import { isDesktopChatActive } from '../os/desktop-state';
 import { resolveChatToolWorkspaceRoot } from '../state/worktree-isolation';
-import { isChatAppForeground } from '../ui/chat-mount';
+import { isChatAppForeground, shouldPaintDesktopChatSurface } from '../ui/chat-mount';
 import { runWithFileTreeAutoRefresh } from '../ui/file-tree-auto-refresh';
 import { executeWithResultCache } from './result-cache';
 import { validateToolRequiredArgs } from './validate-tool-required-args';
@@ -738,7 +737,7 @@ async function executeStreamingCodeTool(
 }
 
 /** Resolve tool workspace from chat binding, then desktop/chat UI foreground, else server default. */
-async function resolveToolWorkspaceRoot(
+export async function resolveToolWorkspaceRoot(
   context?: ExecuteToolContext,
 ): Promise<string | undefined> {
   const chatId = context?.chatId?.trim();
@@ -749,7 +748,10 @@ async function resolveToolWorkspaceRoot(
       if (scoped) return scoped;
     }
   }
-  if (isDesktopChatActive()) {
+  // Desktop chat state stays `chatActive` while Code is fullscreen (for return
+  // navigation), so gate on the foreground-aware predicate — a Code chat must
+  // never resolve to the desktop workspace.
+  if (shouldPaintDesktopChatSurface()) {
     const path = await getDesktopWorkspacePath();
     return path ?? undefined;
   }

--- a/test/orchestrate/worktree-isolation.test.mts
+++ b/test/orchestrate/worktree-isolation.test.mts
@@ -340,6 +340,36 @@ describe('resolveChatToolWorkspaceRoot', () => {
       '/home/user/.minnow/chats',
     );
   });
+
+  test('desktop chats keep their own folder outside the sandbox (MIN-573)', () => {
+    assert.equal(
+      resolveChatToolWorkspaceRoot(
+        { modeId: 'desktop', workspacePath: 'D:/Projects/Foo' },
+        [],
+      ),
+      'D:/Projects/Foo',
+    );
+  });
+
+  test('app-scoped chats keep their own folder', () => {
+    assert.equal(
+      resolveChatToolWorkspaceRoot(
+        { appScope: 'email', workspacePath: 'D:/Projects/Foo' },
+        [],
+      ),
+      'D:/Projects/Foo',
+    );
+  });
+
+  test('plain code chats still follow the live top-bar workspace', () => {
+    assert.equal(
+      resolveChatToolWorkspaceRoot(
+        { modeId: 'general', workspacePath: 'D:/Projects/Foo' },
+        [],
+      ),
+      undefined,
+    );
+  });
 });
 
 describe('dev port allocation', () => {

--- a/test/tools/tool-workspace-root.test.mts
+++ b/test/tools/tool-workspace-root.test.mts
@@ -1,0 +1,152 @@
+/**
+ * MIN-576: tool workspace resolution must not follow desktop chat state while
+ * Code owns the foreground — a Code chat writes into the top-bar workspace.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { launchInstance, resetInstancesForTests } from '../../src/os/instances.ts';
+import {
+  resetDesktopStateForTests,
+  setDesktopStateForTests,
+} from '../../src/os/desktop-state.ts';
+import {
+  initOsPageBridge,
+  resetOsPageBridgeForTests,
+} from '../../src/os/page-bridge.ts';
+import { resetDesktopWorkspacePathCache } from '../../src/lib/desktop-workspace.ts';
+import { setSessionStateForTests, createEmptyChatObject } from '../../src/state/sessions.ts';
+
+const DESKTOP_WS = '/home/user/.minnow/workspace';
+const PROJECT_WS = '/home/user/myproject';
+
+/** Prime the desktop workspace path cache so resolution has a concrete path to pick. */
+async function primeDesktopWorkspace(): Promise<() => void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
+    if (String(url).includes('/api/desktop-workspace')) {
+      return {
+        ok: true,
+        json: async () => ({ ok: true, path: DESKTOP_WS, label: 'workspace', fileCount: 0 }),
+      } as Response;
+    }
+    return originalFetch(url);
+  }) as typeof fetch;
+  const { fetchDesktopWorkspaceInfo } = await import('../../src/lib/desktop-workspace.ts');
+  await fetchDesktopWorkspaceInfo();
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+describe('resolveToolWorkspaceRoot', () => {
+  beforeEach(async () => {
+    const { Window } = await import('happy-dom');
+    const win = new Window();
+    const g = globalThis as typeof globalThis & {
+      window: Window;
+      document: Document;
+      HTMLElement: typeof HTMLElement;
+    };
+    g.window = win as unknown as Window & typeof globalThis.window;
+    g.document = win.document;
+    g.HTMLElement = win.HTMLElement;
+    win.document.body.innerHTML = '<div id="osDesktopLayer"></div><main id="chatView"></main>';
+    resetInstancesForTests();
+    resetDesktopStateForTests();
+    resetOsPageBridgeForTests();
+    initOsPageBridge();
+    resetDesktopWorkspacePathCache();
+  });
+
+  afterEach(() => {
+    setSessionStateForTests(null);
+    resetDesktopStateForTests();
+    resetInstancesForTests();
+    resetOsPageBridgeForTests();
+    resetDesktopWorkspacePathCache();
+  });
+
+  test('a Code chat does not inherit the desktop workspace while desktop chat stays active', async () => {
+    setSessionStateForTests({
+      version: 5,
+      activeId: 'code-chat',
+      sidebarCollapsed: false,
+      chats: [
+        {
+          ...createEmptyChatObject('model-a'),
+          id: 'code-chat',
+          name: 'Code chat',
+          workspacePath: PROJECT_WS,
+          modeId: 'general',
+        },
+      ],
+    });
+
+    // Desktop chat was used earlier, then Code went fullscreen.
+    setDesktopStateForTests('chatActive');
+    launchInstance('code');
+
+    const restoreFetch = await primeDesktopWorkspace();
+    try {
+      const { resolveToolWorkspaceRoot } = await import('../../src/tools/client.ts');
+      const { getCachedDesktopWorkspacePath } = await import(
+        '../../src/lib/desktop-workspace.ts'
+      );
+      // Guard the guard: the desktop path is resolvable, so undefined below is
+      // the foreground check firing, not a failed lookup.
+      assert.equal(getCachedDesktopWorkspacePath(), DESKTOP_WS);
+      assert.equal(await resolveToolWorkspaceRoot({ chatId: 'code-chat' }), undefined);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test('a desktop-foreground chat still resolves to the desktop workspace', async () => {
+    setSessionStateForTests({
+      version: 5,
+      activeId: 'sandbox-chat',
+      sidebarCollapsed: false,
+      chats: [
+        {
+          ...createEmptyChatObject('model-a'),
+          id: 'sandbox-chat',
+          name: 'Sandbox chat',
+          workspacePath: '',
+          modeId: 'general',
+        },
+      ],
+    });
+
+    setDesktopStateForTests('chatActive');
+
+    const restoreFetch = await primeDesktopWorkspace();
+    try {
+      const { resolveToolWorkspaceRoot } = await import('../../src/tools/client.ts');
+      assert.equal(await resolveToolWorkspaceRoot({ chatId: 'sandbox-chat' }), DESKTOP_WS);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test('a desktop chat resolves to its own bound folder, not the top-bar workspace', async () => {
+    setSessionStateForTests({
+      version: 5,
+      activeId: 'desktop-chat',
+      sidebarCollapsed: false,
+      chats: [
+        {
+          ...createEmptyChatObject('model-a'),
+          id: 'desktop-chat',
+          name: 'Desktop chat',
+          workspacePath: PROJECT_WS,
+          modeId: 'desktop',
+        },
+      ],
+    });
+
+    const { resolveToolWorkspaceRoot } = await import('../../src/tools/client.ts');
+    assert.equal(await resolveToolWorkspaceRoot({ chatId: 'desktop-chat' }), PROJECT_WS);
+    assert.notEqual(PROJECT_WS, DESKTOP_WS);
+  });
+});

--- a/test/ui/desktop-workspace-folder.test.mts
+++ b/test/ui/desktop-workspace-folder.test.mts
@@ -113,4 +113,59 @@ describe('desktop-workspace-folder', () => {
     activateDesktopAssistantChatForApp(PROJECT_WS);
     assert.equal(getActiveChat().id, 'project-chat');
   });
+
+  test('activateDesktopChatSession refuses a chat bound to another folder', async () => {
+    setSessionStateForTests({
+      version: 5,
+      activeId: 'project-chat',
+      sidebarCollapsed: false,
+      chats: [
+        {
+          ...createEmptyChatObject('model-a'),
+          id: 'project-chat',
+          name: 'Project chat',
+          workspacePath: PROJECT_WS,
+          modeId: 'desktop',
+          history: [{ role: 'user', content: 'project work' }],
+        },
+        {
+          ...createEmptyChatObject('model-a'),
+          id: 'foreign-chat',
+          name: 'Other folder chat',
+          workspacePath: DESKTOP_WS,
+          modeId: 'desktop',
+          history: [{ role: 'user', content: 'other folder' }],
+        },
+      ],
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      if (String(url).includes('/api/desktop-workspace')) {
+        return {
+          ok: true,
+          json: async () => ({ ok: true, path: PROJECT_WS, label: 'myproject', fileCount: 1 }),
+        } as Response;
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    try {
+      // Desktop workspace is PROJECT_WS; the requested chat lives in DESKTOP_WS.
+      const { fetchDesktopWorkspaceInfo } = await import('../../src/lib/desktop-workspace.ts');
+      await fetchDesktopWorkspaceInfo();
+
+      const { activateDesktopChatSession } = await import('../../src/os/desktop-chat.ts');
+      const { sessionState } = await import('../../src/state/sessions.ts');
+
+      await activateDesktopChatSession('foreign-chat');
+      assert.equal(sessionState?.activeId, 'project-chat');
+
+      await activateDesktopChatSession('project-chat');
+      assert.equal(sessionState?.activeId, 'project-chat');
+    } finally {
+      globalThis.fetch = originalFetch;
+      resetDesktopWorkspacePathCache();
+    }
+  });
 });


### PR DESCRIPTION
Fixes two Urgent bugs that share one root cause: **a chat's working folder was derived from global UI state rather than from the chat itself**, so its tools, prompt `{{cwd}}`, and injections could each resolve to a different folder depending on which app was in the foreground.

`resolveChatToolWorkspaceRoot()` returned `undefined` for anything that was not a board chat or a literal `~/.minnow/{chats,workspace}` sandbox path, and each caller then fell back to a different piece of ambient state:

| Caller | Fallback when unresolved |
| --- | --- |
| `compose-context.ts` (`{{cwd}}`) | `getWorkspacePath()` — the Code top-bar workspace |
| `tools/client.ts` | `isDesktopChatActive()` → the desktop workspace |
| `code-injection-config.ts` | `getWorkspacePath()` — injects the Code repo map |

The `~/.minnow`-only assumption was correct when written; 96baa174 (MIN-430) let the desktop workspace point at an arbitrary folder and nothing updated the resolver.

## MIN-573 — desktop chat gets the Code app workspace context

A desktop chat bound to a real project folder failed the sandbox test, so it resolved to `undefined` and inherited the Code workspace everywhere: `desktop.full.md` literally rendered *"The desktop workspace root is `{{cwd}}`"* with the Code project path, the Code repo map got injected, and `workspaceRoot` was omitted from tool calls entirely.

`resolveChatToolWorkspaceRoot` now returns the chat's own normalized `workspacePath` for any chat owned by a Minnow app surface — `appScope` set, or `modeId === 'desktop'`. `desktop` is a safe discriminator: it is excluded from `listComposerModes()` so a user can never select it on a Code chat, and `createDesktopChat()` is its only producer. Plain Code chats still return `undefined` so they keep following the live top-bar workspace.

Every consumer reads through this one function, so `chatUsesDesktopSandboxWorkspace`, `shouldInjectCodeMap`, `shouldInjectContextDocuments`, `compose-context`, `turn-snapshots`, and `eval-agent` all become correct with no call-site changes.

## MIN-576 — Code chat writes land in the desktop workspace

`resolveToolWorkspaceRoot()` read `isDesktopChatActive()`, which means *"the desktop surface is in chat mode"*, **not** *"desktop chat is what the user is looking at"* — `applyRoute()` deliberately keeps it set while Code is fullscreen so returning to the desktop restores the thread.

So: use desktop chat → open Code → start a chat in a new workspace. The file tree and `{{cwd}}` both said the new workspace, but every tool call resolved to `getDesktopWorkspacePath()`. Reloading reset desktop state to `idle`, which is the "reload corrects itself" in the report.

Swapped for `shouldPaintDesktopChatSurface()` — the foreground-aware predicate that every other consumer of this flag already pairs with a Code-foreground guard (`isChatAppForeground`, `shouldHostOnDesktop`, `restoreDesktopSessionOnForeground`). `tools/client.ts` was the one place that did not.

## Invariant guard

Each desktop chat now sends its own folder as `workspaceRoot`, and the server allowlist (`isAllowedWorkspaceRoot`) only accepts the *current* desktop workspace — so the mismatch is made impossible rather than handled. The desktop rail was already correct; two entry points bypassed it and activated an arbitrary `chatId` with no folder check (the notification/deep-link `activateDesktopChatSession`, and the `options.chatId` branch of `bootstrapDesktopChat`). `canOpenOnDesktop()` now gates both.

**Two deviations a reviewer should look at:**

1. The guard refuses only a **known** mismatch. My first version returned `false` when the desktop folder was unresolvable, which broke two existing tests (`activateDesktopChatSession parks/unparks ask_question`) by blocking *every* switch whenever the server was unreachable. When the folder is unknown the server is down and no tool write can land anywhere, so refusing the UI switch buys nothing and regresses real behavior.
2. The path comparison normalizes both sides and this is load-bearing — the server returns `C:\Users\...\Business Simulator` while chats store `C:/Users/...`. A naive compare would have blocked every legitimate desktop chat.

`resolveToolWorkspaceRoot` is exported so it can be tested directly.

## Verification

`npx tsc --noEmit` clean. All suites green: os + tools (475), orchestrate + prompts + brain (451), ui (714), state + chat (435). Stashing the three source files and re-running makes all 6 new tests fail, so they discriminate.

Live-app check against the real backend, driving the actual MIN-576 sequence (desktop chat active → Code foreground):

| | value |
| --- | --- |
| old gate `isDesktopChatActive()` | `true` — would have returned the desktop workspace |
| new gate `shouldPaintDesktopChatSurface()` | `false` |
| Code chat resolves to | `undefined` → falls back to top-bar workspace ✅ |
| desktop chat resolves to | its own project folder, not the sandbox ✅ |

The desktop workspace on that machine is a real project folder, so this exercised the MIN-573 path too — pre-fix that chat resolved to `undefined` and inherited the Code workspace.

**Not verified:** the end-to-end "ask the chat to write a file, confirm the location" steps and the notification deep-link guard. Both need interaction that can't be driven from the browser pane (native folder picker, notification click) and would mutate the desktop-workspace config. The guard's logic is covered by unit tests, but the deep-link path itself is untested.

## Out of scope

Left for separate issues, per the plan: the file-tree flip after a workspace round-trip (re-test after these fixes), the stale `getDesktopWorkspacePath()` module cache, and the dead `server/session/engine-bundle/` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
