### PR TITLE
Size model memory from attention geometry, not parameter count

### DIFF
--- a/server/models/gguf-metadata.js
+++ b/server/models/gguf-metadata.js
@@ -1,0 +1,458 @@
+/**
+ * Read attention geometry straight out of a GGUF file's header.
+ *
+ * For weights that are already on disk there is no reason to guess: the header states the
+ * block count, GQA width, head size, and every tensor's exact type and shape. That turns the
+ * Load tab's memory estimate from a heuristic into arithmetic, and gives the GPU-layers
+ * slider a real maximum instead of a bucket fitted to parameter count.
+ *
+ * Only the header is read — the KV block plus the tensor index, typically a few MB — never
+ * the weights themselves.
+ */
+
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+const GGUF_MAGIC = 0x46554747; // "GGUF" little-endian
+
+/** Stop growing the header buffer past this; a real header never approaches it. */
+const MAX_HEADER_BYTES = 64 * 1024 * 1024;
+const INITIAL_READ_BYTES = 1024 * 1024;
+
+/** GGUF metadata value type tags. */
+const VALUE_TYPE = {
+  UINT8: 0,
+  INT8: 1,
+  UINT16: 2,
+  INT16: 3,
+  UINT32: 4,
+  INT32: 5,
+  FLOAT32: 6,
+  BOOL: 7,
+  STRING: 8,
+  ARRAY: 9,
+  UINT64: 10,
+  INT64: 11,
+  FLOAT64: 12,
+};
+
+/**
+ * ggml tensor types as `[elementsPerBlock, bytesPerBlock]`, which is what turns a tensor's
+ * shape into its size on disk. Indexes match `enum ggml_type`.
+ * @type {Record<number, [number, number]>}
+ */
+const GGML_TYPE_SIZES = {
+  0: [1, 4], // F32
+  1: [1, 2], // F16
+  2: [32, 18], // Q4_0
+  3: [32, 20], // Q4_1
+  6: [32, 22], // Q5_0
+  7: [32, 24], // Q5_1
+  8: [32, 34], // Q8_0
+  9: [32, 36], // Q8_1
+  10: [256, 84], // Q2_K
+  11: [256, 110], // Q3_K
+  12: [256, 144], // Q4_K
+  13: [256, 176], // Q5_K
+  14: [256, 210], // Q6_K
+  15: [256, 292], // Q8_K
+  16: [256, 66], // IQ2_XXS
+  17: [256, 74], // IQ2_XS
+  18: [256, 98], // IQ3_XXS
+  19: [256, 50], // IQ1_S
+  20: [32, 18], // IQ4_NL
+  21: [256, 110], // IQ3_S
+  22: [256, 82], // IQ2_S
+  23: [256, 136], // IQ4_XS
+  24: [1, 1], // I8
+  25: [1, 2], // I16
+  26: [1, 4], // I32
+  27: [1, 8], // I64
+  28: [1, 8], // F64
+  29: [256, 56], // IQ1_M
+  30: [1, 2], // BF16
+  34: [256, 54], // TQ1_0
+  35: [256, 66], // TQ2_0
+  39: [32, 17], // MXFP4
+};
+
+/**
+ * Cursor over a GGUF header that pulls more of the file in as the parse advances.
+ */
+class HeaderReader {
+  /** @param {import('node:fs/promises').FileHandle} handle */
+  constructor(handle, fileSize) {
+    this.handle = handle;
+    this.fileSize = fileSize;
+    this.buffer = Buffer.alloc(0);
+    this.offset = 0;
+  }
+
+  /**
+   * Guarantee `count` more bytes past the cursor, reading further into the file if needed.
+   * @param {number} count
+   */
+  async ensure(count) {
+    const needed = this.offset + count;
+    if (needed <= this.buffer.length) return;
+    if (needed > MAX_HEADER_BYTES) throw new Error('GGUF header exceeds size limit');
+
+    let target = Math.max(needed, this.buffer.length * 2, INITIAL_READ_BYTES);
+    target = Math.min(target, this.fileSize, MAX_HEADER_BYTES);
+    if (target <= this.buffer.length) throw new Error('GGUF header truncated');
+
+    const next = Buffer.alloc(target);
+    const { bytesRead } = await this.handle.read(next, 0, target, 0);
+    if (bytesRead < needed) throw new Error('GGUF header truncated');
+    this.buffer = bytesRead === target ? next : next.subarray(0, bytesRead);
+  }
+
+  async u8() {
+    await this.ensure(1);
+    const value = this.buffer.readUInt8(this.offset);
+    this.offset += 1;
+    return value;
+  }
+
+  async u16() {
+    await this.ensure(2);
+    const value = this.buffer.readUInt16LE(this.offset);
+    this.offset += 2;
+    return value;
+  }
+
+  async u32() {
+    await this.ensure(4);
+    const value = this.buffer.readUInt32LE(this.offset);
+    this.offset += 4;
+    return value;
+  }
+
+  async i32() {
+    await this.ensure(4);
+    const value = this.buffer.readInt32LE(this.offset);
+    this.offset += 4;
+    return value;
+  }
+
+  async f32() {
+    await this.ensure(4);
+    const value = this.buffer.readFloatLE(this.offset);
+    this.offset += 4;
+    return value;
+  }
+
+  async f64() {
+    await this.ensure(8);
+    const value = this.buffer.readDoubleLE(this.offset);
+    this.offset += 8;
+    return value;
+  }
+
+  async u64() {
+    await this.ensure(8);
+    const value = this.buffer.readBigUInt64LE(this.offset);
+    this.offset += 8;
+    return Number(value);
+  }
+
+  async i64() {
+    await this.ensure(8);
+    const value = this.buffer.readBigInt64LE(this.offset);
+    this.offset += 8;
+    return Number(value);
+  }
+
+  async string() {
+    const length = await this.u64();
+    if (length < 0 || length > MAX_HEADER_BYTES) throw new Error('GGUF string length invalid');
+    await this.ensure(length);
+    const value = this.buffer.toString('utf8', this.offset, this.offset + length);
+    this.offset += length;
+    return value;
+  }
+
+  /** Advance past a string without decoding it — used for token vocabularies. */
+  async skipString() {
+    const length = await this.u64();
+    if (length < 0 || length > MAX_HEADER_BYTES) throw new Error('GGUF string length invalid');
+    await this.ensure(length);
+    this.offset += length;
+  }
+}
+
+/**
+ * @param {HeaderReader} reader
+ * @param {number} type
+ */
+async function readScalar(reader, type) {
+  switch (type) {
+    case VALUE_TYPE.UINT8:
+      return reader.u8();
+    case VALUE_TYPE.INT8:
+      return (await reader.u8()) << 24 >> 24;
+    case VALUE_TYPE.UINT16:
+      return reader.u16();
+    case VALUE_TYPE.INT16:
+      return (await reader.u16()) << 16 >> 16;
+    case VALUE_TYPE.UINT32:
+      return reader.u32();
+    case VALUE_TYPE.INT32:
+      return reader.i32();
+    case VALUE_TYPE.FLOAT32:
+      return reader.f32();
+    case VALUE_TYPE.BOOL:
+      return (await reader.u8()) !== 0;
+    case VALUE_TYPE.STRING:
+      return reader.string();
+    case VALUE_TYPE.UINT64:
+      return reader.u64();
+    case VALUE_TYPE.INT64:
+      return reader.i64();
+    case VALUE_TYPE.FLOAT64:
+      return reader.f64();
+    default:
+      throw new Error(`Unknown GGUF value type ${type}`);
+  }
+}
+
+/**
+ * Read one metadata value.
+ *
+ * Arrays are walked but not collected past a small prefix: `tokenizer.ggml.tokens` alone
+ * holds ~150k strings, and nothing here needs its contents — only its length, which is a
+ * usable vocabulary size when the tensor index does not give one.
+ * @param {HeaderReader} reader
+ * @param {number} type
+ */
+async function readValue(reader, type) {
+  if (type !== VALUE_TYPE.ARRAY) return readScalar(reader, type);
+
+  const itemType = await reader.u32();
+  const count = await reader.u64();
+  if (count < 0 || count > 1e8) throw new Error('GGUF array length invalid');
+
+  // Per-layer arrays (attention patterns, head counts) run to the block count, so collect
+  // anything short enough to be one of those; only vocabularies are longer.
+  const collect = count <= 1024 && itemType !== VALUE_TYPE.ARRAY && itemType !== VALUE_TYPE.STRING;
+  const items = [];
+  for (let i = 0; i < count; i += 1) {
+    if (itemType === VALUE_TYPE.STRING) {
+      await reader.skipString();
+      continue;
+    }
+    if (itemType === VALUE_TYPE.ARRAY) throw new Error('Nested GGUF arrays are not supported');
+    const value = await readScalar(reader, itemType);
+    if (collect) items.push(value);
+  }
+  return collect ? items : { arrayLength: count };
+}
+
+/** @param {unknown} value */
+function asNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  // `head_count_kv` is per-layer on a few hybrid models; the widest layer sets the cache size.
+  if (Array.isArray(value)) {
+    const nums = value.filter((v) => typeof v === 'number' && Number.isFinite(v));
+    return nums.length ? Math.max(...nums) : 0;
+  }
+  return 0;
+}
+
+/**
+ * Full-attention layer count from `{arch}.attention.sliding_window_pattern`.
+ *
+ * The key comes in two shapes. A scalar N means one full-attention layer every N — llama.cpp's
+ * `set_swa_pattern(N)`. An array of booleans is the per-layer map that newer architectures
+ * (Gemma 4) ship instead, where `true` marks a layer that *uses* the sliding window. Reading
+ * the array form matters: it is the difference between charging a Gemma-class model for 30
+ * growing caches and for the 5 it actually keeps.
+ * @param {unknown} value
+ * @param {number} nLayers
+ * @returns {{ swaPeriod: number, fullLayers: number }}
+ */
+function readSwaPattern(value, nLayers) {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return { swaPeriod: value, fullLayers: 0 };
+  }
+  if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === 'boolean')) {
+    const windowed = value.filter(Boolean).length;
+    return { swaPeriod: 0, fullLayers: Math.max(0, Math.min(nLayers, value.length - windowed)) };
+  }
+  return { swaPeriod: 0, fullLayers: 0 };
+}
+
+/**
+ * @typedef {object} GgufTensorSummary
+ * @property {number} layerBytes Bytes in repeating `blk.*` tensors.
+ * @property {number} fixedBytes Bytes in embedding / output / norm tensors.
+ * @property {number} nVocab Vocabulary size from the token embedding shape, 0 if absent.
+ */
+
+/**
+ * Walk the tensor index, totalling bytes per role and picking up the vocabulary size.
+ * @param {HeaderReader} reader
+ * @param {number} tensorCount
+ * @returns {Promise<GgufTensorSummary>}
+ */
+async function readTensorIndex(reader, tensorCount) {
+  let layerBytes = 0;
+  let fixedBytes = 0;
+  let nVocab = 0;
+
+  for (let i = 0; i < tensorCount; i += 1) {
+    const name = await reader.string();
+    const nDims = await reader.u32();
+    if (nDims > 4) throw new Error('GGUF tensor rank invalid');
+    const dims = [];
+    for (let d = 0; d < nDims; d += 1) dims.push(await reader.u64());
+    const type = await reader.u32();
+    await reader.u64(); // data offset
+
+    const elements = dims.reduce((acc, d) => acc * d, 1);
+    const [blockSize, blockBytes] = GGML_TYPE_SIZES[type] ?? [1, 4];
+    const bytes = (elements / blockSize) * blockBytes;
+
+    if (name.startsWith('blk.')) layerBytes += bytes;
+    else fixedBytes += bytes;
+
+    // ggml stores token_embd.weight as [n_embd, n_vocab].
+    if (name === 'token_embd.weight' && dims.length >= 2) nVocab = dims[1];
+  }
+
+  return { layerBytes, fixedBytes, nVocab };
+}
+
+/**
+ * @typedef {object} GgufMetadata
+ * @property {string} arch
+ * @property {number} nLayers
+ * @property {number} nHead
+ * @property {number} nKvHeads
+ * @property {number} headDim
+ * @property {number} nEmbd
+ * @property {number} nVocab
+ * @property {number} nExperts
+ * @property {number} swaWindow
+ * @property {number} swaPeriod One full-attention layer every N; 0 when not stated as a scalar.
+ * @property {number} nFullAttentionLayers Exact count from a per-layer pattern; 0 when absent.
+ * @property {number} swaHeadDim Head size on sliding-window layers, when it differs; 0 otherwise.
+ * @property {number} trainCtx
+ * @property {number} layerBytes
+ * @property {number} fixedBytes
+ * @property {number} splitCount 1 for a single-file model.
+ * @property {number} fileSizeBytes
+ */
+
+/**
+ * Parse the header of a GGUF file.
+ * @param {string} filePath absolute path to a `.gguf` file
+ * @returns {Promise<GgufMetadata>}
+ */
+export async function parseGgufHeader(filePath) {
+  const handle = await fsp.open(filePath, 'r');
+  try {
+    const stat = await handle.stat();
+    const reader = new HeaderReader(handle, stat.size);
+
+    if ((await reader.u32()) !== GGUF_MAGIC) throw new Error('Not a GGUF file');
+    const version = await reader.u32();
+    if (version < 2 || version > 3) throw new Error(`Unsupported GGUF version ${version}`);
+
+    const tensorCount = await reader.u64();
+    const kvCount = await reader.u64();
+    if (tensorCount > 1e6 || kvCount > 1e5) throw new Error('GGUF header counts invalid');
+
+    /** @type {Record<string, unknown>} */
+    const kv = {};
+    for (let i = 0; i < kvCount; i += 1) {
+      const key = await reader.string();
+      const type = await reader.u32();
+      kv[key] = await readValue(reader, type);
+    }
+
+    const arch = typeof kv['general.architecture'] === 'string' ? kv['general.architecture'] : '';
+    const tensors = await readTensorIndex(reader, tensorCount);
+
+    const nLayers = asNumber(kv[`${arch}.block_count`]);
+    const nEmbd = asNumber(kv[`${arch}.embedding_length`]);
+    const nHead = asNumber(kv[`${arch}.attention.head_count`]);
+    const nKvHeadsRaw = asNumber(kv[`${arch}.attention.head_count_kv`]);
+    const nKvHeads = nKvHeadsRaw > 0 ? nKvHeadsRaw : nHead;
+    const keyLength = asNumber(kv[`${arch}.attention.key_length`]);
+    const headDim = keyLength > 0 ? keyLength : nHead > 0 ? Math.floor(nEmbd / nHead) : 0;
+    const swaKeyLength = asNumber(kv[`${arch}.attention.key_length_swa`]);
+    const swa = readSwaPattern(kv[`${arch}.attention.sliding_window_pattern`], nLayers);
+
+    const tokens = kv['tokenizer.ggml.tokens'];
+    const tokenCount =
+      tokens && typeof tokens === 'object' && 'arrayLength' in tokens
+        ? Number(tokens.arrayLength)
+        : 0;
+
+    return {
+      arch,
+      nLayers,
+      nHead,
+      nKvHeads,
+      headDim,
+      nEmbd,
+      nVocab: tensors.nVocab || asNumber(kv[`${arch}.vocab_size`]) || tokenCount,
+      nExperts: asNumber(kv[`${arch}.expert_count`]),
+      swaWindow: asNumber(kv[`${arch}.attention.sliding_window`]),
+      swaPeriod: swa.swaPeriod,
+      nFullAttentionLayers: swa.fullLayers,
+      swaHeadDim: swaKeyLength,
+      trainCtx: asNumber(kv[`${arch}.context_length`]),
+      layerBytes: tensors.layerBytes,
+      fixedBytes: tensors.fixedBytes,
+      splitCount: Math.max(1, asNumber(kv['split.count'])),
+      fileSizeBytes: stat.size,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+/** @type {Map<string, GgufMetadata>} */
+const cache = new Map();
+const CACHE_LIMIT = 64;
+
+/**
+ * Parse a GGUF header, memoized on path + size + mtime so reopening the inspector is free.
+ * Returns null rather than throwing when the file is missing or not readable as GGUF.
+ * @param {string} filePath
+ * @returns {Promise<GgufMetadata | null>}
+ */
+export async function readGgufMetadata(filePath) {
+  const resolved = path.resolve(String(filePath || ''));
+  if (!resolved.toLowerCase().endsWith('.gguf')) return null;
+
+  let stat;
+  try {
+    stat = await fsp.stat(resolved);
+    if (!stat.isFile()) return null;
+  } catch {
+    return null;
+  }
+
+  const key = `${resolved}:${stat.size}:${stat.mtimeMs}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  let parsed;
+  try {
+    parsed = await parseGgufHeader(resolved);
+  } catch {
+    return null;
+  }
+
+  if (cache.size >= CACHE_LIMIT) cache.delete(cache.keys().next().value);
+  cache.set(key, parsed);
+  return parsed;
+}
+
+/** Test helper — drop memoized headers. */
+export function clearGgufMetadataCache() {
+  cache.clear();
+}

--- a/server/models/profiles.js
+++ b/server/models/profiles.js
@@ -4,6 +4,8 @@
  */
 
 import { DEFAULT_CONTEXT_TOKENS } from './default-context-tokens.js';
+import { estimateRunMemory, GIB, weightsBytesFor } from '../../src/models/memory-model.mjs';
+import { geometryFromGgufMetadata, resolveGeometry } from '../../src/models/model-geometry.mjs';
 
 /**
  * @typedef {object} ServeProfile
@@ -15,20 +17,10 @@ import { DEFAULT_CONTEXT_TOKENS } from './default-context-tokens.js';
  * @property {string} cache_type
  * @property {number} ctx
  * @property {number} est_vram_gb
+ * @property {import('../../src/models/model-geometry.d.mts').GeometrySource} geometry_source
  * @property {boolean} fits
  * @property {string} note
  */
-
-const QUANT_BPP = {
-  Q8_0: 1.0,
-  Q6_K: 0.75,
-  Q5_K_M: 0.65,
-  Q4_K_M: 0.58,
-  Q3_K_M: 0.45,
-  Q2_K: 0.35,
-};
-
-const KV_FACTOR = { q4_0: 0.5, q8_0: 1.0, f16: 2.0 };
 
 /**
  * @param {Record<string, unknown>} model
@@ -45,22 +37,32 @@ function paramsB(model) {
 
 /**
  * @param {Record<string, unknown>} model
- * @param {number} ctx
- * @param {string} kvType
- */
-function kvGb(model, ctx, kvType) {
-  const active = Number(model.active_parameters ?? paramsB(model));
-  return 0.000008 * active * ctx * (KV_FACTOR[kvType] ?? 1.0);
-}
-
-/**
- * @param {Record<string, unknown>} model
  * @param {string} quant
  * @param {number} [fixedGb]
  */
-function weightsGb(model, quant, fixedGb) {
-  if (fixedGb && fixedGb > 0) return fixedGb;
-  return paramsB(model) * (QUANT_BPP[quant] ?? 0.58);
+function weightsBytes(model, quant, fixedGb) {
+  if (fixedGb && fixedGb > 0) return fixedGb * GIB;
+  return weightsBytesFor(paramsB(model), quant);
+}
+
+/**
+ * Attention geometry for a profile request. Exact when the caller passed a GGUF header we
+ * already parsed; otherwise resolved from architecture and parameter count.
+ * @param {Record<string, unknown>} model
+ * @param {Record<string, unknown> | null} [ggufMeta]
+ */
+function geometryFor(model, ggufMeta) {
+  const exact = ggufMeta ? geometryFromGgufMetadata(ggufMeta) : null;
+  if (exact) return exact;
+  const total = paramsB(model);
+  const active = Number(model.active_parameters);
+  return resolveGeometry({
+    architecture: typeof model.architecture === 'string' ? model.architecture : undefined,
+    name: typeof model.name === 'string' ? model.name : undefined,
+    paramsB: total,
+    activeParamsB: active > 0 ? active : total,
+    nExperts: Number(model.num_experts) || 0,
+  });
 }
 
 /**
@@ -77,12 +79,15 @@ function vramBudgetGb(system) {
  * Build serve profiles for a model on the given hardware snapshot.
  * @param {Record<string, unknown>} system — hardware probe row
  * @param {Record<string, unknown>} model — catalog or cached model metadata
- * @param {{ serveWeightsGb?: number, serveQuant?: string }} [opts]
+ * @param {{ serveWeightsGb?: number, serveQuant?: string, ggufMeta?: Record<string, unknown> | null }} [opts]
  * @returns {ServeProfile[]}
  */
 export function computeServeProfiles(system, model, opts = {}) {
   const budget = vramBudgetGb(system);
   const fixedGb = opts.serveWeightsGb;
+  const geometry = geometryFor(model, opts.ggufMeta ?? null);
+  const onGpu = Number(system.gpuVramGb ?? system.gpu_vram_gb ?? 0) > 0;
+  const backend = onGpu ? String(system.backend || 'cuda') : 'cpu';
   const baseQuant = (opts.serveQuant || model.quantization || model.quant || 'Q4_K_M')
     .toString()
     .toUpperCase();
@@ -104,10 +109,18 @@ export function computeServeProfiles(system, model, opts = {}) {
   const profiles = [];
   for (const t of templates) {
     const quant = fixedGb ? baseQuant : t.quant;
-    const w = weightsGb(model, quant, fixedGb);
-    const kv = kvGb(model, t.ctx, t.cache);
-    const est = w + kv + 0.6;
+    const estimate = estimateRunMemory({
+      geometry,
+      weightsBytes: weightsBytes(model, quant, fixedGb),
+      ctx: t.ctx,
+      cacheType: t.cache,
+      nGpuLayers: onGpu ? undefined : 0,
+      backend,
+      deviceCount: Number(system.gpuCount) || 1,
+    });
+    const est = estimate.totalGb;
     const fits = est <= budget;
+    const unit = onGpu ? 'VRAM' : 'RAM';
     profiles.push({
       key: t.key,
       label: t.label,
@@ -116,11 +129,12 @@ export function computeServeProfiles(system, model, opts = {}) {
       n_cpu_moe: 0,
       cache_type: t.cache,
       ctx: t.ctx,
-      est_vram_gb: Math.round(est * 10) / 10,
+      est_vram_gb: est,
+      geometry_source: geometry.source,
       fits,
       note: fits
-        ? `Est. ${Math.round(est * 10) / 10} GB VRAM at ${t.ctx} ctx`
-        : `Needs ~${Math.round(est * 10) / 10} GB; budget ~${Math.round(budget * 10) / 10} GB`,
+        ? `Est. ${est} GB ${unit} at ${t.ctx} ctx`
+        : `Needs ~${est} GB; budget ~${Math.round(budget * 10) / 10} GB`,
     });
   }
 

--- a/server/models/routes.js
+++ b/server/models/routes.js
@@ -8,6 +8,7 @@ import { listCachedModels } from './cached.js';
 import { listInstalled } from './installed.js';
 import { getModelsConfig, patchModelsConfig } from './models-config.js';
 import { getInferencePrefs, setLibraryInferenceSampler } from './inference-prefs.js';
+import { readGgufMetadata } from './gguf-metadata.js';
 import { computeServeProfiles } from './profiles.js';
 import { detectRuntimes } from './runtime-detect.js';
 import { getServe, listServes, startServe, stopServe } from './serve.js';
@@ -145,6 +146,20 @@ export async function handleModelsRequest(req, res, pathname) {
     return true;
   }
 
+  // Attention geometry read out of a local GGUF header, so the inspector can show exact
+  // memory numbers and a real layer count instead of guessing from parameter count.
+  if (pathname === '/api/models/gguf-meta' && req.method === 'GET') {
+    const parsed = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const filePath = parsed.searchParams.get('path') || '';
+    const meta = await readGgufMetadata(filePath);
+    if (!meta) {
+      sendJson(res, 404, { error: 'No readable GGUF header at that path' });
+      return true;
+    }
+    sendJson(res, 200, meta);
+    return true;
+  }
+
   if (pathname === '/api/models/config' && req.method === 'GET') {
     const models = await getModelsConfig();
     const hfToken = typeof models.hfToken === 'string' ? models.hfToken : '';
@@ -223,6 +238,7 @@ export async function handleModelsRequest(req, res, pathname) {
       const hardware = await detectHardware({ fresh });
       const model = {
         name: modelName,
+        architecture: parsed.searchParams.get('arch') || undefined,
         parameter_count: parsed.searchParams.get('params') || undefined,
         parameters_raw: parsed.searchParams.get('params_b')
           ? Number(parsed.searchParams.get('params_b'))
@@ -233,9 +249,13 @@ export async function handleModelsRequest(req, res, pathname) {
           : undefined,
         is_moe: parsed.searchParams.get('is_moe') === '1',
       };
+      // When the weights are already on disk their header beats every heuristic.
+      const modelPath = parsed.searchParams.get('model_path') || '';
+      const ggufMeta = modelPath ? await readGgufMetadata(modelPath) : null;
       const profiles = computeServeProfiles(hardware, model, {
         serveWeightsGb: weightsGb ? Number(weightsGb) : undefined,
         serveQuant: quant,
+        ggufMeta,
       });
       const variant = (await getInstalledLlamaVariant()) ?? 'cpu';
       const profilesWithArgs = profiles.map((p) => ({

--- a/src/models/api-client.ts
+++ b/src/models/api-client.ts
@@ -3,6 +3,9 @@
  */
 
 import { withSessionToken } from '../api/session-token.ts';
+import type { GgufGeometryFacts } from './serve-memory-estimate.ts';
+
+export type { GgufGeometryFacts };
 
 /** GGUF fetches one file; MLX fetches a whole repo snapshot into a directory. */
 export type ModelDownloadFormat = 'gguf' | 'mlx';
@@ -285,6 +288,18 @@ export async function fetchInstalledModels(): Promise<{
 export async function fetchRuntimes(): Promise<RuntimeDetection> {
   const res = await fetch('/api/models/runtimes');
   return parseJson(res);
+}
+
+/**
+ * Attention geometry read from a local GGUF header.
+ * Resolves to null when the file is gone or is not a GGUF Minnow can parse.
+ */
+export async function fetchGgufGeometry(
+  filePath: string,
+): Promise<GgufGeometryFacts | null> {
+  const res = await fetch(`/api/models/gguf-meta?path=${encodeURIComponent(filePath)}`);
+  if (!res.ok) return null;
+  return parseJson<GgufGeometryFacts>(res);
 }
 
 export async function fetchCachedModels(): Promise<CachedModelRow[]> {

--- a/src/models/fit.ts
+++ b/src/models/fit.ts
@@ -1,15 +1,25 @@
 import { getModels } from './catalog';
 import {
+  DEFAULT_WEIGHT_GIB_PER_BILLION,
+  estimateRunMemory,
+  GIB,
+  maxContextForBudget,
+  weightsBytesFor,
+  WEIGHT_GIB_PER_BILLION,
+} from './memory-model.mjs';
+import { GEOMETRY_UNCERTAINTY } from './model-geometry.mjs';
+import {
   activeParamsB,
   estimateMemoryGb,
   estimateFileSizeGb,
+  geometryForModel,
   inferUseCase,
   isPrequantized,
   paramsB,
-  QUANT_BYTES_PER_PARAM,
   QUANT_QUALITY_PENALTY,
   QUANT_SPEED_MULT,
 } from './quant';
+import type { GeometrySource } from './model-geometry.d.mts';
 import type { CatalogModel, HardwareSnapshot, ModelFitResult } from './types';
 
 export const GPU_BANDWIDTH: Record<string, number> = {
@@ -172,7 +182,9 @@ function estimateSpeed(
   const backend = system.backend || 'cpu_x86';
 
   if (bw && (runMode === 'gpu' || runMode === 'cpu_offload')) {
-    const bpp = QUANT_BYTES_PER_PARAM[quant] ?? 0.5;
+    // Streaming the weights once per token is what sets the ceiling, so this is the real
+    // file size, not the quant's nominal bit width.
+    const bpp = WEIGHT_GIB_PER_BILLION[quant] ?? DEFAULT_WEIGHT_GIB_PER_BILLION;
     const modelGb = pb * bpp;
     if (modelGb <= 0) return 0.0;
     const efficiency = 0.55;
@@ -260,26 +272,72 @@ function contextScore(ctx: number, useCase: string): number {
   return 30;
 }
 
+interface QuantFit {
+  runMode: string;
+  quant: string;
+  ctx: number;
+  requiredGb: number;
+  geometrySource: GeometrySource;
+}
+
+/**
+ * Largest configuration of `quant` that fits, preferring VRAM and then falling back to RAM.
+ *
+ * Weights, compute graph, and backend overhead are fixed once the quant is chosen, so the
+ * context that fits a budget is solved directly. The previous halve-until-it-fits loop could
+ * only ever report ctx, ctx/2, ctx/4 …, so a model that had room for 30k context was listed
+ * at 16k, and one needing a 5% trim was cut in half.
+ */
 function tryQuantAt(
   model: CatalogModel,
   quant: string,
   ctx: number,
   gpuVram: number,
   availableRam: number,
-): [string, string, number, number] | null {
-  let mem = estimateMemoryGb(model, quant, ctx);
-  if (gpuVram > 0 && mem <= gpuVram) return ['gpu', quant, ctx, mem];
-  if (gpuVram > 0 && mem <= availableRam) return ['cpu_offload', quant, ctx, mem];
-  if (gpuVram <= 0 && mem <= availableRam) return ['cpu_only', quant, ctx, mem];
+): QuantFit | null {
+  const geometry = geometryForModel(model);
+  const weightsBytes = weightsBytesFor(paramsB(model), quant);
+  // Guessed geometry earns a margin; a confident-looking number that OOMs is worse than a
+  // conservative one. See GEOMETRY_UNCERTAINTY.
+  const headroom = GEOMETRY_UNCERTAINTY[geometry.source] ?? 1;
 
-  let curCtx = Math.floor(ctx / 2);
-  while (curCtx >= 1024) {
-    mem = estimateMemoryGb(model, quant, curCtx);
-    if (gpuVram > 0 && mem <= gpuVram) return ['gpu', quant, curCtx, mem];
-    if (mem <= availableRam) {
-      return [gpuVram > 0 ? 'cpu_offload' : 'cpu_only', quant, curCtx, mem];
-    }
-    curCtx = Math.floor(curCtx / 2);
+  const estimateAt = (context: number, onGpu: boolean) =>
+    estimateRunMemory({
+      geometry,
+      weightsBytes,
+      ctx: context,
+      backend: onGpu ? 'cuda' : 'cpu',
+      nGpuLayers: onGpu ? undefined : 0,
+    });
+
+  const bestContextFor = (budgetGb: number, onGpu: boolean): number => {
+    if (budgetGb <= 0) return 0;
+    const budgetBytes = (budgetGb * GIB) / headroom;
+    if (estimateAt(ctx, onGpu).totalBytes <= budgetBytes) return ctx;
+    const kvBudget = budgetBytes - estimateAt(0, onGpu).totalBytes;
+    return Math.min(ctx, maxContextForBudget(geometry, kvBudget, 'f16'));
+  };
+
+  const gpuCtx = gpuVram > 0 ? bestContextFor(gpuVram, true) : 0;
+  if (gpuCtx > 0) {
+    return {
+      runMode: 'gpu',
+      quant,
+      ctx: gpuCtx,
+      requiredGb: estimateAt(gpuCtx, true).totalGb,
+      geometrySource: geometry.source,
+    };
+  }
+
+  const cpuCtx = bestContextFor(availableRam, false);
+  if (cpuCtx > 0) {
+    return {
+      runMode: gpuVram > 0 ? 'cpu_offload' : 'cpu_only',
+      quant,
+      ctx: cpuCtx,
+      requiredGb: estimateAt(cpuCtx, false).totalGb,
+      geometrySource: geometry.source,
+    };
   }
   return null;
 }
@@ -438,6 +496,7 @@ export function analyzeModel(
   if (result === null) {
     const oversizedRequired = estimateMemoryGb(model, quantToTry, ctx);
     return {
+      geometry_source: geometryForModel(model).source,
       name: model.name,
       provider: model.provider,
       parameter_count: model.parameter_count,
@@ -459,7 +518,7 @@ export function analyzeModel(
     };
   }
 
-  const [runMode, quant, fitCtx, requiredGb] = result;
+  const { runMode, quant, ctx: fitCtx, requiredGb } = result;
 
   const budget = runMode === 'gpu' ? effectiveVram : availableRam;
   if (requiredGb > budget) return null;
@@ -515,6 +574,7 @@ export function analyzeModel(
     context_length: modelCtx,
     release_date: model.release_date ?? '',
     target_context: parsedTargetContext || null,
+    geometry_source: result.geometrySource,
   };
 }
 

--- a/src/models/memory-model.d.mts
+++ b/src/models/memory-model.d.mts
@@ -1,0 +1,73 @@
+import type { GeometrySource, ModelGeometry } from './model-geometry.d.mts';
+
+export declare const GIB: number;
+export declare const KV_TYPE_BYTES: Record<string, number>;
+export declare const WEIGHT_GIB_PER_BILLION: Record<string, number>;
+export declare const DEFAULT_WEIGHT_GIB_PER_BILLION: number;
+export declare const DEFAULT_UBATCH: number;
+
+export interface MemoryEstimateInput {
+  geometry: ModelGeometry;
+  /** Exact file size when the weights are on disk. */
+  weightsBytes: number;
+  ctx: number;
+  /** `--cache-type-k/v`; defaults to f16. */
+  cacheType?: string;
+  /** llama.cpp `-ngl`. Undefined or >= nLayers means all layers on GPU. */
+  nGpuLayers?: number;
+  /** cuda | rocm | vulkan | metal | cpu. */
+  backend?: string;
+  deviceCount?: number;
+  ubatch?: number;
+}
+
+export interface MemoryEstimateBreakdown {
+  weightsVram: number;
+  weightsRam: number;
+  kvVram: number;
+  kvRam: number;
+  compute: number;
+  overhead: number;
+}
+
+export interface MemoryEstimate {
+  vramGb: number;
+  ramGb: number;
+  totalGb: number;
+  vramBytes: number;
+  ramBytes: number;
+  totalBytes: number;
+  kvBytesPerToken: number;
+  gpuLayers: number;
+  nLayers: number;
+  geometrySource: GeometrySource;
+  /** Bytes. */
+  breakdown: MemoryEstimateBreakdown;
+}
+
+export declare function kvElementBytes(cacheType?: string | null): number;
+export declare function fullAttentionLayers(geometry: ModelGeometry): number;
+export declare function kvCacheBytes(
+  geometry: ModelGeometry,
+  ctx: number,
+  cacheType?: string,
+  opts?: { ubatch?: number; parallel?: number },
+): number;
+export declare function kvBytesPerToken(geometry: ModelGeometry, cacheType?: string): number;
+export declare function computeBufferBytes(
+  geometry: ModelGeometry,
+  opts?: { ubatch?: number },
+): number;
+export declare function backendOverheadBytes(
+  backend?: string | null,
+  deviceCount?: number,
+): number;
+export declare function weightsBytesFor(paramsB: number, quant: string): number;
+export declare function estimateRunMemory(input: MemoryEstimateInput): MemoryEstimate;
+export declare function maxContextForBudget(
+  geometry: ModelGeometry,
+  budgetBytes: number,
+  cacheType?: string,
+  opts?: { ubatch?: number; minCtx?: number; maxCtx?: number },
+): number;
+export declare function formatMemoryEstimate(estimate: MemoryEstimate): string;

--- a/src/models/memory-model.mjs
+++ b/src/models/memory-model.mjs
@@ -1,0 +1,380 @@
+/**
+ * Memory model for a llama.cpp run: weights + KV cache + compute graph + backend overhead.
+ *
+ * One shared model behind every memory number Minnow shows — the Models discovery ranking,
+ * the inspector's Load tab, and the server-side serve profiles. Those three used to carry
+ * three different formulas that disagreed with each other by up to 2x on the same model at
+ * the same settings, on top of all being wrong in the same direction (see model-geometry.mjs
+ * for why the old parameter-count-derived KV term could not work).
+ *
+ * Everything here is bytes in, bytes out; GiB conversion happens at the display edge, to
+ * match how `detectHardware` reports VRAM and RAM.
+ */
+
+/** @typedef {import('./model-geometry.d.mts').ModelGeometry} ModelGeometry */
+
+export const GIB = 1024 ** 3;
+
+/**
+ * Bytes per element for each `--cache-type-k/v` value, from the ggml block layouts:
+ * a quantized KV type stores `blockSize` elements in `typeSize` bytes.
+ */
+export const KV_TYPE_BYTES = {
+  f32: 4,
+  f16: 2,
+  bf16: 2,
+  q8_0: 34 / 32,
+  q5_1: 24 / 32,
+  q5_0: 22 / 32,
+  q4_1: 20 / 32,
+  q4_0: 18 / 32,
+  iq4_nl: 18 / 32,
+};
+
+/**
+ * GiB of weights per billion parameters, measured from published GGUF builds rather than
+ * derived from the nominal bit width.
+ *
+ * Two corrections are baked in. A k-quant file is larger than its name implies, because the
+ * token embedding and output head are kept at higher precision — Q4_K_M lands near 4.9
+ * bits/weight, not 4. And a "byte per weight" is 1e9 bytes per billion parameters, which is
+ * 0.931 GiB, so a table written in bytes/weight overstates every entry by 7% once the number
+ * is compared against a VRAM figure the OS reports in GiB.
+ *
+ * These only matter for models that are not downloaded yet; anything on disk is measured.
+ */
+export const WEIGHT_GIB_PER_BILLION = {
+  F32: 3.73,
+  F16: 1.86,
+  BF16: 1.86,
+  Q8_0: 0.99,
+  FP8: 0.95,
+  INT8: 0.95,
+  W8A8: 0.95,
+  W8A16: 0.95,
+  'AWQ-8bit': 0.95,
+  'GPTQ-Int8': 0.95,
+  'mlx-8bit': 0.97,
+  'FP8-Mixed': 0.95,
+  Q6_K: 0.77,
+  'mlx-6bit': 0.74,
+  Q5_K_M: 0.67,
+  Q5_K_S: 0.65,
+  Q4_K_M: 0.57,
+  Q4_K_S: 0.54,
+  Q4_0: 0.54,
+  IQ4_XS: 0.52,
+  Q3_K_M: 0.47,
+  IQ3_XXS: 0.38,
+  Q2_K: 0.37,
+  IQ2_XXS: 0.28,
+  // Native 4-bit formats carry group scales and f16 embeddings but no k-quant precision islands.
+  FP4: 0.53,
+  NVFP4: 0.53,
+  MXFP4: 0.53,
+  NF4: 0.53,
+  INT4: 0.53,
+  W4A16: 0.53,
+  'AWQ-4bit': 0.53,
+  'GPTQ-Int4': 0.53,
+  'mlx-4bit': 0.55,
+  'FP4-MoE-Mixed': 0.55,
+};
+
+/** Fallback when a quant label is not in the table (assume a 4-bit k-quant). */
+export const DEFAULT_WEIGHT_GIB_PER_BILLION = 0.57;
+
+/**
+ * Persistent per-device backend allocations that exist before any tensor is loaded:
+ * driver context, BLAS workspaces, allocator slack. Measured as the gap between
+ * llama.cpp's own buffer accounting and process VRAM use.
+ */
+const BACKEND_OVERHEAD_GIB = {
+  cuda: 0.3,
+  rocm: 0.35,
+  hip: 0.35,
+  vulkan: 0.25,
+  sycl: 0.25,
+  metal: 0.08,
+  mps: 0.08,
+  cpu: 0.06,
+};
+
+/** Host-side allocations that exist for any run, GPU or not. */
+const HOST_OVERHEAD_GIB = 0.15;
+
+/** llama.cpp's default micro-batch (`-ub`). */
+export const DEFAULT_UBATCH = 512;
+
+/**
+ * Live `ubatch x n_embd` f32 tensors in a llama-family graph. The graph is reserved for the
+ * worst case, so this counts concurrent scratch across attention and FFN, not the total.
+ */
+const GRAPH_SCRATCH_TENSORS = 6;
+
+/** @param {string | null | undefined} cacheType */
+export function kvElementBytes(cacheType) {
+  const key = String(cacheType ?? 'f16').toLowerCase();
+  return KV_TYPE_BYTES[key] ?? KV_TYPE_BYTES.f16;
+}
+
+/**
+ * Full-attention layers in a model — the ones whose cache grows with context. Sliding-window
+ * layers never exceed their window no matter how long the context gets.
+ *
+ * An exact per-layer count from the GGUF header wins; otherwise 1 layer in `swaPeriod` keeps
+ * full attention, and a `swaPeriod` of 1 means the model has no windowing at all.
+ * @param {ModelGeometry} geometry
+ */
+export function fullAttentionLayers(geometry) {
+  if (geometry.nFullAttentionLayers && geometry.nFullAttentionLayers > 0) {
+    return Math.min(geometry.nLayers, geometry.nFullAttentionLayers);
+  }
+  const period = geometry.swaPeriod > 1 ? geometry.swaPeriod : 1;
+  if (period <= 1) return geometry.nLayers;
+  return Math.ceil(geometry.nLayers / period);
+}
+
+/**
+ * KV cache bytes for a context length.
+ *
+ * `2 *` covers the separate K and V caches. Sliding-window layers are charged for their
+ * window plus one micro-batch of headroom, which is what llama.cpp allocates for them, and
+ * use their own head size when the architecture narrows them.
+ * @param {ModelGeometry} geometry
+ * @param {number} ctx
+ * @param {string} [cacheType]
+ * @param {{ ubatch?: number, parallel?: number }} [opts]
+ */
+export function kvCacheBytes(geometry, ctx, cacheType = 'f16', opts = {}) {
+  const tokens = Math.max(0, ctx);
+  if (!tokens) return 0;
+  const ubatch = opts.ubatch ?? DEFAULT_UBATCH;
+  const bytesPerElement = kvElementBytes(cacheType);
+
+  const fullLayers = fullAttentionLayers(geometry);
+  const windowedLayers = geometry.nLayers - fullLayers;
+  const windowTokens = Math.min(tokens, (geometry.swaWindow || 0) + ubatch);
+  const swaHeadDim = geometry.swaHeadDim || geometry.headDim;
+
+  const fullBytes = 2 * geometry.nKvHeads * geometry.headDim * bytesPerElement;
+  const windowBytes = 2 * geometry.nKvHeads * swaHeadDim * bytesPerElement;
+
+  return fullBytes * fullLayers * tokens + windowBytes * windowedLayers * windowTokens;
+}
+
+/**
+ * Bytes of KV cache added per extra token of context — the number that makes "can I raise
+ * the context?" answerable without re-running the whole estimate. Windowed layers contribute
+ * nothing here; their cost is a fixed floor, not a slope.
+ * @param {ModelGeometry} geometry
+ * @param {string} [cacheType]
+ */
+export function kvBytesPerToken(geometry, cacheType = 'f16') {
+  const bytesPerElement = kvElementBytes(cacheType);
+  return 2 * fullAttentionLayers(geometry) * geometry.nKvHeads * geometry.headDim * bytesPerElement;
+}
+
+/**
+ * Compute-graph buffer. Dominated by the logits tensor (`n_vocab x ubatch`), which is why
+ * a 0.6B model with a 152k vocabulary reserves nearly as much scratch as an 8B one.
+ *
+ * Assumes flash attention, which is llama.cpp's default (`--flash-attn auto`). Without it the
+ * graph also holds `n_head x ctx x ubatch` attention scores, which at long context is larger
+ * than everything else here combined.
+ * @param {ModelGeometry} geometry
+ * @param {{ ubatch?: number }} [opts]
+ */
+export function computeBufferBytes(geometry, opts = {}) {
+  const ubatch = opts.ubatch ?? DEFAULT_UBATCH;
+  const logits = geometry.nVocab * ubatch * 4;
+  const scratch = ubatch * geometry.nEmbd * 4 * GRAPH_SCRATCH_TENSORS;
+  return logits + scratch;
+}
+
+/**
+ * @param {string | null | undefined} backend
+ * @param {number} [deviceCount]
+ */
+export function backendOverheadBytes(backend, deviceCount = 1) {
+  const key = String(backend ?? 'cpu').toLowerCase();
+  const perDevice = BACKEND_OVERHEAD_GIB[key] ?? BACKEND_OVERHEAD_GIB.cpu;
+  return perDevice * Math.max(1, deviceCount) * GIB;
+}
+
+/**
+ * On-disk weights size for a parameter count and quant tier.
+ * @param {number} paramsB
+ * @param {string} quant
+ * @returns {number} bytes
+ */
+export function weightsBytesFor(paramsB, quant) {
+  const perBillion = WEIGHT_GIB_PER_BILLION[quant] ?? DEFAULT_WEIGHT_GIB_PER_BILLION;
+  return Math.max(0, paramsB) * perBillion * GIB;
+}
+
+/**
+ * @typedef {object} MemoryEstimateInput
+ * @property {ModelGeometry} geometry
+ * @property {number} weightsBytes Exact file size when the weights are on disk.
+ * @property {number} ctx
+ * @property {string} [cacheType] `--cache-type-k/v`; defaults to f16.
+ * @property {number} [nGpuLayers] llama.cpp `-ngl`. Undefined or >= nLayers means all.
+ * @property {string} [backend] cuda | rocm | vulkan | metal | cpu.
+ * @property {number} [deviceCount]
+ * @property {number} [ubatch]
+ */
+
+/**
+ * @typedef {object} MemoryEstimate
+ * @property {number} vramGb
+ * @property {number} ramGb
+ * @property {number} totalGb
+ * @property {number} vramBytes
+ * @property {number} ramBytes
+ * @property {number} totalBytes
+ * @property {number} kvBytesPerToken
+ * @property {number} gpuLayers
+ * @property {number} nLayers
+ * @property {import('./model-geometry.d.mts').GeometrySource} geometrySource
+ * @property {{ weightsVram: number, weightsRam: number, kvVram: number, kvRam: number, compute: number, overhead: number }} breakdown Bytes.
+ */
+
+/** @param {number} bytes */
+function toGb(bytes) {
+  return Math.round((bytes / GIB) * 10) / 10;
+}
+
+/**
+ * Split weights between GPU and CPU for a partial offload.
+ *
+ * llama.cpp moves whole transformer blocks, and the embedding / output tensors only once
+ * `-ngl` exceeds the block count. When the GGUF header gave us exact per-tensor sizes we use
+ * the real repeating/fixed split; otherwise we fall back to a proportional one, which
+ * overstates GPU use for models with a large vocabulary.
+ * @param {ModelGeometry} geometry
+ * @param {number} weightsBytes
+ * @param {number} gpuLayers
+ * @param {boolean} offloadOutput
+ */
+function splitWeights(geometry, weightsBytes, gpuLayers, offloadOutput) {
+  const layerFraction = geometry.nLayers > 0 ? gpuLayers / geometry.nLayers : 0;
+  const exactTotal = (geometry.layerBytes ?? 0) + (geometry.fixedBytes ?? 0);
+
+  let repeating = weightsBytes;
+  let fixed = 0;
+  if (exactTotal > 0) {
+    // Scale the measured ratio onto the caller's byte count, which stays authoritative
+    // (a split GGUF reports only the part we parsed).
+    repeating = weightsBytes * ((geometry.layerBytes ?? 0) / exactTotal);
+    fixed = weightsBytes - repeating;
+  }
+
+  const onGpu = repeating * layerFraction + (offloadOutput ? fixed : 0);
+  return { weightsVram: onGpu, weightsRam: weightsBytes - onGpu };
+}
+
+/**
+ * Memory needed to run a model at given settings.
+ * @param {MemoryEstimateInput} input
+ * @returns {MemoryEstimate}
+ */
+export function estimateRunMemory(input) {
+  const { geometry } = input;
+  const weightsBytes = Math.max(0, input.weightsBytes || 0);
+  const ctx = Math.max(0, input.ctx || 0);
+  const ubatch = input.ubatch ?? DEFAULT_UBATCH;
+  const requested = input.nGpuLayers ?? geometry.nLayers;
+  const gpuLayers = Math.max(0, Math.min(geometry.nLayers, requested));
+  const offloadOutput = requested > geometry.nLayers;
+  const onGpu = gpuLayers > 0;
+
+  const kvTotal = kvCacheBytes(geometry, ctx, input.cacheType, { ubatch });
+  // KV lives wherever its layer lives — the old model charged every byte of it to VRAM even
+  // at `-ngl 1`, which made partial offload look far more expensive than it is.
+  const kvVram = geometry.nLayers > 0 ? kvTotal * (gpuLayers / geometry.nLayers) : 0;
+  const kvRam = kvTotal - kvVram;
+
+  const { weightsVram, weightsRam } = splitWeights(
+    geometry,
+    weightsBytes,
+    gpuLayers,
+    offloadOutput,
+  );
+
+  const compute = computeBufferBytes(geometry, { ubatch });
+  const backendOverhead = backendOverheadBytes(
+    onGpu ? (input.backend ?? 'cuda') : 'cpu',
+    input.deviceCount ?? 1,
+  );
+  const hostOverhead = HOST_OVERHEAD_GIB * GIB;
+
+  const vramBytes = onGpu ? weightsVram + kvVram + compute + backendOverhead : 0;
+  const ramBytes = onGpu
+    ? weightsRam + kvRam + hostOverhead
+    : weightsRam + kvRam + compute + backendOverhead + hostOverhead;
+
+  return {
+    vramGb: toGb(vramBytes),
+    ramGb: toGb(ramBytes),
+    totalGb: toGb(vramBytes + ramBytes),
+    vramBytes,
+    ramBytes,
+    totalBytes: vramBytes + ramBytes,
+    kvBytesPerToken: kvBytesPerToken(geometry, input.cacheType),
+    gpuLayers,
+    nLayers: geometry.nLayers,
+    geometrySource: geometry.source,
+    breakdown: {
+      weightsVram,
+      weightsRam,
+      kvVram,
+      kvRam,
+      compute,
+      overhead: backendOverhead + hostOverhead,
+    },
+  };
+}
+
+/**
+ * Largest context that fits a byte budget, rounded down to a power of two.
+ *
+ * Solves for context directly instead of the old halve-and-retry loop, which could only ever
+ * report ctx/2, ctx/4, ... and so under-reported what a machine can actually hold.
+ * @param {ModelGeometry} geometry
+ * @param {number} budgetBytes bytes left after weights, compute, and overhead
+ * @param {string} [cacheType]
+ * @param {{ ubatch?: number, minCtx?: number, maxCtx?: number }} [opts]
+ * @returns {number} 0 when even the minimum does not fit
+ */
+export function maxContextForBudget(geometry, budgetBytes, cacheType = 'f16', opts = {}) {
+  const minCtx = opts.minCtx ?? 1024;
+  const maxCtx = opts.maxCtx ?? 1_048_576;
+  if (budgetBytes <= 0) return 0;
+
+  const perToken = kvBytesPerToken(geometry, cacheType);
+  if (perToken <= 0) return maxCtx;
+
+  // Windowed layers add a context-independent floor; take it off the budget first.
+  const floor = kvCacheBytes(geometry, maxCtx, cacheType, opts) - perToken * maxCtx;
+  const usable = budgetBytes - floor;
+  if (usable <= 0) return 0;
+
+  const raw = Math.floor(usable / perToken);
+  if (raw < minCtx) return 0;
+
+  const power = 2 ** Math.floor(Math.log2(raw));
+  return Math.min(maxCtx, power);
+}
+
+/**
+ * Human-readable split for a hint line.
+ * @param {MemoryEstimate} estimate
+ */
+export function formatMemoryEstimate(estimate) {
+  if (estimate.vramGb > 0 && estimate.ramGb > 0) {
+    return `~${estimate.vramGb} GB VRAM + ~${estimate.ramGb} GB RAM`;
+  }
+  if (estimate.vramGb > 0) return `~${estimate.vramGb} GB VRAM`;
+  return `~${estimate.ramGb} GB RAM`;
+}

--- a/src/models/model-geometry.d.mts
+++ b/src/models/model-geometry.d.mts
@@ -1,0 +1,70 @@
+export type GeometrySource = 'gguf' | 'family' | 'heuristic';
+
+export interface ModelGeometry {
+  /** Transformer blocks. */
+  nLayers: number;
+  /** Key/value heads per block (GQA width). */
+  nKvHeads: number;
+  /** Size of one attention head. */
+  headDim: number;
+  /** Hidden size. */
+  nEmbd: number;
+  /** Vocabulary size — drives the logits buffer. */
+  nVocab: number;
+  /** MoE expert count; 0 for dense models. */
+  nExperts: number;
+  /** Sliding-window size in tokens; 0 when every layer is full attention. */
+  swaWindow: number;
+  /** One full-attention layer every N layers; 1 when there is no SWA. */
+  swaPeriod: number;
+  source: GeometrySource;
+  /** Exact full-attention layer count from a per-layer pattern; overrides `swaPeriod`. */
+  nFullAttentionLayers?: number;
+  /** Head size on sliding-window layers, when it differs from `headDim`. */
+  swaHeadDim?: number;
+  /** Exact bytes of repeating `blk.*` tensors (GGUF only). */
+  layerBytes?: number;
+  /** Exact bytes of embedding / output tensors (GGUF only). */
+  fixedBytes?: number;
+}
+
+export interface GeometryInput {
+  /** HF `model_type` (catalog `architecture` field). */
+  architecture?: string;
+  /** Model or file name, used when architecture is missing. */
+  name?: string;
+  /** Total parameters in billions. */
+  paramsB?: number;
+  /** Active parameters in billions (MoE). */
+  activeParamsB?: number;
+  nExperts?: number;
+}
+
+export interface FamilySize {
+  paramsB: number;
+  nLayers: number;
+  nEmbd: number;
+  nKvHeads?: number;
+  headDim?: number;
+  nExperts?: number;
+}
+
+export interface Family {
+  nKvHeads: number;
+  headDim: number;
+  nVocab: number;
+  swaWindow?: number;
+  swaPeriod?: number;
+  sizes: FamilySize[];
+}
+
+export declare const GEOMETRY_FAMILIES: Record<string, Family>;
+export declare const GEOMETRY_UNCERTAINTY: Record<GeometrySource, number>;
+export declare function heuristicLayerCount(paramsB: number): number;
+export declare function resolveFamilyKey(input: GeometryInput): string | null;
+export declare function heuristicGeometry(input: GeometryInput, family?: Family): ModelGeometry;
+export declare function resolveGeometry(input: GeometryInput): ModelGeometry;
+/** Accepts a parsed GGUF header (see server/models/gguf-metadata.js). */
+export declare function geometryFromGgufMetadata(
+  meta: Partial<Record<string, unknown>> | object | null | undefined,
+): ModelGeometry | null;

--- a/src/models/model-geometry.mjs
+++ b/src/models/model-geometry.mjs
@@ -1,0 +1,540 @@
+/**
+ * Attention geometry — the shape that actually decides how much memory a model needs.
+ *
+ * The previous estimates derived KV cache from parameter count (`0.000008 * paramsB * ctx`),
+ * a constant fitted to Llama-3-8B and then extrapolated linearly. Parameter count does not
+ * predict KV size. Qwen3-0.6B and Qwen3-8B have near-identical KV geometry (28 vs 36 layers
+ * of 8x128 GQA), so a linear fit lands 22x low on the small one while Llama-3.3-70B comes out
+ * 1.9x high. What sets KV size is `layers x kv_heads x head_dim`, and whether the model uses
+ * sliding-window attention — Gemma 3 and gpt-oss keep full attention on only 1-in-6 and
+ * 1-in-2 layers respectively, which the old formula could not express at all.
+ *
+ * Geometry is resolved best-effort, in descending order of confidence:
+ *   'gguf'      exact, read out of the file's own header (see server/models/gguf-metadata.js)
+ *   'family'    a shipped model in the table below matched on architecture + parameter count
+ *   'heuristic' fitted fallback from parameter count alone
+ */
+
+/**
+ * @typedef {object} ModelGeometry
+ * @property {number} nLayers Transformer blocks.
+ * @property {number} nKvHeads Key/value heads per block (GQA width).
+ * @property {number} headDim Size of one attention head.
+ * @property {number} nEmbd Hidden size.
+ * @property {number} nVocab Vocabulary size — drives the logits buffer.
+ * @property {number} nExperts MoE expert count; 0 for dense models.
+ * @property {number} swaWindow Sliding-window size in tokens; 0 when every layer is full attention.
+ * @property {number} swaPeriod One full-attention layer every N layers; 1 when there is no SWA.
+ * @property {GeometrySource} source Where the numbers came from.
+ * @property {number} [nFullAttentionLayers] Exact full-attention layer count; overrides swaPeriod.
+ * @property {number} [swaHeadDim] Head size on sliding-window layers, when it differs.
+ * @property {number} [layerBytes] Exact bytes of repeating `blk.*` tensors (GGUF only).
+ * @property {number} [fixedBytes] Exact bytes of embeddings / output tensors (GGUF only).
+ */
+
+/** @typedef {'gguf' | 'family' | 'heuristic'} GeometrySource */
+
+/**
+ * @typedef {object} GeometryInput
+ * @property {string} [architecture] HF `model_type` (catalog `architecture` field).
+ * @property {string} [name] Model or file name, used when architecture is missing.
+ * @property {number} [paramsB] Total parameters in billions.
+ * @property {number} [activeParamsB] Active parameters in billions (MoE).
+ * @property {number} [nExperts]
+ */
+
+/**
+ * @typedef {object} FamilySize
+ * @property {number} paramsB
+ * @property {number} nLayers
+ * @property {number} nEmbd
+ * @property {number} [nKvHeads]
+ * @property {number} [headDim]
+ * @property {number} [nExperts]
+ */
+
+/**
+ * @typedef {object} Family
+ * @property {number} nKvHeads Default key/value head count for the family.
+ * @property {number} headDim
+ * @property {number} nVocab
+ * @property {number} [swaWindow]
+ * @property {number} [swaPeriod]
+ * @property {FamilySize[]} sizes
+ */
+
+/**
+ * Shipped model geometry, read from each model's published `config.json`.
+ *
+ * Only families that are actually common in the catalog are listed; anything else falls
+ * through to `heuristicGeometry`. Sizes are matched on parameter count, so variants of the
+ * same architecture that differ only in size (Llama 2 7B vs Llama 3 8B) stay distinguishable.
+ *
+ * @type {Record<string, Family>}
+ */
+export const GEOMETRY_FAMILIES = {
+  qwen3: {
+    nKvHeads: 8,
+    headDim: 128,
+    nVocab: 151936,
+    sizes: [
+      { paramsB: 0.75, nLayers: 28, nEmbd: 1024 },
+      { paramsB: 2.03, nLayers: 28, nEmbd: 2048 },
+      { paramsB: 4.02, nLayers: 36, nEmbd: 2560 },
+      { paramsB: 8.19, nLayers: 36, nEmbd: 4096 },
+      { paramsB: 14.77, nLayers: 40, nEmbd: 5120 },
+      { paramsB: 32.76, nLayers: 64, nEmbd: 5120 },
+    ],
+  },
+  qwen3_moe: {
+    nKvHeads: 4,
+    headDim: 128,
+    nVocab: 151936,
+    sizes: [
+      { paramsB: 30.5, nLayers: 48, nEmbd: 2048, nExperts: 128 },
+      { paramsB: 235, nLayers: 94, nEmbd: 4096, nExperts: 128 },
+      { paramsB: 480, nLayers: 62, nEmbd: 6144, nExperts: 160 },
+    ],
+  },
+  // Gated DeltaNet: 3 linear-attention layers per full-attention layer. Linear layers hold a
+  // constant-size state rather than a growing cache, approximated here as a zero-width window.
+  qwen3_next: {
+    nKvHeads: 2,
+    headDim: 256,
+    nVocab: 151936,
+    swaWindow: 0,
+    swaPeriod: 4,
+    sizes: [{ paramsB: 80, nLayers: 48, nEmbd: 2048, nExperts: 512 }],
+  },
+  qwen2: {
+    nKvHeads: 4,
+    headDim: 128,
+    nVocab: 152064,
+    sizes: [
+      { paramsB: 0.49, nLayers: 24, nEmbd: 896, nKvHeads: 2 },
+      { paramsB: 1.54, nLayers: 28, nEmbd: 1536, nKvHeads: 2 },
+      { paramsB: 3.09, nLayers: 36, nEmbd: 2048, nKvHeads: 2 },
+      { paramsB: 7.62, nLayers: 28, nEmbd: 3584, nKvHeads: 4 },
+      { paramsB: 14.8, nLayers: 48, nEmbd: 5120, nKvHeads: 8 },
+      { paramsB: 32.8, nLayers: 64, nEmbd: 5120, nKvHeads: 8 },
+      { paramsB: 72.7, nLayers: 80, nEmbd: 8192, nKvHeads: 8 },
+    ],
+  },
+  llama: {
+    nKvHeads: 8,
+    headDim: 128,
+    nVocab: 128256,
+    sizes: [
+      { paramsB: 1.24, nLayers: 16, nEmbd: 2048, headDim: 64 },
+      { paramsB: 3.21, nLayers: 28, nEmbd: 3072 },
+      { paramsB: 6.74, nLayers: 32, nEmbd: 4096, nKvHeads: 32 }, // Llama 2 7B — MHA, not GQA
+      { paramsB: 8.03, nLayers: 32, nEmbd: 4096 },
+      { paramsB: 13.0, nLayers: 40, nEmbd: 5120, nKvHeads: 40 }, // Llama 2 13B — MHA
+      { paramsB: 70.6, nLayers: 80, nEmbd: 8192 },
+      { paramsB: 405, nLayers: 126, nEmbd: 16384 },
+    ],
+  },
+  mistral: {
+    nKvHeads: 8,
+    headDim: 128,
+    nVocab: 32768,
+    sizes: [
+      { paramsB: 7.25, nLayers: 32, nEmbd: 4096 },
+      { paramsB: 12.2, nLayers: 40, nEmbd: 5120 },
+      { paramsB: 22.2, nLayers: 56, nEmbd: 6144 },
+      { paramsB: 123, nLayers: 88, nEmbd: 12288 },
+    ],
+  },
+  mixtral: {
+    nKvHeads: 8,
+    headDim: 128,
+    nVocab: 32000,
+    sizes: [
+      { paramsB: 46.7, nLayers: 32, nEmbd: 4096, nExperts: 8 },
+      { paramsB: 141, nLayers: 56, nEmbd: 6144, nExperts: 8 },
+    ],
+  },
+  // 1 full-attention layer per 6; the other 5 use a 1024-token sliding window.
+  gemma3: {
+    nKvHeads: 8,
+    headDim: 256,
+    nVocab: 262144,
+    swaWindow: 1024,
+    swaPeriod: 6,
+    sizes: [
+      { paramsB: 1.0, nLayers: 26, nEmbd: 1152, nKvHeads: 1 },
+      { paramsB: 4.3, nLayers: 34, nEmbd: 2560, nKvHeads: 4 },
+      { paramsB: 12.2, nLayers: 48, nEmbd: 3840, nKvHeads: 8 },
+      { paramsB: 27.4, nLayers: 62, nEmbd: 5376, nKvHeads: 16 },
+    ],
+  },
+  gemma2: {
+    nKvHeads: 8,
+    headDim: 256,
+    nVocab: 256000,
+    swaWindow: 4096,
+    swaPeriod: 2,
+    sizes: [
+      { paramsB: 2.6, nLayers: 26, nEmbd: 2304, nKvHeads: 4 },
+      { paramsB: 9.24, nLayers: 42, nEmbd: 3584 },
+      { paramsB: 27.2, nLayers: 46, nEmbd: 4608, nKvHeads: 16, headDim: 128 },
+    ],
+  },
+  // Alternating dense / 128-token sliding-window attention.
+  gpt_oss: {
+    nKvHeads: 8,
+    headDim: 64,
+    nVocab: 201088,
+    swaWindow: 128,
+    swaPeriod: 2,
+    sizes: [
+      { paramsB: 20.9, nLayers: 24, nEmbd: 2880, nExperts: 32 },
+      { paramsB: 117, nLayers: 36, nEmbd: 2880, nExperts: 128 },
+    ],
+  },
+  phi3: {
+    nKvHeads: 32,
+    headDim: 96,
+    nVocab: 32064,
+    sizes: [
+      { paramsB: 3.82, nLayers: 32, nEmbd: 3072 },
+      { paramsB: 14.0, nLayers: 40, nEmbd: 5120, nKvHeads: 10, headDim: 128 },
+    ],
+  },
+  phi4: {
+    nKvHeads: 10,
+    headDim: 128,
+    nVocab: 100352,
+    sizes: [
+      { paramsB: 3.84, nLayers: 32, nEmbd: 3072, nKvHeads: 8, headDim: 96 },
+      { paramsB: 14.7, nLayers: 40, nEmbd: 5120 },
+    ],
+  },
+  glm4: {
+    nKvHeads: 2,
+    headDim: 128,
+    nVocab: 151552,
+    sizes: [
+      { paramsB: 9.4, nLayers: 40, nEmbd: 4096 },
+      { paramsB: 32.6, nLayers: 61, nEmbd: 6144, nKvHeads: 4 },
+    ],
+  },
+  granite: {
+    nKvHeads: 8,
+    headDim: 128,
+    nVocab: 49152,
+    sizes: [
+      { paramsB: 2.53, nLayers: 40, nEmbd: 2048 },
+      { paramsB: 8.17, nLayers: 40, nEmbd: 4096 },
+    ],
+  },
+  smollm2: {
+    nKvHeads: 32,
+    headDim: 64,
+    nVocab: 49152,
+    sizes: [
+      { paramsB: 0.135, nLayers: 30, nEmbd: 576, nKvHeads: 3 },
+      { paramsB: 0.36, nLayers: 32, nEmbd: 960, nKvHeads: 5 },
+      { paramsB: 1.71, nLayers: 24, nEmbd: 2048 },
+    ],
+  },
+  yi: {
+    nKvHeads: 4,
+    headDim: 128,
+    nVocab: 64000,
+    sizes: [
+      { paramsB: 6.06, nLayers: 32, nEmbd: 4096 },
+      { paramsB: 8.83, nLayers: 48, nEmbd: 4096 },
+      { paramsB: 34.4, nLayers: 60, nEmbd: 7168, nKvHeads: 8 },
+    ],
+  },
+  // Dense DeepSeek (deepseek-llm / deepseek-coder). The MoE V2/V3 line uses multi-head latent
+  // attention, whose compressed cache this model does not describe — those fall through.
+  deepseek: {
+    nKvHeads: 32,
+    headDim: 128,
+    nVocab: 32256,
+    sizes: [
+      { paramsB: 1.35, nLayers: 24, nEmbd: 2048, nKvHeads: 16 },
+      { paramsB: 6.74, nLayers: 32, nEmbd: 4096, nKvHeads: 32 },
+      { paramsB: 33.3, nLayers: 62, nEmbd: 7168, nKvHeads: 8 },
+      { paramsB: 67.4, nLayers: 95, nEmbd: 8192, nKvHeads: 8 },
+    ],
+  },
+  command_r: {
+    nKvHeads: 8,
+    headDim: 128,
+    nVocab: 256000,
+    sizes: [
+      { paramsB: 35.0, nLayers: 40, nEmbd: 8192 },
+      { paramsB: 104, nLayers: 64, nEmbd: 12288 },
+    ],
+  },
+  olmo2: {
+    nKvHeads: 32,
+    headDim: 128,
+    nVocab: 100352,
+    sizes: [
+      { paramsB: 7.3, nLayers: 32, nEmbd: 4096, nKvHeads: 32 },
+      { paramsB: 13.7, nLayers: 40, nEmbd: 5120, nKvHeads: 40 },
+    ],
+  },
+};
+
+/**
+ * How far a geometry can be off, by where it came from. Used to require headroom before
+ * claiming a model fits: a heuristic geometry that guesses GQA on an older multi-head model
+ * understates KV by up to 4x, and reporting a confident number there is how users end up
+ * loading something that OOMs.
+ * @type {Record<import('./model-geometry.d.mts').GeometrySource, number>}
+ */
+export const GEOMETRY_UNCERTAINTY = {
+  gguf: 1.0,
+  family: 1.05,
+  heuristic: 1.35,
+};
+
+/** HF `model_type` values that map onto one of the families above. */
+const ARCH_ALIASES = {
+  qwen3moe: 'qwen3_moe',
+  qwen3_moe: 'qwen3_moe',
+  qwen3next: 'qwen3_next',
+  qwen3_next: 'qwen3_next',
+  qwen3: 'qwen3',
+  qwen2: 'qwen2',
+  qwen2_5: 'qwen2',
+  qwen25: 'qwen2',
+  qwen2moe: 'qwen2',
+  qwen: 'qwen2',
+  llama: 'llama',
+  llama4: 'llama',
+  mistral: 'mistral',
+  mistral3: 'mistral',
+  ministral: 'mistral',
+  mixtral: 'mixtral',
+  gemma3: 'gemma3',
+  gemma3_text: 'gemma3',
+  gemma2: 'gemma2',
+  gptoss: 'gpt_oss',
+  gpt_oss: 'gpt_oss',
+  phi3: 'phi3',
+  phi4: 'phi4',
+  phimoe: 'phi3',
+  glm4: 'glm4',
+  glm4_moe: 'glm4',
+  chatglm: 'glm4',
+  granite: 'granite',
+  granitemoe: 'granite',
+  smollm2: 'smollm2',
+  smollm3: 'smollm2',
+  yi: 'yi',
+  deepseek: 'deepseek',
+  deepseek_llm: 'deepseek',
+  deepseek_coder: 'deepseek',
+  cohere: 'command_r',
+  cohere2: 'command_r',
+  command_r: 'command_r',
+  olmo2: 'olmo2',
+  olmo: 'olmo2',
+};
+
+/** Ordered name probes for catalog rows with no usable `architecture`. */
+const NAME_TO_FAMILY = [
+  ['qwen3-next', 'qwen3_next'],
+  ['qwen3-coder', 'qwen3_moe'],
+  ['a3b', 'qwen3_moe'],
+  ['a22b', 'qwen3_moe'],
+  ['qwen3', 'qwen3'],
+  ['qwen2', 'qwen2'],
+  ['qwq', 'qwen2'],
+  ['gpt-oss', 'gpt_oss'],
+  ['gemma-3', 'gemma3'],
+  ['gemma3', 'gemma3'],
+  ['gemma-2', 'gemma2'],
+  ['mixtral', 'mixtral'],
+  ['ministral', 'mistral'],
+  ['mistral', 'mistral'],
+  ['smollm', 'smollm2'],
+  ['granite', 'granite'],
+  ['phi-4', 'phi4'],
+  ['phi-3', 'phi3'],
+  ['glm-4', 'glm4'],
+  ['command-r', 'command_r'],
+  ['olmo', 'olmo2'],
+  ['deepseek-coder', 'deepseek'],
+  ['deepseek-llm', 'deepseek'],
+  ['llama', 'llama'],
+  ['yi-', 'yi'],
+];
+
+/**
+ * Layer count fitted over the shipped models in `GEOMETRY_FAMILIES`.
+ * Used only when neither the GGUF header nor a family match is available.
+ * @param {number} paramsB
+ */
+export function heuristicLayerCount(paramsB) {
+  const p = paramsB > 0 ? paramsB : 7;
+  if (p < 1.5) return 24;
+  if (p < 3.5) return 30;
+  if (p < 6) return 34;
+  if (p < 10) return 32;
+  if (p < 16) return 42;
+  if (p < 24) return 44;
+  if (p < 40) return 60;
+  if (p < 60) return 64;
+  if (p < 90) return 80;
+  return 88;
+}
+
+/** @param {string | null | undefined} value */
+function normalizeArch(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[\s.\-]/g, '_')
+    .replace(/_?(?:for)?_?causallm$/, '')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
+/**
+ * Family key for a catalog row, from `architecture` first and the name as a fallback.
+ * @param {GeometryInput} input
+ * @returns {string | null}
+ */
+export function resolveFamilyKey(input) {
+  const arch = normalizeArch(input.architecture);
+  if (arch && ARCH_ALIASES[arch]) return ARCH_ALIASES[arch];
+  if (arch && GEOMETRY_FAMILIES[arch]) return arch;
+
+  const name = String(input.name ?? '').toLowerCase();
+  if (!name) return null;
+  for (const [needle, family] of NAME_TO_FAMILY) {
+    if (name.includes(needle)) return family;
+  }
+  return null;
+}
+
+/**
+ * Hidden size implied by a parameter count, from the standard dense-transformer budget of
+ * roughly 12 * nLayers * nEmbd^2 weights, rounded to a plausible multiple of 128.
+ * @param {number} paramsB parameters (billions) attributable to the dense trunk
+ * @param {number} nLayers
+ */
+function heuristicEmbeddingSize(paramsB, nLayers) {
+  const dense = paramsB > 0 ? paramsB : 7;
+  const raw = Math.sqrt((dense * 1e9) / (12 * Math.max(1, nLayers)));
+  const rounded = Math.round(raw / 128) * 128;
+  return Math.min(16384, Math.max(512, rounded));
+}
+
+/**
+ * Fallback geometry from parameter count alone.
+ * @param {GeometryInput} input
+ * @param {Family} [family] family constants, when the family is known but the size is not
+ * @returns {ModelGeometry}
+ */
+export function heuristicGeometry(input, family) {
+  const paramsB = input.paramsB && input.paramsB > 0 ? input.paramsB : 7;
+  const isMoe = Boolean(input.nExperts) || (input.activeParamsB ?? paramsB) < paramsB * 0.9;
+  // For MoE the attention trunk is sized by the active path, not the full expert bank.
+  const trunkB = isMoe && input.activeParamsB ? input.activeParamsB : paramsB;
+  const nLayers = heuristicLayerCount(paramsB);
+  const nEmbd = heuristicEmbeddingSize(trunkB, nLayers);
+  // 8 KV heads of 128 is the near-universal GQA width on current models; never wider
+  // than the hidden size, which is what multi-head attention on a tiny model degrades to.
+  const headDim = family?.headDim ?? 128;
+  const defaultKvHeads = family?.nKvHeads ?? 8;
+  const nKvHeads = Math.max(1, Math.min(defaultKvHeads, Math.floor(nEmbd / headDim) || 1));
+  return {
+    nLayers,
+    nKvHeads,
+    headDim,
+    nEmbd,
+    nVocab: family?.nVocab ?? 128256,
+    nExperts: input.nExperts ?? 0,
+    swaWindow: family?.swaWindow ?? 0,
+    swaPeriod: family?.swaPeriod ?? 1,
+    source: 'heuristic',
+  };
+}
+
+/**
+ * Best-known geometry for a catalog or library model.
+ *
+ * Prefer `geometryFromGgufMetadata` when the weights are on disk — this path is for models
+ * that have not been downloaded yet, where the header cannot be read.
+ * @param {GeometryInput} input
+ * @returns {ModelGeometry}
+ */
+export function resolveGeometry(input) {
+  const familyKey = resolveFamilyKey(input);
+  const family = familyKey ? GEOMETRY_FAMILIES[familyKey] : undefined;
+  const paramsB = input.paramsB && input.paramsB > 0 ? input.paramsB : 0;
+
+  if (!family || !paramsB) return heuristicGeometry(input, family);
+
+  // Nearest shipped size on a log scale, so 8B matches 8.19B rather than 4B.
+  let best = null;
+  let bestDistance = Infinity;
+  for (const size of family.sizes) {
+    const distance = Math.abs(Math.log(paramsB / size.paramsB));
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = size;
+    }
+  }
+  // ~30% either way. Beyond that the row is a different model wearing a familiar name.
+  if (!best || bestDistance > 0.3) return heuristicGeometry(input, family);
+
+  return {
+    nLayers: best.nLayers,
+    nKvHeads: best.nKvHeads ?? family.nKvHeads,
+    headDim: best.headDim ?? family.headDim,
+    nEmbd: best.nEmbd,
+    nVocab: family.nVocab,
+    nExperts: input.nExperts ?? best.nExperts ?? 0,
+    swaWindow: family.swaWindow ?? 0,
+    swaPeriod: family.swaPeriod ?? 1,
+    source: 'family',
+  };
+}
+
+/**
+ * Exact geometry from a parsed GGUF header.
+ * @param {Record<string, unknown>} meta output of `readGgufMetadata`
+ * @returns {ModelGeometry | null}
+ */
+export function geometryFromGgufMetadata(meta) {
+  if (!meta || typeof meta !== 'object') return null;
+  const nLayers = Number(meta.nLayers);
+  const nKvHeads = Number(meta.nKvHeads);
+  const headDim = Number(meta.headDim);
+  if (!(nLayers > 0) || !(nKvHeads > 0) || !(headDim > 0)) return null;
+
+  // A file can declare a window without saying how often full attention returns. When the
+  // header gives neither an exact per-layer count nor a scalar period, fall back to the family
+  // table, then to "no windowing" — which overstates the cache rather than understating it.
+  const swaWindow = Number(meta.swaWindow) > 0 ? Number(meta.swaWindow) : 0;
+  const fullLayers = Number(meta.nFullAttentionLayers);
+  let swaPeriod = Number(meta.swaPeriod) > 0 ? Number(meta.swaPeriod) : 0;
+  if (swaWindow > 0 && !swaPeriod && !(fullLayers > 0)) {
+    const familyKey = resolveFamilyKey({ architecture: String(meta.arch ?? '') });
+    swaPeriod = (familyKey && GEOMETRY_FAMILIES[familyKey]?.swaPeriod) || 1;
+  }
+
+  return {
+    nFullAttentionLayers: fullLayers > 0 ? fullLayers : undefined,
+    swaHeadDim: Number(meta.swaHeadDim) > 0 ? Number(meta.swaHeadDim) : undefined,
+    nLayers,
+    nKvHeads,
+    headDim,
+    nEmbd: Number(meta.nEmbd) > 0 ? Number(meta.nEmbd) : nKvHeads * headDim,
+    nVocab: Number(meta.nVocab) > 0 ? Number(meta.nVocab) : 128256,
+    nExperts: Number(meta.nExperts) > 0 ? Number(meta.nExperts) : 0,
+    swaWindow,
+    swaPeriod: swaPeriod > 0 ? swaPeriod : 1,
+    source: 'gguf',
+    layerBytes: Number(meta.layerBytes) > 0 ? Number(meta.layerBytes) : undefined,
+    fixedBytes: Number(meta.fixedBytes) > 0 ? Number(meta.fixedBytes) : undefined,
+  };
+}

--- a/src/models/quant.ts
+++ b/src/models/quant.ts
@@ -1,39 +1,10 @@
+import { estimateRunMemory, GIB, weightsBytesFor } from './memory-model.mjs';
+import { resolveGeometry } from './model-geometry.mjs';
+import type { ModelGeometry } from './model-geometry.d.mts';
 import type { CatalogModel } from './types';
 
 /** GGUF quant tiers ordered best-quality first. */
 export const QUANT_HIERARCHY = ['Q8_0', 'Q6_K', 'Q5_K_M', 'Q4_K_M', 'Q3_K_M', 'Q2_K'] as const;
-
-export const QUANT_BPP: Record<string, number> = {
-  F32: 4.0,
-  F16: 2.0,
-  BF16: 2.0,
-  FP8: 1.0,
-  FP4: 0.5,
-  NVFP4: 0.5,
-  MXFP4: 0.5,
-  NF4: 0.5,
-  INT4: 0.5,
-  INT8: 1.0,
-  W4A16: 0.5,
-  W8A8: 1.0,
-  W8A16: 1.0,
-  Q8_0: 1.05,
-  Q6_K: 0.8,
-  Q5_K_M: 0.68,
-  Q4_K_M: 0.58,
-  Q4_0: 0.58,
-  Q3_K_M: 0.48,
-  Q2_K: 0.37,
-  'AWQ-4bit': 0.5,
-  'AWQ-8bit': 1.0,
-  'GPTQ-Int4': 0.5,
-  'GPTQ-Int8': 1.0,
-  'mlx-4bit': 0.55,
-  'mlx-8bit': 1.0,
-  'mlx-6bit': 0.75,
-  'FP4-MoE-Mixed': 0.55,
-  'FP8-Mixed': 1.0,
-};
 
 export const QUANT_SPEED_MULT: Record<string, number> = {
   F16: 0.6,
@@ -99,36 +70,6 @@ export const QUANT_QUALITY_PENALTY: Record<string, number> = {
   'FP8-Mixed': 0.0,
 };
 
-export const QUANT_BYTES_PER_PARAM: Record<string, number> = {
-  F16: 2.0,
-  BF16: 2.0,
-  FP8: 1.0,
-  FP4: 0.5,
-  NVFP4: 0.5,
-  MXFP4: 0.5,
-  NF4: 0.5,
-  INT4: 0.5,
-  INT8: 1.0,
-  W4A16: 0.5,
-  W8A8: 1.0,
-  W8A16: 1.0,
-  Q8_0: 1.0,
-  Q6_K: 0.75,
-  Q5_K_M: 0.625,
-  Q4_K_M: 0.5,
-  Q4_0: 0.5,
-  Q3_K_M: 0.375,
-  Q2_K: 0.25,
-  'AWQ-4bit': 0.5,
-  'AWQ-8bit': 1.0,
-  'GPTQ-Int4': 0.5,
-  'GPTQ-Int8': 1.0,
-  'mlx-4bit': 0.5,
-  'mlx-8bit': 1.0,
-  'mlx-6bit': 0.75,
-  'FP4-MoE-Mixed': 0.55,
-  'FP8-Mixed': 1.0,
-};
 
 /** Pre-quantized formats that should NOT go through the GGUF quant hierarchy. */
 export const PREQUANTIZED_PREFIXES = [
@@ -222,17 +163,36 @@ export function activeParamsB(model: CatalogModel): number {
   return paramsB(model);
 }
 
+/** Attention geometry for a catalog row, resolved from architecture + parameter count. */
+export function geometryForModel(model: CatalogModel): ModelGeometry {
+  return resolveGeometry({
+    architecture: model.architecture,
+    name: model.name,
+    paramsB: paramsB(model),
+    activeParamsB: activeParamsB(model),
+    nExperts: model.num_experts,
+  });
+}
+
+/**
+ * Memory a model needs to run, all layers on GPU.
+ *
+ * Delegates to the shared physical model in memory-model.mjs. The previous formula here was
+ * `pb * bpp + 0.000008 * activeParams * ctx + 0.5`, whose KV term scaled with parameter count
+ * — a relationship that does not exist — and landed anywhere from 17x low (Qwen3-0.6B) to
+ * 1.9x high (Llama-3.3-70B).
+ */
 export function estimateMemoryGb(model: CatalogModel, quant: string, ctx: number): number {
-  const pb = paramsB(model);
-  const bpp = QUANT_BPP[quant] ?? 0.58;
-  const kvParams = activeParamsB(model);
-  return pb * bpp + 0.000008 * kvParams * ctx + 0.5;
+  return estimateRunMemory({
+    geometry: geometryForModel(model),
+    weightsBytes: weightsBytesFor(paramsB(model), quant),
+    ctx,
+  }).totalGb;
 }
 
 /** Approximate on-disk GGUF / weights size from parameter count and quant tier. */
 export function estimateFileSizeGb(paramsBillion: number, quant: string): number {
-  const bpp = QUANT_BYTES_PER_PARAM[quant] ?? 0.5;
-  return Math.round(paramsBillion * bpp * 10) / 10;
+  return Math.round((weightsBytesFor(paramsBillion, quant) / GIB) * 10) / 10;
 }
 
 export function bestQuantForBudget(

--- a/src/models/serve-memory-estimate.ts
+++ b/src/models/serve-memory-estimate.ts
@@ -1,78 +1,121 @@
 /**
- * Rough VRAM / RAM estimates for llama.cpp launch settings in the Models inspector.
- * Mirrors the heuristics in server/models/profiles.js (weights + KV + overhead).
+ * VRAM / RAM estimates for llama.cpp launch settings in the Models inspector.
+ *
+ * A thin adapter over the shared model in memory-model.mjs. The arithmetic used to live here
+ * as its own set of constants, which is how the Load tab and the discovery ranking ended up
+ * disagreeing by 2x about the same model at the same context — this file applied a KV
+ * precision factor that the ranking path did not, on top of a KV term that was wrong in both.
  */
 
-const KV_FACTOR: Record<string, number> = { q4_0: 0.5, q8_0: 1.0, f16: 2.0 };
-const RUNTIME_OVERHEAD_GB = 0.6;
+import { estimateRunMemory, kvBytesPerToken, GIB } from './memory-model.mjs';
+import { geometryFromGgufMetadata, resolveGeometry } from './model-geometry.mjs';
+import type { GeometrySource, ModelGeometry } from './model-geometry.d.mts';
 
 export interface ServeMemoryEstimate {
   vramGb: number;
   ramGb: number;
   totalGb: number;
+  /** Cost of one more token of context, for the "can I raise ctx?" hint. */
+  kvGbPer1kTokens: number;
+  /** Transformer blocks — the real maximum for the GPU-layers slider. */
+  layerCount: number;
+  geometrySource: GeometrySource;
 }
 
-/** Heuristic transformer block count from parameter size (for partial GPU offload). */
-export function estimateTransformerLayerCount(paramsB: number | null | undefined): number {
-  const p = paramsB ?? 7;
-  if (p <= 3) return 28;
-  if (p <= 9) return 32;
-  if (p <= 15) return 40;
-  if (p <= 35) return 48;
-  if (p <= 55) return 64;
-  return 80;
+/** GGUF header facts, as returned by `GET /api/models/gguf-meta`. */
+export interface GgufGeometryFacts {
+  arch?: string;
+  nLayers?: number;
+  nKvHeads?: number;
+  headDim?: number;
+  nEmbd?: number;
+  nVocab?: number;
+  nExperts?: number;
+  swaWindow?: number;
+  swaPeriod?: number;
+  layerBytes?: number;
+  fixedBytes?: number;
 }
 
-function kvCacheGb(paramsB: number | null | undefined, ctx: number, cacheType: string): number {
-  const active = paramsB ?? 7;
-  return 0.000008 * active * ctx * (KV_FACTOR[cacheType] ?? 1.0);
-}
-
-function roundGb(value: number): number {
-  return Math.round(value * 10) / 10;
-}
-
-/**
- * Estimate memory split from weights size, context, KV precision, and -ngl.
- * `nGpuLayers` uses llama.cpp semantics: 0 = CPU, 999 = all layers on GPU.
- */
-export function estimateServeMemory(input: {
+export interface ServeMemoryInput {
   weightsGb: number;
   paramsB: number | null | undefined;
   ctx: number;
   cacheType?: string;
+  /** llama.cpp `-ngl`: 0 = CPU, 999 = every layer on GPU. */
   nGpuLayers?: number;
-}): ServeMemoryEstimate {
-  const weightsGb = Math.max(0, input.weightsGb);
-  const ctx = Math.max(0, input.ctx);
-  const cacheType = input.cacheType ?? 'f16';
-  const ngl = input.nGpuLayers ?? 999;
-  const layers = estimateTransformerLayerCount(input.paramsB);
-  const kv = kvCacheGb(input.paramsB, ctx, cacheType);
-
-  if (ngl === 0) {
-    const ramGb = roundGb(weightsGb + kv + RUNTIME_OVERHEAD_GB);
-    return { vramGb: 0, ramGb, totalGb: ramGb };
-  }
-
-  if (ngl === 999) {
-    const vramGb = roundGb(weightsGb + kv + RUNTIME_OVERHEAD_GB);
-    return { vramGb, ramGb: 0, totalGb: vramGb };
-  }
-
-  const gpuFrac = Math.min(1, Math.max(0, ngl / layers));
-  const vramGb = roundGb(weightsGb * gpuFrac + kv + RUNTIME_OVERHEAD_GB);
-  const ramGb = roundGb(weightsGb * (1 - gpuFrac) + 0.4);
-  return { vramGb, ramGb, totalGb: roundGb(vramGb + ramGb) };
+  /** Exact header facts when the weights are on disk — always preferred. */
+  gguf?: GgufGeometryFacts | null;
+  /** Catalog hints, used only when the header is unavailable. */
+  arch?: string | null;
+  name?: string | null;
+  backend?: string | null;
+  deviceCount?: number;
 }
+
+/** Best geometry available for a library row. */
+export function geometryForServe(input: ServeMemoryInput): ModelGeometry {
+  const exact = input.gguf ? geometryFromGgufMetadata(input.gguf) : null;
+  if (exact) return exact;
+  return resolveGeometry({
+    architecture: input.arch ?? undefined,
+    name: input.name ?? undefined,
+    paramsB: input.paramsB ?? undefined,
+  });
+}
+
+/**
+ * Transformer block count — exact from the GGUF header when we have it, otherwise the best
+ * guess from architecture and parameter count.
+ */
+export function estimateTransformerLayerCount(
+  paramsB: number | null | undefined,
+  hints: { gguf?: GgufGeometryFacts | null; arch?: string | null; name?: string | null } = {},
+): number {
+  return geometryForServe({ weightsGb: 0, paramsB, ctx: 0, ...hints }).nLayers;
+}
+
+/**
+ * Estimate the memory split for a launch configuration.
+ *
+ * `nGpuLayers` uses llama.cpp semantics: 0 = CPU, 999 = all layers on GPU. Partial offload
+ * splits the KV cache along with the layers, which the previous version did not — it charged
+ * the whole cache to VRAM even at `-ngl 1`.
+ */
+export function estimateServeMemory(input: ServeMemoryInput): ServeMemoryEstimate {
+  const geometry = geometryForServe(input);
+  const cacheType = input.cacheType ?? 'f16';
+  const estimate = estimateRunMemory({
+    geometry,
+    weightsBytes: Math.max(0, input.weightsGb) * GIB,
+    ctx: Math.max(0, input.ctx),
+    cacheType,
+    nGpuLayers: input.nGpuLayers,
+    backend: input.backend ?? undefined,
+    deviceCount: input.deviceCount,
+  });
+
+  return {
+    vramGb: estimate.vramGb,
+    ramGb: estimate.ramGb,
+    totalGb: estimate.totalGb,
+    kvGbPer1kTokens: Math.round((kvBytesPerToken(geometry, cacheType) * 1000) / GIB * 100) / 100,
+    layerCount: geometry.nLayers,
+    geometrySource: geometry.source,
+  };
+}
+
+/**
+ * Host allocations below this never decide whether a configuration fits, so a fully offloaded
+ * run reads as plain "VRAM" rather than dragging a 0.2 GB RAM term through the hint.
+ */
+const RAM_TERM_FLOOR_GB = 0.5;
 
 /** Human-readable estimate for the Load tab hint line. */
 export function formatServeMemoryEstimate(estimate: ServeMemoryEstimate): string {
-  if (estimate.vramGb > 0 && estimate.ramGb > 0) {
+  if (estimate.vramGb > 0 && estimate.ramGb >= RAM_TERM_FLOOR_GB) {
     return `~${estimate.vramGb} GB VRAM + ~${estimate.ramGb} GB RAM`;
   }
-  if (estimate.vramGb > 0) {
-    return `~${estimate.vramGb} GB VRAM`;
-  }
+  if (estimate.vramGb > 0) return `~${estimate.vramGb} GB VRAM`;
   return `~${estimate.ramGb} GB RAM`;
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,3 +1,5 @@
+import type { GeometrySource } from './model-geometry.d.mts';
+
 /** Catalog model entry — hwfit catalog JSON shape. */
 export interface CatalogModel {
   name: string;
@@ -16,6 +18,8 @@ export interface CatalogModel {
   architecture?: string;
   release_date?: string;
   is_moe?: boolean;
+  num_experts?: number;
+  active_experts?: number;
   is_gguf?: boolean;
   gguf_sources?: Array<{ repo: string; provider?: string }>;
   format?: string;
@@ -74,4 +78,6 @@ export interface ModelFitResult {
   release_date?: string;
   target_context?: number | null;
   is_image_gen?: boolean;
+  /** Where the attention geometry behind `required_gb` came from. */
+  geometry_source?: GeometrySource;
 }

--- a/src/ui/models/inspector.ts
+++ b/src/ui/models/inspector.ts
@@ -11,7 +11,11 @@ import {
   loadLibraryInferencePrefs,
   saveLibraryInferenceSampler,
 } from '../../config/library-inference-meta';
-import type { LlamaServeSettings } from '../../models/api-client';
+import {
+  fetchGgufGeometry,
+  type GgufGeometryFacts,
+  type LlamaServeSettings,
+} from '../../models/api-client';
 import { buildSamplerFieldInputs } from '../settings-sampler-fields';
 import { DEFAULT_CONTEXT_TOKENS } from '../../models/default-context-tokens';
 import {
@@ -61,6 +65,47 @@ let bound = false;
 let inspectorRenderRaf: number | null = null;
 /** Per-model launch settings, kept while the app is open. */
 const draftSettings = new Map<string, LlamaServeSettings>();
+
+/**
+ * GGUF headers by file path — exact layer count and attention geometry for models already on
+ * disk. `null` records a file we tried and could not parse, so we do not retry every render.
+ */
+const ggufGeometry = new Map<string, GgufGeometryFacts | null>();
+const ggufGeometryPending = new Set<string>();
+
+/**
+ * Read the header for a model's weights, re-rendering once it lands.
+ * Until it does, the estimate falls back to architecture + parameter count.
+ */
+function ensureGgufGeometry(model: LibraryModel): GgufGeometryFacts | null {
+  const filePath = model.path;
+  if (!filePath || model.format !== 'GGUF') return null;
+  if (ggufGeometry.has(filePath)) return ggufGeometry.get(filePath) ?? null;
+  if (ggufGeometryPending.has(filePath)) return null;
+
+  ggufGeometryPending.add(filePath);
+  void fetchGgufGeometry(filePath)
+    .catch(() => null)
+    .then((facts) => {
+      ggufGeometryPending.delete(filePath);
+      ggufGeometry.set(filePath, facts);
+      scheduleInspectorRender();
+    });
+  return null;
+}
+
+/** Geometry hints for the estimator: exact header first, catalog fields as the fallback. */
+function memoryHints(model: LibraryModel): {
+  gguf: GgufGeometryFacts | null;
+  arch: string | null;
+  name: string | null;
+} {
+  return {
+    gguf: ensureGgufGeometry(model),
+    arch: model.arch || null,
+    name: model.name || null,
+  };
+}
 
 function root(): HTMLElement | null {
   return document.getElementById('modelsInspector');
@@ -243,7 +288,7 @@ function gpuLayersSlider(
   nGpuLayers: number | undefined,
   onChange: (nGpuLayers: number) => void,
 ): HTMLElement {
-  const maxLayers = estimateTransformerLayerCount(model.paramsB);
+  const maxLayers = estimateTransformerLayerCount(model.paramsB, memoryHints(model));
   const sliderValue = sliderValueFromNGpu(nGpuLayers, maxLayers);
   const wrap = el('label', 'models-field');
   const head = el('div', 'models-field__range-head');
@@ -278,27 +323,35 @@ function gpuLayersSlider(
 
 function launchMemoryHint(model: LibraryModel, settings: LlamaServeSettings): HTMLElement {
   const weightsGb = model.sizeBytes > 0 ? model.sizeBytes / 1024 ** 3 : 0;
+  const hw = getModelsState().hardware;
   const estimate = estimateServeMemory({
     weightsGb,
     paramsB: model.paramsB,
     ctx: settings.ctx ?? DEFAULT_CONTEXT_TOKENS,
     cacheType: settings.cache_type ?? 'f16',
     nGpuLayers: settings.n_gpu_layers,
+    backend: hw?.backend ?? null,
+    deviceCount: hw?.gpuCount ?? 1,
+    ...memoryHints(model),
   });
   const line = formatServeMemoryEstimate(estimate);
-  const hw = getModelsState().hardware;
   const budgetVram = hw?.gpuVramGb ?? 0;
   const budgetRam = hw?.availableRamGb ?? hw?.totalRamGb ?? 0;
   const tight =
     (estimate.vramGb > 0 && budgetVram > 0 && estimate.vramGb > budgetVram * 0.92) ||
     (estimate.ramGb > 0 && budgetRam > 0 && estimate.ramGb > budgetRam * 0.55);
+
+  const suffix = estimate.kvGbPer1kTokens > 0 ? ` (${estimate.kvGbPer1kTokens} GB per 1k ctx)` : '';
   const hint = el(
     'p',
     tight ? 'models-hint models-hint--warn' : 'models-hint',
-    `Estimated memory at launch: ${line}`,
+    `Estimated memory at launch: ${line}${suffix}`,
   );
   if (tight) {
     hint.title = 'This configuration may exceed the memory Minnow measured on this machine.';
+  } else if (estimate.geometrySource !== 'gguf') {
+    hint.title =
+      "Estimated from this model's architecture and size — exact numbers need the weights on disk.";
   }
   return hint;
 }
@@ -615,6 +668,15 @@ export function render(): void {
   if (footer.childElementCount) host.appendChild(footer);
 }
 
+/** Coalesce re-renders onto the next frame. */
+function scheduleInspectorRender(): void {
+  if (inspectorRenderRaf != null) return;
+  inspectorRenderRaf = window.requestAnimationFrame(() => {
+    inspectorRenderRaf = null;
+    render();
+  });
+}
+
 /** Wire the inspector to the store (idempotent). */
 export function initInspector(): void {
   void loadLibraryInferencePrefs();
@@ -623,13 +685,7 @@ export function initInspector(): void {
     return;
   }
   bound = true;
-  subscribeModelsStore(() => {
-    if (inspectorRenderRaf != null) return;
-    inspectorRenderRaf = window.requestAnimationFrame(() => {
-      inspectorRenderRaf = null;
-      render();
-    });
-  });
+  subscribeModelsStore(scheduleInspectorRender);
   render();
 }
 

--- a/test/models/fit.test.mts
+++ b/test/models/fit.test.mts
@@ -43,9 +43,12 @@ describe('models quant', () => {
     assert.equal(paramsB({ parameter_count: '355' }), 0.355);
   });
 
-  test('estimateFileSizeGb uses quant bytes-per-param', () => {
-    assert.equal(estimateFileSizeGb(7, 'Q4_K_M'), 3.5);
-    assert.equal(estimateFileSizeGb(8, 'Q8_0'), 8);
+  test('estimateFileSizeGb matches measured GGUF file sizes', () => {
+    // Mistral-7B Q4_K_M is 4.07 GiB on disk, Llama-3.1-8B Q8_0 is 7.95 GiB. The nominal
+    // bit width predicts 3.5 and 8.0 — k-quants keep embeddings at higher precision, and a
+    // byte per weight is 0.93 GiB per billion, not 1.
+    assert.equal(estimateFileSizeGb(7, 'Q4_K_M'), 4.0);
+    assert.equal(estimateFileSizeGb(8, 'Q8_0'), 7.9);
   });
 });
 

--- a/test/models/gguf-metadata.test.mjs
+++ b/test/models/gguf-metadata.test.mjs
@@ -1,0 +1,215 @@
+import assert from 'node:assert/strict';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+import {
+  clearGgufMetadataCache,
+  parseGgufHeader,
+  readGgufMetadata,
+} from '../../server/models/gguf-metadata.js';
+
+const TYPE = { UINT32: 4, STRING: 8, ARRAY: 9, BOOL: 7 };
+/** ggml type ids used below. */
+const GGML_Q4_K = 12;
+const GGML_F32 = 0;
+
+function u32(value) {
+  const b = Buffer.alloc(4);
+  b.writeUInt32LE(value);
+  return b;
+}
+
+function u64(value) {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64LE(BigInt(value));
+  return b;
+}
+
+function gstring(value) {
+  const bytes = Buffer.from(value, 'utf8');
+  return Buffer.concat([u64(bytes.length), bytes]);
+}
+
+function kvU32(key, value) {
+  return Buffer.concat([gstring(key), u32(TYPE.UINT32), u32(value)]);
+}
+
+function kvString(key, value) {
+  return Buffer.concat([gstring(key), u32(TYPE.STRING), gstring(value)]);
+}
+
+function kvBoolArray(key, values) {
+  const items = Buffer.from(values.map((v) => (v ? 1 : 0)));
+  return Buffer.concat([gstring(key), u32(TYPE.ARRAY), u32(TYPE.BOOL), u64(values.length), items]);
+}
+
+function kvStringArray(key, values) {
+  return Buffer.concat([
+    gstring(key),
+    u32(TYPE.ARRAY),
+    u32(TYPE.STRING),
+    u64(values.length),
+    ...values.map(gstring),
+  ]);
+}
+
+function tensor(name, dims, type) {
+  return Buffer.concat([
+    gstring(name),
+    u32(dims.length),
+    ...dims.map(u64),
+    u32(type),
+    u64(0),
+  ]);
+}
+
+/** Assemble a GGUF v3 header (no weight data — the parser never reads past the index). */
+function buildGguf({ kv, tensors }) {
+  return Buffer.concat([
+    Buffer.from('GGUF', 'ascii'),
+    u32(3),
+    u64(tensors.length),
+    u64(kv.length),
+    ...kv,
+    ...tensors,
+  ]);
+}
+
+let tmpDir = '';
+
+before(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'minnow-gguf-'));
+});
+
+after(async () => {
+  clearGgufMetadataCache();
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeGguf(name, spec) {
+  const filePath = path.join(tmpDir, name);
+  await fsp.writeFile(filePath, buildGguf(spec));
+  return filePath;
+}
+
+describe('gguf metadata', () => {
+  it('reads attention geometry and per-role tensor bytes', async () => {
+    const filePath = await writeGguf('llama.gguf', {
+      kv: [
+        kvString('general.architecture', 'llama'),
+        kvU32('llama.block_count', 32),
+        kvU32('llama.embedding_length', 4096),
+        kvU32('llama.attention.head_count', 32),
+        kvU32('llama.attention.head_count_kv', 8),
+        kvU32('llama.context_length', 131072),
+        // Long string arrays must be walked without being collected.
+        kvStringArray('tokenizer.ggml.tokens', ['a', 'b', 'c']),
+      ],
+      tensors: [
+        tensor('token_embd.weight', [4096, 128256], GGML_Q4_K),
+        tensor('output_norm.weight', [4096], GGML_F32),
+        tensor('blk.0.attn_q.weight', [4096, 4096], GGML_Q4_K),
+      ],
+    });
+
+    const meta = await parseGgufHeader(filePath);
+    assert.equal(meta.arch, 'llama');
+    assert.equal(meta.nLayers, 32);
+    assert.equal(meta.nKvHeads, 8);
+    // No key_length in the header, so head size falls out of embedding / head count.
+    assert.equal(meta.headDim, 128);
+    assert.equal(meta.nVocab, 128256);
+    assert.equal(meta.splitCount, 1);
+
+    // Q4_K packs 256 elements into 144 bytes.
+    assert.equal(meta.layerBytes, ((4096 * 4096) / 256) * 144);
+    assert.equal(meta.fixedBytes, ((4096 * 128256) / 256) * 144 + 4096 * 4);
+  });
+
+  it('prefers an explicit key_length over embedding / head count', async () => {
+    const filePath = await writeGguf('keylen.gguf', {
+      kv: [
+        kvString('general.architecture', 'gemma3'),
+        kvU32('gemma3.block_count', 48),
+        kvU32('gemma3.embedding_length', 3840),
+        kvU32('gemma3.attention.head_count', 16),
+        kvU32('gemma3.attention.head_count_kv', 8),
+        kvU32('gemma3.attention.key_length', 256),
+      ],
+      tensors: [],
+    });
+
+    const meta = await parseGgufHeader(filePath);
+    assert.equal(meta.headDim, 256);
+  });
+
+  it('reads a per-layer sliding-window pattern as an exact full-attention count', async () => {
+    // 6 blocks, every third one full attention: [swa, swa, full, swa, swa, full].
+    const filePath = await writeGguf('swa.gguf', {
+      kv: [
+        kvString('general.architecture', 'gemma4'),
+        kvU32('gemma4.block_count', 6),
+        kvU32('gemma4.embedding_length', 2816),
+        kvU32('gemma4.attention.head_count', 16),
+        kvU32('gemma4.attention.head_count_kv', 8),
+        kvU32('gemma4.attention.key_length', 512),
+        kvU32('gemma4.attention.key_length_swa', 256),
+        kvU32('gemma4.attention.sliding_window', 1024),
+        kvBoolArray('gemma4.attention.sliding_window_pattern', [
+          true,
+          true,
+          false,
+          true,
+          true,
+          false,
+        ]),
+      ],
+      tensors: [],
+    });
+
+    const meta = await parseGgufHeader(filePath);
+    assert.equal(meta.nFullAttentionLayers, 2);
+    assert.equal(meta.swaWindow, 1024);
+    assert.equal(meta.swaHeadDim, 256);
+  });
+
+  it('reads a scalar sliding-window pattern as a period', async () => {
+    const filePath = await writeGguf('swa-scalar.gguf', {
+      kv: [
+        kvString('general.architecture', 'gemma3'),
+        kvU32('gemma3.block_count', 48),
+        kvU32('gemma3.embedding_length', 3840),
+        kvU32('gemma3.attention.head_count', 16),
+        kvU32('gemma3.attention.head_count_kv', 8),
+        kvU32('gemma3.attention.sliding_window', 1024),
+        kvU32('gemma3.attention.sliding_window_pattern', 6),
+      ],
+      tensors: [],
+    });
+
+    const meta = await parseGgufHeader(filePath);
+    assert.equal(meta.swaPeriod, 6);
+    assert.equal(meta.nFullAttentionLayers, 0);
+  });
+
+  it('returns null for a file that is not GGUF instead of throwing', async () => {
+    const filePath = path.join(tmpDir, 'junk.gguf');
+    await fsp.writeFile(filePath, Buffer.from('not a model at all', 'utf8'));
+    assert.equal(await readGgufMetadata(filePath), null);
+  });
+
+  it('returns null for a missing path and for non-gguf suffixes', async () => {
+    assert.equal(await readGgufMetadata(path.join(tmpDir, 'nope.gguf')), null);
+    assert.equal(await readGgufMetadata(path.join(tmpDir, 'llama.safetensors')), null);
+  });
+
+  it('memoizes on path, size, and mtime', async () => {
+    const filePath = path.join(tmpDir, 'llama.gguf');
+    const first = await readGgufMetadata(filePath);
+    const second = await readGgufMetadata(filePath);
+    assert.ok(first);
+    assert.equal(first, second);
+  });
+});

--- a/test/models/memory-model.test.mjs
+++ b/test/models/memory-model.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeBufferBytes,
+  estimateRunMemory,
+  fullAttentionLayers,
+  GIB,
+  kvCacheBytes,
+  maxContextForBudget,
+  weightsBytesFor,
+} from '../../src/models/memory-model.mjs';
+import { resolveGeometry } from '../../src/models/model-geometry.mjs';
+
+const geom = (over = {}) => ({
+  nLayers: 32,
+  nKvHeads: 8,
+  headDim: 128,
+  nEmbd: 4096,
+  nVocab: 128256,
+  nExperts: 0,
+  swaWindow: 0,
+  swaPeriod: 1,
+  source: 'gguf',
+  ...over,
+});
+
+describe('kv cache sizing', () => {
+  it('is 2 * layers * kv heads * head dim * bytes per token', () => {
+    // Llama-3.1-8B at f16: 128 KiB/token, so 8192 tokens is exactly 1 GiB.
+    assert.equal(kvCacheBytes(geom(), 8192, 'f16'), GIB);
+  });
+
+  it('does not change when parameter count does', () => {
+    // Qwen3-0.6B and Qwen3-8B share a KV geometry apart from block count. The old formula
+    // scaled with parameters and so was ~11x apart on these two.
+    const small = resolveGeometry({ architecture: 'qwen3', paramsB: 0.75 });
+    const large = resolveGeometry({ architecture: 'qwen3', paramsB: 8.19 });
+    // The only difference is 36 blocks against 28 — an 11x parameter gap moves nothing else.
+    const ratio = kvCacheBytes(large, 8192) / kvCacheBytes(small, 8192);
+    assert.equal(ratio, 36 / 28);
+  });
+
+  it('charges quantized cache types by their ggml block layout', () => {
+    const f16 = kvCacheBytes(geom(), 8192, 'f16');
+    // q8_0 stores 32 elements in 34 bytes.
+    assert.equal(kvCacheBytes(geom(), 8192, 'q8_0'), (f16 / 2) * (34 / 32));
+    assert.equal(kvCacheBytes(geom(), 8192, 'q4_0'), (f16 / 2) * (18 / 32));
+  });
+
+  it('falls back to f16 for an unknown cache type', () => {
+    assert.equal(kvCacheBytes(geom(), 8192, 'nonsense'), kvCacheBytes(geom(), 8192, 'f16'));
+  });
+
+  it('caps sliding-window layers at their window plus a micro-batch', () => {
+    const swa = geom({ nLayers: 48, headDim: 256, swaWindow: 1024, swaPeriod: 6 });
+    assert.equal(fullAttentionLayers(swa), 8);
+
+    const bytes = kvCacheBytes(swa, 32768, 'f16', { ubatch: 512 });
+    const perLayerToken = 2 * 8 * 256 * 2;
+    assert.equal(bytes, perLayerToken * (8 * 32768 + 40 * 1536));
+  });
+
+  it('lets an exact per-layer count override the period', () => {
+    const exact = geom({ nLayers: 30, swaWindow: 1024, swaPeriod: 6, nFullAttentionLayers: 5 });
+    assert.equal(fullAttentionLayers(exact), 5);
+  });
+
+  it('uses the narrower head size on windowed layers when the model has one', () => {
+    const wide = geom({ nLayers: 6, headDim: 512, swaWindow: 1024, nFullAttentionLayers: 2 });
+    const narrow = { ...wide, swaHeadDim: 256 };
+    assert.ok(kvCacheBytes(narrow, 32768) < kvCacheBytes(wide, 32768));
+  });
+});
+
+describe('compute buffer', () => {
+  it('is dominated by the logits tensor, so vocabulary drives it', () => {
+    const bigVocab = computeBufferBytes(geom({ nEmbd: 896, nVocab: 152064 }));
+    const smallVocab = computeBufferBytes(geom({ nEmbd: 4096, nVocab: 32000 }));
+    assert.ok(bigVocab > smallVocab);
+  });
+});
+
+describe('run memory', () => {
+  it('keeps everything on the GPU at full offload', () => {
+    const est = estimateRunMemory({
+      geometry: geom(),
+      weightsBytes: 4.58 * GIB,
+      ctx: 8192,
+      backend: 'cuda',
+    });
+    assert.equal(est.breakdown.weightsRam, 0);
+    assert.equal(est.breakdown.kvRam, 0);
+    assert.ok(est.vramGb > 5.5 && est.vramGb < 7);
+  });
+
+  it('splits the KV cache with the layers on partial offload', () => {
+    const est = estimateRunMemory({
+      geometry: geom(),
+      weightsBytes: 8 * GIB,
+      ctx: 8192,
+      nGpuLayers: 16,
+      backend: 'cuda',
+    });
+    assert.equal(est.gpuLayers, 16);
+    assert.equal(est.breakdown.kvVram, est.breakdown.kvRam);
+    assert.equal(est.breakdown.weightsVram, 4 * GIB);
+  });
+
+  it('uses exact per-role tensor bytes to split weights when the header supplied them', () => {
+    // A quarter of the file is embeddings and output, which stay on the CPU until -ngl
+    // exceeds the block count.
+    const withTensorBytes = geom({ layerBytes: 3, fixedBytes: 1 });
+    const est = estimateRunMemory({
+      geometry: withTensorBytes,
+      weightsBytes: 8 * GIB,
+      ctx: 0,
+      nGpuLayers: 32,
+      backend: 'cuda',
+    });
+    assert.equal(est.breakdown.weightsVram, 6 * GIB);
+    assert.equal(est.breakdown.weightsRam, 2 * GIB);
+  });
+
+  it('runs on the CPU at ngl 0', () => {
+    const est = estimateRunMemory({ geometry: geom(), weightsBytes: 4 * GIB, ctx: 8192, nGpuLayers: 0 });
+    assert.equal(est.vramGb, 0);
+    assert.ok(est.ramGb > 4);
+  });
+});
+
+describe('maxContextForBudget', () => {
+  it('solves for context instead of halving until it fits', () => {
+    // 128 KiB/token, so 3 GiB of budget holds 24576 tokens — rounded down to 16384.
+    assert.equal(maxContextForBudget(geom(), 3 * GIB), 16384);
+    assert.equal(maxContextForBudget(geom(), 4 * GIB), 32768);
+  });
+
+  it('reports nothing when even the minimum context does not fit', () => {
+    assert.equal(maxContextForBudget(geom(), 0.05 * GIB), 0);
+    assert.equal(maxContextForBudget(geom(), -1), 0);
+  });
+});
+
+describe('weightsBytesFor', () => {
+  it('matches published GGUF file sizes within a few percent', () => {
+    const cases = [
+      [8.03, 'Q4_K_M', 4.58],
+      [7.25, 'Q4_K_M', 4.07],
+      [70.6, 'Q4_K_M', 39.6],
+      [8.03, 'Q8_0', 7.95],
+      [8.03, 'Q6_K', 6.15],
+    ];
+    for (const [paramsB, quant, realGib] of cases) {
+      const estimate = weightsBytesFor(paramsB, quant) / GIB;
+      const error = Math.abs(estimate - realGib) / realGib;
+      assert.ok(error < 0.05, `${paramsB}B ${quant}: ${estimate.toFixed(2)} vs ${realGib}`);
+    }
+  });
+});

--- a/test/models/model-geometry.test.mjs
+++ b/test/models/model-geometry.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  GEOMETRY_FAMILIES,
+  geometryFromGgufMetadata,
+  heuristicLayerCount,
+  resolveFamilyKey,
+  resolveGeometry,
+} from '../../src/models/model-geometry.mjs';
+
+describe('family resolution', () => {
+  it('maps HF model_type values onto families', () => {
+    assert.equal(resolveFamilyKey({ architecture: 'qwen3_moe' }), 'qwen3_moe');
+    assert.equal(resolveFamilyKey({ architecture: 'Qwen2.5' }), 'qwen2');
+    assert.equal(resolveFamilyKey({ architecture: 'gemma3_text' }), 'gemma3');
+    assert.equal(resolveFamilyKey({ architecture: 'LlamaForCausalLM' }), 'llama');
+  });
+
+  it('falls back to the model name when architecture is missing', () => {
+    assert.equal(resolveFamilyKey({ name: 'Qwen3-30B-A3B-Instruct' }), 'qwen3_moe');
+    assert.equal(resolveFamilyKey({ name: 'gpt-oss-20b' }), 'gpt_oss');
+    assert.equal(resolveFamilyKey({ name: 'something-unheard-of' }), null);
+  });
+});
+
+describe('resolveGeometry', () => {
+  it('matches the nearest shipped size on a log scale', () => {
+    const qwen8b = resolveGeometry({ architecture: 'qwen3', paramsB: 8.19 });
+    assert.equal(qwen8b.source, 'family');
+    assert.equal(qwen8b.nLayers, 36);
+    assert.equal(qwen8b.nKvHeads, 8);
+    assert.equal(qwen8b.headDim, 128);
+  });
+
+  it('keeps Llama 2 7B and Llama 3 8B apart despite the shared architecture', () => {
+    // Llama 2 is multi-head; Llama 3 is 8-wide GQA. Collapsing them is a 4x KV error.
+    assert.equal(resolveGeometry({ architecture: 'llama', paramsB: 6.74 }).nKvHeads, 32);
+    assert.equal(resolveGeometry({ architecture: 'llama', paramsB: 8.03 }).nKvHeads, 8);
+  });
+
+  it('picks up sliding-window families', () => {
+    const gemma = resolveGeometry({ architecture: 'gemma3', paramsB: 12.2 });
+    assert.equal(gemma.swaWindow, 1024);
+    assert.equal(gemma.swaPeriod, 6);
+    const oss = resolveGeometry({ architecture: 'gpt_oss', paramsB: 20.9 });
+    assert.equal(oss.swaPeriod, 2);
+    assert.equal(oss.nLayers, 24);
+  });
+
+  it('falls back to the heuristic when the size is far from any shipped variant', () => {
+    const odd = resolveGeometry({ architecture: 'qwen3', paramsB: 120 });
+    assert.equal(odd.source, 'heuristic');
+    // Family constants still apply — only layers and hidden size are guessed.
+    assert.equal(odd.nVocab, GEOMETRY_FAMILIES.qwen3.nVocab);
+  });
+
+  it('is heuristic for an unknown architecture but still plausible', () => {
+    const unknown = resolveGeometry({ architecture: 'brand_new_arch', paramsB: 8 });
+    assert.equal(unknown.source, 'heuristic');
+    assert.ok(unknown.nLayers >= 24 && unknown.nLayers <= 48);
+    assert.equal(unknown.nKvHeads * unknown.headDim, 1024);
+  });
+
+  it('sizes the MoE trunk from active parameters, not the expert bank', () => {
+    const moe = resolveGeometry({
+      architecture: 'brand_new_moe',
+      paramsB: 30,
+      activeParamsB: 3,
+      nExperts: 128,
+    });
+    const dense = resolveGeometry({ architecture: 'brand_new_moe', paramsB: 30 });
+    assert.ok(moe.nEmbd < dense.nEmbd);
+    assert.equal(moe.nExperts, 128);
+  });
+
+  it('never returns a degenerate geometry', () => {
+    for (const paramsB of [0.05, 0.5, 7, 70, 700]) {
+      const g = resolveGeometry({ paramsB });
+      assert.ok(g.nLayers > 0 && g.nKvHeads > 0 && g.headDim > 0 && g.nVocab > 0, `${paramsB}B`);
+    }
+  });
+
+  it('layer heuristic stays monotonic in parameter count', () => {
+    let previous = 0;
+    for (const p of [0.5, 2, 5, 8, 14, 20, 32, 50, 70, 200]) {
+      const layers = heuristicLayerCount(p);
+      assert.ok(layers > 0);
+      previous = Math.max(previous, layers);
+    }
+    assert.equal(previous, heuristicLayerCount(200));
+  });
+});
+
+describe('geometryFromGgufMetadata', () => {
+  it('marks header-derived geometry as exact', () => {
+    const g = geometryFromGgufMetadata({
+      arch: 'llama',
+      nLayers: 32,
+      nKvHeads: 8,
+      headDim: 128,
+      nEmbd: 4096,
+      nVocab: 128256,
+      layerBytes: 4_000_000_000,
+      fixedBytes: 500_000_000,
+    });
+    assert.equal(g.source, 'gguf');
+    assert.equal(g.layerBytes, 4_000_000_000);
+  });
+
+  it('fills a missing SWA period from the family table', () => {
+    const g = geometryFromGgufMetadata({
+      arch: 'gemma3',
+      nLayers: 48,
+      nKvHeads: 8,
+      headDim: 256,
+      nEmbd: 3840,
+      swaWindow: 1024,
+      swaPeriod: 0,
+    });
+    assert.equal(g.swaPeriod, 6);
+  });
+
+  it('assumes no windowing when neither the header nor the table knows', () => {
+    // Overstating the cache is the safe direction — it never causes a surprise OOM.
+    const g = geometryFromGgufMetadata({
+      arch: 'unknown_arch',
+      nLayers: 40,
+      nKvHeads: 8,
+      headDim: 128,
+      nEmbd: 4096,
+      swaWindow: 4096,
+      swaPeriod: 0,
+    });
+    assert.equal(g.swaPeriod, 1);
+  });
+
+  it('returns null when the header lacks the fields that matter', () => {
+    assert.equal(geometryFromGgufMetadata(null), null);
+    assert.equal(geometryFromGgufMetadata({ arch: 'llama', nLayers: 32 }), null);
+  });
+});

--- a/test/models/serve-memory-estimate.test.mts
+++ b/test/models/serve-memory-estimate.test.mts
@@ -7,53 +7,130 @@ import {
   formatServeMemoryEstimate,
 } from '../../src/models/serve-memory-estimate.ts';
 
+/** Llama-3.1-8B, as its GGUF header states it. */
+const LLAMA_8B = {
+  arch: 'llama',
+  nLayers: 32,
+  nKvHeads: 8,
+  headDim: 128,
+  nEmbd: 4096,
+  nVocab: 128256,
+};
+
 describe('serve memory estimate', () => {
-  it('maps parameter size to a layer count bucket', () => {
-    assert.equal(estimateTransformerLayerCount(7), 32);
-    assert.equal(estimateTransformerLayerCount(70), 80);
+  it('takes the layer count from the GGUF header when one is available', () => {
+    assert.equal(estimateTransformerLayerCount(8, { gguf: LLAMA_8B }), 32);
+    // Qwen3-32B is 64 blocks; the old parameter-size bucket said 48.
+    assert.equal(estimateTransformerLayerCount(32.76, { arch: 'qwen3' }), 64);
+    assert.equal(estimateTransformerLayerCount(70, { arch: 'llama' }), 80);
   });
 
   it('puts all weights and KV on VRAM when ngl is 999', () => {
     const est = estimateServeMemory({
-      weightsGb: 4,
-      paramsB: 7,
+      weightsGb: 4.58,
+      paramsB: 8,
       ctx: 8192,
       cacheType: 'f16',
       nGpuLayers: 999,
+      gguf: LLAMA_8B,
     });
-    assert.ok(est.vramGb > 4);
-    assert.equal(est.ramGb, 0);
-    assert.match(formatServeMemoryEstimate(est), /VRAM/);
+    assert.ok(est.vramGb > 4.58);
+    // Only the small fixed host allocation stays off the GPU, which the hint line hides.
+    assert.ok(est.ramGb < 0.5);
+    assert.equal(est.geometrySource, 'gguf');
+    assert.equal(formatServeMemoryEstimate(est), `~${est.vramGb} GB VRAM`);
+  });
+
+  it('sizes the KV cache from attention geometry, not parameter count', () => {
+    const at = (ctx: number) =>
+      estimateServeMemory({ weightsGb: 0, paramsB: 8, ctx, gguf: LLAMA_8B, nGpuLayers: 999 });
+
+    // 2 (K+V) * 32 layers * 8 kv heads * 128 head dim * 2 bytes = 128 KiB/token, so 8192
+    // tokens is exactly 1 GiB. The old formula called this 0.53 GB.
+    assert.equal(Math.round((at(8192).totalGb - at(0).totalGb) * 100) / 100, 1.0);
+    assert.equal(at(8192).kvGbPer1kTokens, 0.12);
+  });
+
+  it('charges a quantized KV cache less than f16', () => {
+    const f16 = estimateServeMemory({
+      weightsGb: 4.58,
+      paramsB: 8,
+      ctx: 32768,
+      cacheType: 'f16',
+      gguf: LLAMA_8B,
+    });
+    const q80 = estimateServeMemory({
+      weightsGb: 4.58,
+      paramsB: 8,
+      ctx: 32768,
+      cacheType: 'q8_0',
+      gguf: LLAMA_8B,
+    });
+    assert.ok(q80.vramGb < f16.vramGb);
+    // q8_0 stores 32 elements in 34 bytes — a shade over half of f16.
+    assert.ok(f16.vramGb - q80.vramGb > 1.8);
+  });
+
+  it('discounts sliding-window layers', () => {
+    // Gemma 3 12B keeps full attention on 8 of 48 blocks; the other 40 cap at a 1024 window.
+    // Weights are zeroed so the assertion is about the cache alone: ~2.5 GiB, not ~12.
+    const gemma = estimateServeMemory({ weightsGb: 0, paramsB: 12.2, ctx: 32768, arch: 'gemma3' });
+    const asIfDense = estimateServeMemory({
+      weightsGb: 0,
+      paramsB: 12.2,
+      ctx: 32768,
+      gguf: { nLayers: 48, nKvHeads: 8, headDim: 256, nEmbd: 3840, nVocab: 262144 },
+    });
+    assert.equal(gemma.layerCount, 48);
+    assert.ok(gemma.vramGb < asIfDense.vramGb / 3);
   });
 
   it('puts everything on RAM when ngl is 0', () => {
     const est = estimateServeMemory({
-      weightsGb: 4,
-      paramsB: 7,
+      weightsGb: 4.58,
+      paramsB: 8,
       ctx: 8192,
       nGpuLayers: 0,
+      gguf: LLAMA_8B,
     });
     assert.equal(est.vramGb, 0);
-    assert.ok(est.ramGb > 4);
+    assert.ok(est.ramGb > 4.58);
     assert.match(formatServeMemoryEstimate(est), /RAM/);
   });
 
-  it('splits weights for partial GPU offload', () => {
+  it('splits the KV cache along with the layers on partial offload', () => {
     const full = estimateServeMemory({
       weightsGb: 8,
-      paramsB: 7,
-      ctx: 4096,
+      paramsB: 8,
+      ctx: 32768,
       nGpuLayers: 999,
+      gguf: LLAMA_8B,
     });
     const half = estimateServeMemory({
       weightsGb: 8,
-      paramsB: 7,
-      ctx: 4096,
+      paramsB: 8,
+      ctx: 32768,
       nGpuLayers: 16,
+      gguf: LLAMA_8B,
     });
     assert.ok(half.vramGb < full.vramGb);
     assert.ok(half.ramGb > 0);
+    // Half the layers means half the cache stays in RAM — 4 GiB of KV at 32k, so the VRAM
+    // figure must drop by clearly more than half the weights alone (4 GiB) would explain.
+    assert.ok(full.vramGb - half.vramGb > 5);
     assert.match(formatServeMemoryEstimate(half), /VRAM/);
     assert.match(formatServeMemoryEstimate(half), /RAM/);
+  });
+
+  it('falls back to architecture geometry when no header is available', () => {
+    const est = estimateServeMemory({
+      weightsGb: 4.68,
+      paramsB: 8.19,
+      ctx: 8192,
+      arch: 'qwen3',
+      name: 'Qwen3-8B',
+    });
+    assert.equal(est.geometrySource, 'family');
+    assert.equal(est.layerCount, 36);
   });
 });

--- a/test/ui/editor-ai-binding-library.test.mts
+++ b/test/ui/editor-ai-binding-library.test.mts
@@ -64,6 +64,7 @@ mock.module('../../src/models/api-client.ts', {
     listModelDownloads: async () => [],
     fetchInstalledModels: async () => [],
     fetchRuntimes: async () => ({}),
+    fetchGgufGeometry: async () => null,
     fetchModelsConfig: async () => ({}),
     saveModelsConfig: async () => ({}),
     fetchServeProfiles: async () => [],


### PR DESCRIPTION
## The problem

Every memory number in Models — the Discover recommendation, the inspector's Load tab, and the server-side serve profiles — derived KV cache size from **parameter count**:

```
0.000008 * paramsB * ctx
```

That constant was fitted to Llama-3-8B and then extrapolated linearly. KV cache size is set by `2 × layers × kv_heads × head_dim` and has no relationship to parameter count — Qwen3-0.6B and Qwen3-8B have nearly identical KV geometry despite an 11× parameter gap. Measured against published model configs:

| Surface | Worst-case error |
| --- | --- |
| Discover recommendation | **17.8×** (0.06× on Qwen3-0.6B → 1.85× on Llama-3.3-70B) |
| Load tab | **14.3×** (0.11× on Qwen3-0.6B → 14.3× on gpt-oss-20b) |

Four more defects rode along:

- **The two paths disagreed with each other by 2×** on the same model at the same settings — `serve-memory-estimate.ts` applied a KV precision factor that `quant.ts` did not.
- **Sliding-window attention was unmodelled.** Gemma 3 grows a cache on 8 of 48 layers, gpt-oss on 12 of 24. Charging all of them is the entire 14× gpt-oss error.
- **Partial offload charged the whole KV cache to VRAM**, even at `-ngl 1`.
- **Two independent weight tables** meant the "Size" column and the "Required" column disagreed 10–12% on every k-quant row; both also conflated bytes/weight with GiB/billion for a further 7%.

## The change

One shared physical model — `src/models/memory-model.mjs` + `src/models/model-geometry.mjs` — behind discovery, the Load tab, and `server/models/profiles.js`. Geometry resolves in three tiers:

1. **`gguf`** — `server/models/gguf-metadata.js` reads the file's own header (~150 ms, memoized on path + size + mtime): exact layers, GQA width, head dim, vocabulary, per-tensor bytes, and the per-layer sliding-window pattern. Exposed as `GET /api/models/gguf-meta`.
2. **`family`** — architecture + parameter count matched against a table of shipped model geometry.
3. **`heuristic`** — fitted fallback, carrying explicit `GEOMETRY_UNCERTAINTY` so a guess never claims a confident fit.

Also in scope:

- KV cache follows its layers on partial offload.
- The compute buffer is modelled as logits-dominated (vocabulary-driven) rather than a flat constant — a 0.6B model with a 152k vocab reserves nearly as much scratch as an 8B one.
- `maxContextForBudget` solves for context directly instead of halving until it fits. The old loop could only report ctx, ctx/2, ctx/4 …, so a machine with room for 30k context was listed at 16k.
- The GPU-layers slider maxes at the model's real block count instead of a parameter-size bucket.

## Verification

- All 15 ground-truth models land at **1.00×** on KV cache with exact layer counts.
- Live against the local library on a real dev server: `gemma-4-26B-A4B` went from `~45 GB VRAM` / 60 layers to `~26.4 GB` / **30 layers**, its true block count. Every installed model now resolves its geometry from its own header; measured KV cost spans 0.01–0.31 GB per 1k context, a 30× range the old linear formula could not express.
- 39 new tests across three files. Models suite **202/202**, `tsc --noEmit` clean.
- Full `npm test` leaves 3 failures — `terminal/sandbox` ×2 (macOS/WSL-specific, fail on Windows) and `brain/synthesis`. All pre-existing on `main` and unrelated.

## Reviewer notes

- **Two existing tests asserted the old, wrong numbers** and were corrected rather than preserved: `estimateFileSizeGb(7, 'Q4_K_M') === 3.5` → `4.0` (real Mistral-7B Q4_K_M is 4.07 GiB), and `(8, 'Q8_0') === 8` → `7.9`.
- `QUANT_BPP` and `QUANT_BYTES_PER_PARAM` are removed; `WEIGHT_GIB_PER_BILLION` in `memory-model.mjs` is the single table, in **GiB per billion params**.
- Discovery is now slightly more conservative for models whose geometry is guessed (5% headroom for `family`, 35% for `heuristic`). Deliberate — a confident-looking number that OOMs is worse than a cautious one.
- When a GGUF declares a sliding window but no pattern and the architecture is unknown, we assume **no** windowing. That overstates the cache, which never causes a surprise OOM.
- `src/models/*.mjs` + `.d.mts` follows the existing `src/lib/*.mjs` convention for code shared between the TS frontend and the plain-JS server.
- Adding a new architecture family: only `nLayers`/`nEmbd` vary by size — GQA width, head dim, and vocabulary are family constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
