### PR TITLE
Give the agent loop a failure floor (harness correctness, phase 1)

### DIFF
--- a/server/generations/anthropic/pump.js
+++ b/server/generations/anthropic/pump.js
@@ -5,7 +5,7 @@
 import { APICallError } from '@ai-sdk/provider';
 import { generateText as defaultGenerateText, streamText as defaultStreamText } from 'ai';
 import { classifyUpstreamError } from '../fallback.js';
-import { isHostDead, markHostDead, originFromUrl } from '../host-cooldown.js';
+import { isHostDead, originFromUrl } from '../host-cooldown.js';
 import {
   appendChunk,
   markComplete,
@@ -177,7 +177,12 @@ function buildGenerationCallOptions(body, provider, abortSignal) {
 
 /**
  * @param {unknown} err
- * @returns {{ kind: 'retryable' | 'fatal', message: string }}
+ * @returns {{
+ *   kind: 'retryable' | 'fatal',
+ *   message: string,
+ *   rateLimited?: boolean,
+ *   retryAfterMs?: number,
+ * }}
  */
 function classifySdkError(err) {
   if (err instanceof APICallError || (err && typeof err === 'object' && err.name === 'APICallError')) {
@@ -187,8 +192,18 @@ function classifySdkError(err) {
       status || 500,
       typeof apiErr.responseBody === 'string' ? apiErr.responseBody : apiErr.message,
     );
-    const classified = classifyUpstreamError(err, typeof status === 'number' ? { status } : undefined);
-    return { kind: classified.kind, message };
+    const classified = classifyUpstreamError(
+      err,
+      typeof status === 'number'
+        ? { status, headers: apiErr.responseHeaders }
+        : undefined,
+    );
+    return {
+      kind: classified.kind,
+      message,
+      rateLimited: classified.rateLimited,
+      retryAfterMs: classified.retryAfterMs,
+    };
   }
   const classified = classifyUpstreamError(err);
   return { kind: classified.kind, message: classified.reason };
@@ -221,10 +236,15 @@ function parseOpenAiRequestBody(requestBody) {
  *   index: number,
  *   idleMs: number,
  *   maxMs: number,
- *   cooldownSeconds: number,
  *   canFailover: boolean,
  * }} params
- * @returns {Promise<{ outcome: 'complete' | 'retry' | 'fatal', message?: string }>}
+ * @returns {Promise<{
+ *   outcome: 'complete' | 'retry' | 'fatal',
+ *   message?: string,
+ *   retrySameCandidate?: boolean,
+ *   retryAfterMs?: number,
+ *   hostSuspect?: boolean,
+ * }>}
  */
 export async function pumpAnthropicUpstream({
   state,
@@ -233,7 +253,6 @@ export async function pumpAnthropicUpstream({
   index,
   idleMs,
   maxMs,
-  cooldownSeconds,
   canFailover,
 }) {
   const controller = new AbortController();
@@ -270,7 +289,9 @@ export async function pumpAnthropicUpstream({
 
     if (isHostDead(origin)) {
       const message = `Host in cooldown: ${origin}`;
-      if (canFailover) return { outcome: 'retry', message };
+      if (canFailover) {
+        return { outcome: 'retry', message, retrySameCandidate: false };
+      }
       return { outcome: 'fatal', message };
     }
 
@@ -409,17 +430,22 @@ export async function pumpAnthropicUpstream({
 
     if (timeoutKind) {
       const message = generationTimeoutMessage({ idleMs, maxMs }, timeoutKind);
-      if (!bytesEmitted && canFailover) {
-        markHostDead(origin, cooldownSeconds);
-        return { outcome: 'retry', message };
+      if (!bytesEmitted) {
+        // Same-candidate retry after a stall costs the full timeout budget again.
+        return { outcome: 'retry', message, retrySameCandidate: false, hostSuspect: true };
       }
       return { outcome: 'fatal', message };
     }
 
     const classified = classifySdkError(err);
-    if (!bytesEmitted && classified.kind === 'retryable' && canFailover) {
-      markHostDead(origin, cooldownSeconds);
-      return { outcome: 'retry', message: classified.message };
+    if (!bytesEmitted && classified.kind === 'retryable') {
+      return {
+        outcome: 'retry',
+        message: classified.message,
+        retrySameCandidate: classified.rateLimited === true || !canFailover,
+        retryAfterMs: classified.retryAfterMs,
+        hostSuspect: classified.rateLimited !== true,
+      };
     }
 
     if (!bytesEmitted) {

--- a/server/generations/fallback.js
+++ b/server/generations/fallback.js
@@ -58,7 +58,90 @@ const RETRYABLE_NODE_CODES = new Set([
   'UND_ERR_BODY_TIMEOUT',
 ]);
 
-const RETRYABLE_HTTP_STATUSES = new Set([502, 503, 504]);
+/**
+ * Statuses that mean "the same request would succeed later": the model is busy,
+ * not wrong. Retrying the same candidate is the right move — failing over swaps
+ * the user onto a different model, and dying loses the turn outright.
+ * 529 is Anthropic's "overloaded"; 425 is Too Early; 408 is a server-side timeout.
+ */
+const RATE_LIMIT_HTTP_STATUSES = new Set([408, 425, 429, 529]);
+
+const RETRYABLE_HTTP_STATUSES = new Set([502, 503, 504, ...RATE_LIMIT_HTTP_STATUSES]);
+
+/** Attempts against one candidate before falling through to the next. */
+export const MAX_SAME_CANDIDATE_ATTEMPTS = 3;
+
+/** Base backoff for same-candidate retries. */
+const RETRY_BASE_DELAY_MS = 1_000;
+
+/** Never stall a turn longer than this, whatever `Retry-After` claims. */
+const RETRY_MAX_DELAY_MS = 30_000;
+
+/**
+ * Parse a `Retry-After` header (delta-seconds or HTTP-date) into milliseconds.
+ * Returns null when absent or unparseable so the caller falls back to backoff.
+ *
+ * @param {string | null | undefined} value
+ * @param {number} [nowMs]
+ * @returns {number | null}
+ */
+export function parseRetryAfterMs(value, nowMs = Date.now()) {
+  if (typeof value !== 'string') return null;
+  const raw = value.trim();
+  if (!raw) return null;
+
+  if (/^\d+(\.\d+)?$/.test(raw)) {
+    const seconds = Number(raw);
+    if (!Number.isFinite(seconds) || seconds < 0) return null;
+    return Math.min(Math.round(seconds * 1000), RETRY_MAX_DELAY_MS);
+  }
+
+  // Date.parse is lenient enough to read "-4" as a year, so require the weekday
+  // and month names an HTTP-date always carries before trusting it.
+  if (!/[a-z]/i.test(raw)) return null;
+  const at = Date.parse(raw);
+  if (Number.isNaN(at)) return null;
+  return Math.min(Math.max(at - nowMs, 0), RETRY_MAX_DELAY_MS);
+}
+
+/**
+ * Delay before re-running the same candidate: honour `Retry-After` when the
+ * provider sent one, otherwise exponential backoff with jitter so a fleet of
+ * clients does not resynchronize onto the same retry instant.
+ *
+ * @param {number} attempt 1 for the first retry.
+ * @param {number | null | undefined} [retryAfterMs]
+ * @returns {number}
+ */
+export function computeRetryDelayMs(attempt, retryAfterMs) {
+  if (typeof retryAfterMs === 'number' && retryAfterMs >= 0) {
+    return Math.min(retryAfterMs, RETRY_MAX_DELAY_MS);
+  }
+  const exponential = RETRY_BASE_DELAY_MS * 2 ** Math.max(0, attempt - 1);
+  const jitter = Math.random() * RETRY_BASE_DELAY_MS;
+  return Math.min(Math.round(exponential + jitter), RETRY_MAX_DELAY_MS);
+}
+
+/**
+ * Read `Retry-After` off anything response-shaped (undici Response, or the
+ * `{ status }` literals the Anthropic bridge hands us).
+ *
+ * @param {unknown} response
+ * @returns {string | null}
+ */
+function readRetryAfterHeader(response) {
+  if (!response || typeof response !== 'object') return null;
+  const headers = /** @type {{ headers?: unknown }} */ (response).headers;
+  if (headers && typeof (/** @type {Headers} */ (headers).get) === 'function') {
+    return /** @type {Headers} */ (headers).get('retry-after');
+  }
+  if (headers && typeof headers === 'object') {
+    const record = /** @type {Record<string, unknown>} */ (headers);
+    const value = record['retry-after'] ?? record['Retry-After'];
+    return typeof value === 'string' ? value : null;
+  }
+  return null;
+}
 
 /**
  * @param {unknown} config
@@ -202,8 +285,8 @@ function toEnabledSet(enabledProviderIds) {
 
 /**
  * @param {unknown} err
- * @param {{ status?: number } | null | undefined} [response]
- * @returns {{ kind: 'retryable' | 'fatal', reason: string }}
+ * @param {{ status?: number, headers?: unknown } | null | undefined} [response]
+ * @returns {{ kind: 'retryable' | 'fatal', reason: string, rateLimited?: boolean, retryAfterMs?: number }}
  */
 export function classifyUpstreamError(err, response) {
   const status = response?.status;
@@ -217,6 +300,15 @@ export function classifyUpstreamError(err, response) {
     }
     if (status === 422) {
       return { kind: 'fatal', reason: 'Upstream HTTP 422 (validation)' };
+    }
+    if (RATE_LIMIT_HTTP_STATUSES.has(status)) {
+      const retryAfterMs = parseRetryAfterMs(readRetryAfterHeader(response));
+      return {
+        kind: 'retryable',
+        reason: `Upstream HTTP ${status}`,
+        rateLimited: true,
+        ...(retryAfterMs == null ? {} : { retryAfterMs }),
+      };
     }
     if (RETRYABLE_HTTP_STATUSES.has(status)) {
       return { kind: 'retryable', reason: `Upstream HTTP ${status}` };

--- a/server/generations/upstream.js
+++ b/server/generations/upstream.js
@@ -15,6 +15,8 @@ import { sanitizeCompletionBodyForProvider } from '../providers/sanitize-complet
 import {
   buildCandidateRequestBody,
   classifyUpstreamError,
+  computeRetryDelayMs,
+  MAX_SAME_CANDIDATE_ATTEMPTS,
   readFallbackChainsConfig,
 } from './fallback.js';
 import { isHostDead, markHostDead, originFromUrl } from './host-cooldown.js';
@@ -127,6 +129,47 @@ export function pumpUpstream({ state }) {
 }
 
 /**
+ * Sleep, unless the generation is cancelled first.
+ *
+ * @param {import('./store.js').GenerationState} state
+ * @param {number} ms
+ * @returns {Promise<boolean>} false when the wait ended because of cancellation.
+ */
+function delayUnlessCancelled(state, ms) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const tick = () => {
+      if (state.status === 'cancelled') {
+        resolve(false);
+        return;
+      }
+      const remaining = ms - (Date.now() - started);
+      if (remaining <= 0) {
+        resolve(true);
+        return;
+      }
+      setTimeout(tick, Math.min(remaining, 250));
+    };
+    tick();
+  });
+}
+
+/**
+ * Whether a retryable failure is worth re-running against the same candidate.
+ * Rate limits always are — the model is busy, not wrong. Other transient errors
+ * only when there is no other candidate to fall through to, so a configured
+ * fallback chain still switches immediately the way it always did.
+ *
+ * @param {{ kind: string, rateLimited?: boolean }} classified
+ * @param {boolean} canFailover
+ * @returns {boolean}
+ */
+function shouldRetrySameCandidate(classified, canFailover) {
+  if (classified.kind !== 'retryable') return false;
+  return classified.rateLimited === true || !canFailover;
+}
+
+/**
  * @param {{ state: import('./store.js').GenerationState }} params
  */
 async function pumpUpstreamAsync({ state }) {
@@ -197,19 +240,18 @@ async function pumpUpstreamAsync({ state }) {
             },
           }
         : runtime;
-    const result =
+    const runAttempt = () =>
       resolvedApi === 'anthropic-v1'
-        ? await pumpAnthropicUpstream({
+        ? pumpAnthropicUpstream({
             state,
             runtime: anthropicRuntime,
             candidate,
             index,
             idleMs,
             maxMs,
-            cooldownSeconds: fallbackConfig.cooldownSeconds,
             canFailover,
           })
-        : await attemptCandidateStream({
+        : attemptCandidateStream({
             state,
             candidate,
             index,
@@ -224,15 +266,45 @@ async function pumpUpstreamAsync({ state }) {
             ),
             idleMs,
             maxMs,
-            cooldownSeconds: fallbackConfig.cooldownSeconds,
             origin,
             canFailover,
           });
 
+    let result = await runAttempt();
+
+    // Re-run the *same* candidate before falling through. A 429/529 means this
+    // model is busy, not wrong — switching candidates silently swaps the user's
+    // model, and with fallback chains disabled (the default) there is nothing to
+    // switch to, so the turn used to die outright.
+    for (
+      let attempt = 1;
+      result.outcome === 'retry' &&
+      result.retrySameCandidate === true &&
+      attempt < MAX_SAME_CANDIDATE_ATTEMPTS &&
+      state.status !== 'cancelled';
+      attempt += 1
+    ) {
+      const delayMs = computeRetryDelayMs(attempt, result.retryAfterMs);
+      console.warn(
+        `[generations] ${result.message ?? 'upstream retryable failure'} — retrying ${candidate.providerId}/${candidate.modelId} in ${Math.round(delayMs / 1000)}s (attempt ${attempt + 1}/${MAX_SAME_CANDIDATE_ATTEMPTS})`,
+      );
+      if (!(await delayUnlessCancelled(state, delayMs))) {
+        return;
+      }
+      result = await runAttempt();
+    }
+
     if (result.outcome === 'complete') {
       return;
     }
-    if (result.outcome === 'fatal') {
+    // Cooldown belongs to giving up on the candidate: marking it during a retry
+    // would trip the isHostDead pre-flight above on our own next attempt. Only
+    // cool a host off when there is somewhere else to go — locking out the sole
+    // provider would break the next turn too.
+    if (result.hostSuspect && canFailover) {
+      markHostDead(origin, fallbackConfig.cooldownSeconds);
+    }
+    if (result.outcome === 'fatal' || !canFailover) {
       markError(state, result.message ?? 'Generation failed');
       return;
     }
@@ -252,11 +324,16 @@ async function pumpUpstreamAsync({ state }) {
  *   requestBody: Buffer,
  *   idleMs: number,
  *   maxMs: number,
- *   cooldownSeconds: number,
  *   origin: string,
  *   canFailover: boolean,
  * }} params
- * @returns {Promise<{ outcome: 'complete' | 'retry' | 'fatal', message?: string }>}
+ * @returns {Promise<{
+ *   outcome: 'complete' | 'retry' | 'fatal',
+ *   message?: string,
+ *   retrySameCandidate?: boolean,
+ *   retryAfterMs?: number,
+ *   hostSuspect?: boolean,
+ * }>}
  */
 async function attemptCandidateStream({
   state,
@@ -267,7 +344,6 @@ async function attemptCandidateStream({
   requestBody,
   idleMs,
   maxMs,
-  cooldownSeconds,
   origin,
   canFailover,
 }) {
@@ -325,11 +401,15 @@ async function attemptCandidateStream({
         responseText: rawBody,
       });
       const classified = classifyUpstreamError(null, upstream);
-      if (!bytesEmitted && classified.kind === 'retryable' && canFailover) {
-        if (upstream.status >= 500 || [502, 503, 504].includes(upstream.status)) {
-          markHostDead(origin, cooldownSeconds);
-        }
-        return { outcome: 'retry', message };
+      if (!bytesEmitted && classified.kind === 'retryable') {
+        return {
+          outcome: 'retry',
+          message,
+          retrySameCandidate: shouldRetrySameCandidate(classified, canFailover),
+          retryAfterMs: classified.retryAfterMs,
+          // A rate limit is the host behaving correctly — do not cool it off.
+          hostSuspect: classified.rateLimited !== true && upstream.status >= 500,
+        };
       }
       return { outcome: 'fatal', message };
     }
@@ -388,16 +468,21 @@ async function attemptCandidateStream({
     }
     if (timeoutKind) {
       const message = generationTimeoutMessage({ idleMs, maxMs }, timeoutKind);
-      if (!bytesEmitted && canFailover) {
-        markHostDead(origin, cooldownSeconds);
-        return { outcome: 'retry', message };
+      if (!bytesEmitted) {
+        // Never re-run the same candidate after a stall: each attempt costs the
+        // full timeout budget and a wedged host will not unwedge in seconds.
+        return { outcome: 'retry', message, retrySameCandidate: false, hostSuspect: true };
       }
       return { outcome: 'fatal', message };
     }
     const classified = classifyUpstreamError(err);
-    if (!bytesEmitted && classified.kind === 'retryable' && canFailover) {
-      markHostDead(origin, cooldownSeconds);
-      return { outcome: 'retry', message: classified.reason };
+    if (!bytesEmitted && classified.kind === 'retryable') {
+      return {
+        outcome: 'retry',
+        message: classified.reason,
+        retrySameCandidate: shouldRetrySameCandidate(classified, canFailover),
+        hostSuspect: true,
+      };
     }
     return { outcome: 'fatal', message: classified.reason };
   } finally {

--- a/src/agents/sub-agent-runner.ts
+++ b/src/agents/sub-agent-runner.ts
@@ -12,6 +12,7 @@ import {
   type StreamMetaAccumulator,
 } from '../api/chat';
 import { applyClassifiedStreamEnd, classifyStreamEnd } from '../api/stream-end';
+import { repairUnpairedToolCalls } from '../api/provider-message-normalize';
 import { reportBackgroundError } from '../boot/report-background-error.ts';
 import {
   extractInlineThinkingFromContent,
@@ -845,6 +846,13 @@ export const defaultSubAgentRunner: SubAgentRunner = {
           stats: statsSegments.length ? averageStatsSegments(statsSegments) : undefined,
         };
       }
+
+      // Context trimming can drop a tool result while keeping its assistant row;
+      // repair in place so every send this round (and the transcript we return)
+      // carries paired tool calls.
+      const repaired = repairUnpairedToolCalls(messages);
+      messages.length = 0;
+      messages.push(...repaired);
 
       const body = applySamplerToBody(
         {

--- a/src/api/provider-message-normalize.ts
+++ b/src/api/provider-message-normalize.ts
@@ -2,7 +2,80 @@
  * Provider-specific outbound message fixes (LM Studio Jinja, etc.).
  */
 
-import type { ApiMessage } from '../types';
+import type { ApiAssistantMessage, ApiMessage, ApiToolMessage } from '../types';
+
+/**
+ * Stand-in result for a `tool_call` the harness never recorded an answer for
+ * (aborted batch, crashed executor, context trim that severed the pair).
+ */
+export const MISSING_TOOL_RESULT_CONTENT =
+  'Tool call did not complete; no result was recorded.';
+
+function assistantToolCalls(message: ApiMessage): ApiAssistantMessage['tool_calls'] {
+  if (message.role !== 'assistant') return undefined;
+  const calls = (message as ApiAssistantMessage).tool_calls;
+  return calls?.length ? calls : undefined;
+}
+
+/**
+ * Guarantee every assistant `tool_calls` id has exactly one matching `tool` row.
+ *
+ * Every OpenAI-compatible provider 400s a history where an assistant announced a
+ * tool call with no result, or where a `tool` row answers an id nobody requested.
+ * Once such a row is persisted the chat is unsendable forever, so repair on the
+ * way out rather than trusting the loop to never orphan a call.
+ */
+export function repairUnpairedToolCalls(messages: ApiMessage[]): ApiMessage[] {
+  const out: ApiMessage[] = [];
+  const requestedIds = new Set<string>();
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+
+    if (message.role === 'tool') {
+      // A result for a call the model never made is just as fatal as a missing one.
+      if (requestedIds.has((message as ApiToolMessage).tool_call_id)) {
+        out.push(message);
+      }
+      continue;
+    }
+
+    const toolCalls = assistantToolCalls(message);
+    if (!toolCalls) {
+      out.push(message);
+      continue;
+    }
+
+    out.push(message);
+    for (const call of toolCalls) {
+      requestedIds.add(call.id);
+    }
+
+    // Consume the contiguous result block so synthesized rows land inside it.
+    const answered = new Set<string>();
+    let j = i + 1;
+    while (j < messages.length && messages[j].role === 'tool') {
+      const row = messages[j] as ApiToolMessage;
+      if (requestedIds.has(row.tool_call_id)) {
+        out.push(row);
+        answered.add(row.tool_call_id);
+      }
+      j += 1;
+    }
+    for (const call of toolCalls) {
+      if (!answered.has(call.id)) {
+        out.push({
+          role: 'tool',
+          tool_call_id: call.id,
+          content: MISSING_TOOL_RESULT_CONTENT,
+        });
+      }
+    }
+    i = j - 1;
+  }
+
+  return out;
+}
 
 function plainTextContent(message: ApiMessage): string {
   const content = message.content;

--- a/src/benchmark/matrix-scheduler.ts
+++ b/src/benchmark/matrix-scheduler.ts
@@ -2,7 +2,7 @@
  * Generic concurrency pool for target×work matrices.
  */
 
-import { runWithConcurrency } from '../lib/concurrency-pool.ts';
+import { runWithConcurrency, type PoolRunResult } from '../lib/concurrency-pool.ts';
 
 export interface MatrixWorkItem<T> {
   id: string;
@@ -23,8 +23,10 @@ export interface RunMatrixOptions<T, R> {
   worker: (ctx: MatrixWorkerContext<T, R>) => Promise<R>;
 }
 
-/** Run work items with a bounded worker pool. */
-export async function runMatrix<T, R>(options: RunMatrixOptions<T, R>): Promise<R[]> {
+/** Run work items with a bounded worker pool; `results` covers only items that ran. */
+export async function runMatrix<T, R>(
+  options: RunMatrixOptions<T, R>,
+): Promise<PoolRunResult<R>> {
   const concurrency = Math.max(1, Math.min(8, options.concurrency));
   return runWithConcurrency({
     items: options.items,

--- a/src/headless/build-messages.ts
+++ b/src/headless/build-messages.ts
@@ -2,6 +2,7 @@
  * Minimal ApiMessage builder for headless runs (no attachments / VLM).
  */
 
+import { repairUnpairedToolCalls } from '../api/provider-message-normalize';
 import type { ApiMessage, AssistantToolCallMessage, Chat } from '../types';
 
 /** Serialize chat history for the generations API (headless). */
@@ -48,5 +49,5 @@ export function buildHeadlessApiMessages(
     }
   }
 
-  return messages;
+  return repairUnpairedToolCalls(messages);
 }

--- a/src/lib/concurrency-pool.ts
+++ b/src/lib/concurrency-pool.ts
@@ -21,13 +21,27 @@ export interface RunWithConcurrencyOptions<T, R> {
   worker: (ctx: PoolWorkerContext<T, R>) => Promise<R>;
 }
 
-/** Run work items with a bounded worker pool; results preserve input order. */
+export interface PoolRunResult<R> {
+  /**
+   * Results for the items that ran, in input order. Always dense — never
+   * positionally aligned with `items`, because an abort leaves gaps.
+   */
+  results: R[];
+  /** True when the signal aborted before every item ran, so `results` is short. */
+  aborted: boolean;
+}
+
+/**
+ * Run work items with a bounded worker pool. Results preserve input order but
+ * only cover items that actually ran: workers bail on abort, so aligning the
+ * output positionally with `items` would hand callers a sparse array.
+ */
 export async function runWithConcurrency<T, R>(
   options: RunWithConcurrencyOptions<T, R>,
-): Promise<R[]> {
+): Promise<PoolRunResult<R>> {
   const signal = options.signal ?? new AbortController().signal;
   const concurrency = Math.max(1, options.concurrency);
-  const results: R[] = new Array(options.items.length);
+  const byIndex = new Map<number, R>();
   let index = 0;
 
   async function workerLoop(): Promise<void> {
@@ -39,11 +53,18 @@ export async function runWithConcurrency<T, R>(
       const item = options.items[i]!;
       options.onItemStart?.(item);
       const result = await options.worker({ item, signal });
-      results[i] = result;
+      byIndex.set(i, result);
       options.onItemDone?.(item, result);
     }
   }
 
   await Promise.all(Array.from({ length: concurrency }, () => workerLoop()));
-  return results;
+
+  const results: R[] = [];
+  for (let i = 0; i < options.items.length; i += 1) {
+    if (byIndex.has(i)) {
+      results.push(byIndex.get(i)!);
+    }
+  }
+  return { results, aborted: results.length < options.items.length };
 }

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -3,6 +3,7 @@
  * Browser tools run in TS; server tools POST to /api/tools when the local server is up.
  */
 
+import { STOPPED_TOOL_MSG } from './execute-tool-batch';
 import { executeBrowserTool } from './browser-executor';
 import { executeBoardTool } from './board-tools';
 import { executeTodoWrite } from './todo-tools';
@@ -197,17 +198,35 @@ export async function refreshPluginToolCache(): Promise<void> {
   }
 }
 
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
+  );
+}
+
 export async function executeTool(
   name: string,
   args: Record<string, unknown> = {},
   context: ExecuteToolContext = {},
 ): Promise<ToolExecutionResult> {
-  return runWithFileTreeAutoRefresh(
-    name,
-    () => executeToolInner(name, args, context),
-    context,
-    args,
-  );
+  try {
+    return await runWithFileTreeAutoRefresh(
+      name,
+      () => executeToolInner(name, args, context),
+      context,
+      args,
+    );
+  } catch (err) {
+    // A throwing executor used to unwind the whole tool batch, leaving the
+    // assistant `tool_calls` row unanswered and the chat unsendable. Every tool
+    // failure has to come back as a result instead. The "Error: " prefix is
+    // protocol — callers branch on it and the result cache refuses to store it.
+    if (isAbortError(err)) {
+      return { content: STOPPED_TOOL_MSG };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${message || 'tool execution failed'}` };
+  }
 }
 
 async function executeToolInner(
@@ -325,7 +344,11 @@ async function executeToolInner(
     }
     const blocked = await maybeBlockToolForUserApproval(name, args, context, name);
     if (blocked) return blocked;
-    return executeServerTool(name, args, context.modeId, context);
+    // MCP/plugin tools are never cacheable, but they can write files the file
+    // tools cached reads for — route through the wrapper for its invalidation.
+    return executeWithResultCache(name, args, context, () =>
+      executeServerTool(name, args, context.modeId, context),
+    );
   }
 
   if (

--- a/src/tools/execute-tool-batch.ts
+++ b/src/tools/execute-tool-batch.ts
@@ -40,11 +40,17 @@ async function runSingleToolCall(
     constrained: options.constrained,
   });
 
+  // onToolDone is what appends the `tool` history row, so an aborted call still
+  // has to route through it — otherwise the assistant tool_call is left orphaned
+  // and every later send 400s on the unpaired tool_call_id.
   if (options.signal?.aborted) {
-    return {
+    const stopped: ToolCallOutcome = {
       toolCall: tc,
       result: { content: STOPPED_TOOL_MSG },
     };
+    options.onToolStart?.(tc, args);
+    options.onToolDone?.(stopped);
+    return stopped;
   }
 
   options.onToolStart?.(tc, args);
@@ -66,6 +72,11 @@ async function runSingleToolCall(
 /**
  * Execute tool calls with parallel segments for read-only tools and sequential
  * segments for mutating / interactive tools. Outcomes are in original order.
+ *
+ * Invariant: every call in `toolCalls` produces exactly one `onToolDone`, even
+ * when the batch is aborted. Callers append the `tool` history row from that
+ * callback, so a skipped call would orphan its assistant `tool_call_id` and make
+ * every subsequent request to the provider fail.
  */
 export async function executeToolCallBatch(
   options: ExecuteToolBatchOptions,
@@ -73,19 +84,25 @@ export async function executeToolCallBatch(
   const segments = partitionToolCalls(options.toolCalls);
   const outcomeById = new Map<string, ToolCallOutcome>();
 
+  /** Emit a stopped outcome for any call that never ran, in call order. */
+  function fillStopped(calls: ToolCall[]): void {
+    for (const tc of calls) {
+      if (outcomeById.has(tc.id)) {
+        continue;
+      }
+      const stopped: ToolCallOutcome = {
+        toolCall: tc,
+        result: { content: STOPPED_TOOL_MSG },
+      };
+      options.onToolStart?.(tc, {});
+      options.onToolDone?.(stopped);
+      outcomeById.set(tc.id, stopped);
+    }
+  }
+
   for (const segment of segments) {
     if (options.signal?.aborted) {
-      for (const tc of segment.calls) {
-        if (!outcomeById.has(tc.id)) {
-          const stopped: ToolCallOutcome = {
-            toolCall: tc,
-            result: { content: STOPPED_TOOL_MSG },
-          };
-          options.onToolStart?.(tc, {});
-          options.onToolDone?.(stopped);
-          outcomeById.set(tc.id, stopped);
-        }
-      }
+      fillStopped(segment.calls);
       continue;
     }
 
@@ -97,6 +114,9 @@ export async function executeToolCallBatch(
           break;
         }
       }
+      // Sequential segments hold one call today, but the break above would
+      // otherwise silently drop the tail if that ever changes.
+      fillStopped(segment.calls);
       continue;
     }
 
@@ -107,26 +127,26 @@ export async function executeToolCallBatch(
       payload: tc,
     }));
 
-    const segmentOutcomes = await runWithConcurrency<ToolCall, ToolCallOutcome>({
+    const segmentRun = await runWithConcurrency<ToolCall, ToolCallOutcome>({
       items: poolItems,
       concurrency: Math.min(MAX_PARALLEL_READ_TOOLS, segment.calls.length),
       signal: options.signal,
       worker: async ({ item }) => runSingleToolCall(item.payload, options),
     });
 
-    for (const outcome of segmentOutcomes) {
+    for (const outcome of segmentRun.results) {
       outcomeById.set(outcome.toolCall.id, outcome);
+    }
+
+    // With more parallel-safe calls than pool workers, an abort leaves calls the
+    // pool never picked up. Fill them here rather than after every segment so the
+    // emitted rows stay in call order.
+    if (segmentRun.aborted) {
+      fillStopped(segment.calls);
     }
   }
 
-  return options.toolCalls.map((tc) => {
-    const outcome = outcomeById.get(tc.id);
-    if (outcome) {
-      return outcome;
-    }
-    return {
-      toolCall: tc,
-      result: { content: STOPPED_TOOL_MSG },
-    };
-  });
+  fillStopped(options.toolCalls);
+
+  return options.toolCalls.map((tc) => outcomeById.get(tc.id)!);
 }

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -62,7 +62,10 @@ import {
 } from '../api/chat';
 import { applyClassifiedStreamEnd, classifyStreamEnd } from '../api/stream-end';
 import { getLatestStreamingToolName } from '../api/tool-call-stream.ts';
-import { foldLeadingAssistantPreamble } from '../api/provider-message-normalize';
+import {
+  foldLeadingAssistantPreamble,
+  repairUnpairedToolCalls,
+} from '../api/provider-message-normalize';
 import { recordMainChatTurnUsage } from '../usage/record-chat-usage';
 import {
   extractInlineThinkingFromContent,
@@ -747,7 +750,7 @@ export function buildApiMessages(
     messages.push({ role: 'user', content: continueLine });
   }
 
-  return foldLeadingAssistantPreamble(messages);
+  return repairUnpairedToolCalls(foldLeadingAssistantPreamble(messages));
 }
 
 interface StreamTurnResult {

--- a/src/tools/result-cache.ts
+++ b/src/tools/result-cache.ts
@@ -100,6 +100,35 @@ const saveFileInvalidation: InvalidationRule = {
   pathFromArgs: (_, args) => pathKeysFromArgs(args, PATH_WRITE_KEYS),
 };
 
+/**
+ * Shell and extension tools write files without going through a Minnow file tool,
+ * so nothing in {@link INVALIDATION_MAP} can name the paths they touched. Reads are
+ * cached with an indefinite TTL, so without this a `prettier --write` (or any MCP
+ * server that edits files) leaves the model reading pre-write content for the rest
+ * of the session. Bust everything path-scoped rather than guess.
+ */
+const opaqueWriteInvalidation: InvalidationRule = {
+  invalidateTools: FILE_AND_GIT_READ_INVALIDATION_TARGETS,
+  pathFromArgs: () => ['**'],
+};
+
+/** Tools that run arbitrary user code and may touch any file in the workspace. */
+const OPAQUE_WRITE_TOOLS = new Set([
+  'execute_command',
+  'run_javascript',
+  'run_python',
+  'start_background_command',
+]);
+
+/** True when a tool can mutate the workspace in ways its args do not describe. */
+function isOpaqueWriteTool(name: string): boolean {
+  return (
+    OPAQUE_WRITE_TOOLS.has(name) ||
+    name.startsWith('mcp__') ||
+    name.startsWith('plugin__')
+  );
+}
+
 const INVALIDATION_MAP: Record<string, InvalidationRule> = {
   save_file: saveFileInvalidation,
   create_pdf: saveFileInvalidation,
@@ -473,6 +502,9 @@ export function invalidateAfterTool(
   let rule = INVALIDATION_MAP[name];
   if (!rule && FILE_TREE_MUTATING_TOOLS.has(name)) {
     rule = saveFileInvalidation;
+  }
+  if (!rule && isOpaqueWriteTool(name)) {
+    rule = opaqueWriteInvalidation;
   }
   if (!rule) return;
 

--- a/test/generations/fallback.test.mjs
+++ b/test/generations/fallback.test.mjs
@@ -8,6 +8,8 @@ import {
   buildCandidateRequestBody,
   candidateKey,
   classifyUpstreamError,
+  computeRetryDelayMs,
+  parseRetryAfterMs,
   resolveFallbackChain,
 } from '../../server/generations/fallback.js';
 import {
@@ -156,6 +158,92 @@ describe('classifyUpstreamError', () => {
 
   test('abort is fatal', () => {
     assert.equal(classifyUpstreamError({ name: 'AbortError' }).kind, 'fatal');
+  });
+
+  test('rate limit and overload statuses are retryable, not fatal', () => {
+    for (const status of [408, 425, 429, 529]) {
+      const classified = classifyUpstreamError(null, { status });
+      assert.equal(classified.kind, 'retryable', `HTTP ${status}`);
+      assert.equal(classified.rateLimited, true, `HTTP ${status}`);
+    }
+  });
+
+  test('502/503/504 are retryable but not rate limits', () => {
+    for (const status of [502, 503, 504]) {
+      const classified = classifyUpstreamError(null, { status });
+      assert.equal(classified.kind, 'retryable');
+      assert.notEqual(classified.rateLimited, true);
+    }
+  });
+
+  test('Retry-After seconds are carried on the classification', () => {
+    const classified = classifyUpstreamError(null, {
+      status: 429,
+      headers: new Headers({ 'retry-after': '12' }),
+    });
+    assert.equal(classified.retryAfterMs, 12_000);
+  });
+
+  test('Retry-After survives a plain header object', () => {
+    const classified = classifyUpstreamError(null, {
+      status: 429,
+      headers: { 'retry-after': '3' },
+    });
+    assert.equal(classified.retryAfterMs, 3_000);
+  });
+
+  test('a 429 without Retry-After leaves the delay to backoff', () => {
+    const classified = classifyUpstreamError(null, { status: 429 });
+    assert.equal(classified.retryAfterMs, undefined);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  test('parses delta-seconds', () => {
+    assert.equal(parseRetryAfterMs('5'), 5_000);
+    assert.equal(parseRetryAfterMs(' 0 '), 0);
+  });
+
+  test('parses an HTTP-date relative to now', () => {
+    const now = Date.parse('2026-01-01T00:00:00Z');
+    const at = new Date(now + 8_000).toUTCString();
+    assert.equal(parseRetryAfterMs(at, now), 8_000);
+  });
+
+  test('a past HTTP-date clamps to zero', () => {
+    const now = Date.parse('2026-01-01T00:00:00Z');
+    const at = new Date(now - 60_000).toUTCString();
+    assert.equal(parseRetryAfterMs(at, now), 0);
+  });
+
+  test('an absurd wait is capped so a turn cannot stall indefinitely', () => {
+    assert.equal(parseRetryAfterMs('86400'), 30_000);
+  });
+
+  test('missing or unparseable values yield null', () => {
+    assert.equal(parseRetryAfterMs(undefined), null);
+    assert.equal(parseRetryAfterMs(''), null);
+    assert.equal(parseRetryAfterMs('soon'), null);
+    assert.equal(parseRetryAfterMs('-4'), null);
+  });
+});
+
+describe('computeRetryDelayMs', () => {
+  test('honours Retry-After over backoff', () => {
+    assert.equal(computeRetryDelayMs(1, 7_000), 7_000);
+    assert.equal(computeRetryDelayMs(3, 250), 250);
+  });
+
+  test('backs off exponentially with jitter when no Retry-After', () => {
+    const first = computeRetryDelayMs(1);
+    const second = computeRetryDelayMs(2);
+    assert.ok(first >= 1_000 && first <= 2_000, `first=${first}`);
+    assert.ok(second >= 2_000 && second <= 3_000, `second=${second}`);
+  });
+
+  test('never exceeds the cap', () => {
+    assert.equal(computeRetryDelayMs(20, 10 ** 9), 30_000);
+    assert.ok(computeRetryDelayMs(20) <= 30_000);
   });
 });
 

--- a/test/generations/upstream-failover.test.mjs
+++ b/test/generations/upstream-failover.test.mjs
@@ -217,3 +217,120 @@ describe('upstream failover', () => {
     await new Promise((resolve) => emptyServer.close(resolve));
   });
 });
+
+describe('rate limit retries', () => {
+  /**
+   * Stand up an upstream that 429s a fixed number of times before streaming.
+   * @param {{ failures: number, retryAfter?: string }} options
+   */
+  async function startRateLimitedServer({ failures, retryAfter }) {
+    let calls = 0;
+    const server = http.createServer((req, res) => {
+      if (req.method !== 'POST') {
+        res.statusCode = 404;
+        res.end('not found');
+        return;
+      }
+      calls += 1;
+      if (calls <= failures) {
+        const headers = { 'Content-Type': 'text/plain' };
+        if (retryAfter) headers['Retry-After'] = retryAfter;
+        res.writeHead(429, headers);
+        res.end('rate limited');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.end('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n');
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = /** @type {import('net').AddressInfo} */ (server.address()).port;
+    return { server, baseUrl: `http://127.0.0.1:${port}`, calls: () => calls };
+  }
+
+  test('retries the same candidate through 429s instead of failing the turn', async () => {
+    resetHostCooldownForTests();
+    const upstream = await startRateLimitedServer({ failures: 2, retryAfter: '0' });
+    await createProvider({
+      id: 'rate-limited',
+      label: 'Rate limited',
+      baseUrl: upstream.baseUrl,
+      apiKind: 'openai-v1',
+    });
+
+    const state = createGenerationState({
+      providerId: 'rate-limited',
+      body: { model: 'test-model', messages: [{ role: 'user', content: 'hi' }] },
+      candidates: [{ providerId: 'rate-limited', modelId: 'test-model' }],
+    });
+
+    pumpUpstream({ state });
+    const terminal = await waitForTerminal(state.id, 15_000);
+
+    assert.equal(terminal.status, 'complete');
+    assert.equal(terminal.fallbackUsed, false);
+    assert.equal(terminal.chosenProviderId, 'rate-limited');
+    assert.equal(upstream.calls(), 3, 'one initial attempt plus two retries');
+
+    await new Promise((resolve) => upstream.server.close(resolve));
+  });
+
+  test('a persistently rate-limited candidate errors after the attempt cap', async () => {
+    resetHostCooldownForTests();
+    const upstream = await startRateLimitedServer({
+      failures: Number.MAX_SAFE_INTEGER,
+      retryAfter: '0',
+    });
+    await createProvider({
+      id: 'always-limited',
+      label: 'Always limited',
+      baseUrl: upstream.baseUrl,
+      apiKind: 'openai-v1',
+    });
+
+    const state = createGenerationState({
+      providerId: 'always-limited',
+      body: { model: 'test-model', messages: [{ role: 'user', content: 'hi' }] },
+      candidates: [{ providerId: 'always-limited', modelId: 'test-model' }],
+    });
+
+    pumpUpstream({ state });
+    const terminal = await waitForTerminal(state.id, 15_000);
+
+    assert.equal(terminal.status, 'error');
+    assert.match(terminal.errorMessage ?? '', /429/);
+    assert.equal(upstream.calls(), 3, 'capped at MAX_SAME_CANDIDATE_ATTEMPTS');
+
+    await new Promise((resolve) => upstream.server.close(resolve));
+  });
+
+  test('a rate-limited host is not put into cooldown', async () => {
+    resetHostCooldownForTests();
+    const upstream = await startRateLimitedServer({ failures: 1, retryAfter: '0' });
+    await createProvider({
+      id: 'limited-once',
+      label: 'Limited once',
+      baseUrl: upstream.baseUrl,
+      apiKind: 'openai-v1',
+    });
+
+    const first = createGenerationState({
+      providerId: 'limited-once',
+      body: { model: 'test-model', messages: [{ role: 'user', content: 'hi' }] },
+      candidates: [{ providerId: 'limited-once', modelId: 'test-model' }],
+    });
+    pumpUpstream({ state: first });
+    assert.equal((await waitForTerminal(first.id, 15_000)).status, 'complete');
+
+    const second = createGenerationState({
+      providerId: 'limited-once',
+      body: { model: 'test-model', messages: [{ role: 'user', content: 'hi' }] },
+      candidates: [{ providerId: 'limited-once', modelId: 'test-model' }],
+    });
+    pumpUpstream({ state: second });
+    const terminal = await waitForTerminal(second.id, 15_000);
+
+    assert.equal(terminal.status, 'complete', 'host must not be in cooldown');
+
+    await new Promise((resolve) => upstream.server.close(resolve));
+  });
+});

--- a/test/tools/build-api-messages-pairing.test.mts
+++ b/test/tools/build-api-messages-pairing.test.mts
@@ -1,0 +1,134 @@
+/**
+ * Outbound histories must never carry an assistant tool_call without a matching
+ * tool result — every OpenAI-compatible provider 400s it, which makes the chat
+ * permanently unsendable.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  MISSING_TOOL_RESULT_CONTENT,
+  repairUnpairedToolCalls,
+} from '../../src/api/provider-message-normalize.ts';
+import { buildHeadlessApiMessages } from '../../src/headless/build-messages.ts';
+import type { ApiMessage, Chat, ToolCall } from '../../src/types.ts';
+
+function call(id: string, name = 'read_file'): ToolCall {
+  return { id, type: 'function', function: { name, arguments: '{}' } };
+}
+
+function assistantWithCalls(ids: string[]): ApiMessage {
+  return { role: 'assistant', content: null, tool_calls: ids.map((id) => call(id)) };
+}
+
+function toolRow(id: string, content = 'ok'): ApiMessage {
+  return { role: 'tool', tool_call_id: id, content };
+}
+
+function toolIds(messages: ApiMessage[]): string[] {
+  return messages
+    .filter((m) => m.role === 'tool')
+    .map((m) => (m as { tool_call_id: string }).tool_call_id);
+}
+
+describe('repairUnpairedToolCalls', () => {
+  test('leaves a fully paired history untouched', () => {
+    const messages: ApiMessage[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'go' },
+      assistantWithCalls(['a', 'b']),
+      toolRow('a'),
+      toolRow('b'),
+      { role: 'assistant', content: 'done' },
+    ];
+
+    const out = repairUnpairedToolCalls(messages);
+
+    assert.deepEqual(out, messages);
+  });
+
+  test('synthesizes a result per unanswered id, in call order', () => {
+    const messages: ApiMessage[] = [
+      { role: 'user', content: 'go' },
+      assistantWithCalls(['a', 'b', 'c']),
+      toolRow('b'),
+    ];
+
+    const out = repairUnpairedToolCalls(messages);
+
+    assert.deepEqual(toolIds(out), ['b', 'a', 'c']);
+    const synthesized = out.filter(
+      (m) => m.role === 'tool' && m.content === MISSING_TOOL_RESULT_CONTENT,
+    );
+    assert.equal(synthesized.length, 2);
+  });
+
+  test('repairs an assistant tool_calls row with no results at all', () => {
+    const messages: ApiMessage[] = [
+      { role: 'user', content: 'go' },
+      assistantWithCalls(['a', 'b']),
+    ];
+
+    const out = repairUnpairedToolCalls(messages);
+
+    assert.deepEqual(toolIds(out), ['a', 'b']);
+    assert.equal(out.length, 4);
+  });
+
+  test('repairs every batch in a multi-round history', () => {
+    const messages: ApiMessage[] = [
+      { role: 'user', content: 'go' },
+      assistantWithCalls(['a']),
+      toolRow('a'),
+      assistantWithCalls(['b', 'c']),
+      toolRow('b'),
+      { role: 'assistant', content: 'summary' },
+    ];
+
+    const out = repairUnpairedToolCalls(messages);
+
+    assert.deepEqual(toolIds(out), ['a', 'b', 'c']);
+    assert.equal(out[out.length - 1].content, 'summary');
+  });
+
+  test('drops a tool result whose call was never requested', () => {
+    const messages: ApiMessage[] = [
+      { role: 'user', content: 'go' },
+      toolRow('ghost'),
+      assistantWithCalls(['a']),
+      toolRow('a'),
+    ];
+
+    const out = repairUnpairedToolCalls(messages);
+
+    assert.deepEqual(toolIds(out), ['a']);
+  });
+
+  test('preserves the original result objects', () => {
+    const kept = toolRow('a', 'real output');
+    const out = repairUnpairedToolCalls([assistantWithCalls(['a', 'b']), kept]);
+
+    assert.equal(out[1], kept);
+  });
+});
+
+describe('buildHeadlessApiMessages pairing', () => {
+  test('an orphaned tool_calls row is repaired on the send path', () => {
+    const chat = {
+      history: [
+        { role: 'user', content: 'go' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [call('a'), call('b')],
+        },
+        { role: 'tool', tool_call_id: 'a', content: 'ok' },
+      ],
+    } as unknown as Chat;
+
+    const messages = buildHeadlessApiMessages(chat, 'sys');
+
+    assert.deepEqual(toolIds(messages), ['a', 'b']);
+    assert.equal(messages[messages.length - 1].content, MISSING_TOOL_RESULT_CONTENT);
+  });
+});

--- a/test/tools/execute-tool-batch.test.mts
+++ b/test/tools/execute-tool-batch.test.mts
@@ -115,6 +115,58 @@ describe('executeToolCallBatch', () => {
     assert.equal(outcomes[2]!.result?.content, STOPPED_TOOL_MSG);
   });
 
+  test('abort past the pool worker cap leaves no gaps', async () => {
+    // The pool runs min(6, n) workers, so >6 parallel-safe calls means an abort
+    // leaves calls the pool never picked up.
+    const controller = new AbortController();
+    const ids = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+    const calls = ids.map((id) => tc('read_file', id));
+    const done: string[] = [];
+
+    const outcomes = await executeToolCallBatch({
+      toolCalls: calls,
+      signal: controller.signal,
+      execute: async (name) => {
+        controller.abort();
+        await delay(5);
+        return { content: name };
+      },
+      onToolDone: (outcome) => done.push(outcome.toolCall.id),
+    });
+
+    assert.equal(outcomes.length, ids.length);
+    assert.deepEqual(
+      outcomes.map((o) => o.toolCall.id),
+      ids,
+    );
+    for (const outcome of outcomes) {
+      assert.ok(outcome.result || outcome.parseError, `no result for ${outcome.toolCall.id}`);
+    }
+    // Every call must report exactly once or its tool_call_id is left unpaired.
+    assert.deepEqual([...done].sort(), [...ids].sort());
+    assert.equal(done.length, ids.length);
+  });
+
+  test('abort part-way through mutating calls still reports every call', async () => {
+    const controller = new AbortController();
+    const calls = [tc('save_file', 'a'), tc('save_file', 'b'), tc('save_file', 'c')];
+    const done: string[] = [];
+
+    const outcomes = await executeToolCallBatch({
+      toolCalls: calls,
+      signal: controller.signal,
+      execute: async (name) => {
+        controller.abort();
+        return { content: name };
+      },
+      onToolDone: (outcome) => done.push(outcome.toolCall.id),
+    });
+
+    assert.deepEqual(done, ['a', 'b', 'c']);
+    assert.equal(outcomes[1]!.result?.content, STOPPED_TOOL_MSG);
+    assert.equal(outcomes[2]!.result?.content, STOPPED_TOOL_MSG);
+  });
+
   test('onToolStart and onToolDone fire for each call', async () => {
     const starts: string[] = [];
     const done: string[] = [];

--- a/test/tools/result-cache.test.mts
+++ b/test/tools/result-cache.test.mts
@@ -113,6 +113,88 @@ describe('invalidation', () => {
     assert.equal(getCachedResult(scope, key), undefined);
   });
 
+  test('execute_command busts cached file and git reads', () => {
+    const scope = testScope();
+    const readKey = buildCacheKey(
+      'read_file',
+      normalizeToolArgs('read_file', { path: 'src/foo.ts' }),
+    );
+    const gitKey = buildCacheKey('git_status', normalizeToolArgs('git_status', {}));
+    setCachedResult(scope, readKey, { content: 'pre-format' }, getCachePolicyForTool('read_file'));
+    setCachedResult(scope, gitKey, { content: 'stale' }, getCachePolicyForTool('git_status'));
+
+    invalidateAfterTool(
+      scope,
+      'execute_command',
+      { command: 'npx prettier --write src/foo.ts' },
+      { content: 'done' },
+    );
+
+    assert.equal(getCachedResult(scope, readKey), undefined);
+    assert.equal(getCachedResult(scope, gitKey), undefined);
+  });
+
+  for (const shellTool of ['run_javascript', 'run_python', 'start_background_command']) {
+    test(`${shellTool} busts cached reads`, () => {
+      const scope = testScope();
+      const readKey = buildCacheKey(
+        'read_file',
+        normalizeToolArgs('read_file', { path: 'src/foo.ts' }),
+      );
+      setCachedResult(scope, readKey, { content: 'stale' }, getCachePolicyForTool('read_file'));
+
+      invalidateAfterTool(scope, shellTool, {}, { content: 'ok' });
+
+      assert.equal(getCachedResult(scope, readKey), undefined);
+    });
+  }
+
+  test('mcp and plugin tools bust cached reads', () => {
+    for (const toolName of ['mcp__server__write_thing', 'plugin__pkg__edit']) {
+      const scope = testScope();
+      const readKey = buildCacheKey(
+        'read_file',
+        normalizeToolArgs('read_file', { path: 'src/foo.ts' }),
+      );
+      setCachedResult(scope, readKey, { content: 'stale' }, getCachePolicyForTool('read_file'));
+
+      invalidateAfterTool(scope, toolName, {}, { content: 'ok' });
+
+      assert.equal(getCachedResult(scope, readKey), undefined, toolName);
+    }
+  });
+
+  test('a failed shell command leaves the cache intact', () => {
+    const scope = testScope();
+    const readKey = buildCacheKey(
+      'read_file',
+      normalizeToolArgs('read_file', { path: 'src/foo.ts' }),
+    );
+    setCachedResult(scope, readKey, { content: 'body' }, getCachePolicyForTool('read_file'));
+
+    invalidateAfterTool(
+      scope,
+      'execute_command',
+      { command: 'nope' },
+      { content: 'Error: command not found' },
+    );
+
+    assert.equal(getCachedResult(scope, readKey)?.content, 'body');
+  });
+
+  test('read-only shell tools do not bust the cache', () => {
+    const scope = testScope();
+    const readKey = buildCacheKey(
+      'read_file',
+      normalizeToolArgs('read_file', { path: 'src/foo.ts' }),
+    );
+    setCachedResult(scope, readKey, { content: 'body' }, getCachePolicyForTool('read_file'));
+
+    invalidateAfterTool(scope, 'list_running_commands', {}, { content: 'none' });
+
+    assert.equal(getCachedResult(scope, readKey)?.content, 'body');
+  });
+
   test('save_file busts cached git_status', () => {
     const policy = getCachePolicyForTool('git_status');
     const gitKey = buildCacheKey('git_status', normalizeToolArgs('git_status', {}));


### PR DESCRIPTION
Phase 1 of the harness correctness review. Four independent fixes for ways a long agentic run loses the turn — or the whole chat — in a way the user reads as "the model got confused" rather than "the harness dropped it". Each is landable alone; nothing here depends on anything else.

## H1 — sparse-array crash in the parallel tool batch

`runWithConcurrency` allocated `new Array(items.length)` and `return`ed from `workerLoop` on abort, leaving holes. Hitting **Stop** mid-batch with more than six parallel-safe calls (the pool runs `min(6, n)` workers, so holes only appear above six) threw `TypeError: Cannot read properties of undefined (reading 'toolCall')`.

- `runWithConcurrency` now returns `{ results, aborted }` with `results` always dense. The shape change rather than a fill because `R` is generic — there is no value to fill a hole *with* — and because a bare compacted `R[]` would silently misalign positionally for a future caller. `runMatrix` forwards it; `campaign-runner` discards the return, so nothing else moved.
- `executeToolCallBatch` collapses its three separate "stopped" paths into one `fillStopped` helper, making **exactly one `onToolDone` per call** an invariant. Two orphan paths existed beyond the pool: `runSingleToolCall`'s aborted early-return, and the tail `map`, which synthesized `STOPPED` outcomes into the *return value* without firing the callback — and since `chat-tool-batch` discards the return value and appends the `tool` history row only from `onToolDone`, those were orphaned too.

## H2 — tool-call pairing as an invariant

An assistant row carrying `tool_calls` with no matching `tool` rows was sent verbatim, and every OpenAI-compatible provider 400s it. Once persisted, the chat is unsendable forever. Repair existed (`resumeIncompleteToolBatchOnChatSwitch`) but only on chat switch — never on the send path.

- New `repairUnpairedToolCalls` in `src/api/provider-message-normalize.ts` synthesizes a result for every unanswered `tool_call_id`, and drops `tool` rows answering an id nobody requested (which 400s just as hard). Wired into `buildApiMessages`, `buildHeadlessApiMessages`, and the sub-agent runner — in place right after `enforceContextBudget`, since context trimming is the thing that can sever a pair and the runner has ~10 send sites off one mutable array.
- `executeTool` gains a top-level catch. A throwing browser-side executor previously unwound the entire batch *before* `recordChatMessage`, which is precisely how a chat became permanently unsendable. The `"Error: "` prefix is load-bearing protocol (`isErrorToolResult` and ~5 branches in `client.ts`) and is preserved; aborts map to `Stopped by user.`

## H3 — cache invalidation for non-tool writes

File reads cache with `ttlMs: 0` (never expires) and `INVALIDATION_MAP` had no entry for the shell tools or `mcp__*` / `plugin__*`, so a `prettier --write` through `execute_command` left the model reading pre-write content for the rest of the session.

- `execute_command`, `run_javascript`, `run_python`, `start_background_command`, and any `mcp__*` / `plugin__*` name now bust `FILE_AND_GIT_READ_INVALIDATION_TARGETS` with the `['**']` prefix `git_checkout` already uses.
- MCP/plugin tools also needed routing through `executeWithResultCache` — they bypassed it entirely, so the new rule would have been dead code for them. They stay non-cacheable; the wrapper is there purely for its invalidation.

**Deferred:** the precise `mtimeMs` + size revalidation of cached reads. It needs a server stat endpoint and read-result stamping that the H6 `file-read-registry` introduces, and the plan schedules it to be built alongside that (§2.3). The coarse layer fully covers the end-to-end check below; external-editor writes stay stale until then.

## H4 — retry rate limits instead of dying

`classifyUpstreamError` treated everything under 500 as fatal, **including 429**. Worse, `canFailover = index < candidates.length - 1` — with fallback chains disabled by default there is no next candidate, so *every* retryable error was already being converted to fatal.

- 408 / 425 / 429 / 529 are now retryable and flagged `rateLimited`, with `Retry-After` parsed (delta-seconds and HTTP-date, capped at 30s so a turn cannot stall indefinitely).
- The attempt functions now report retryability on their own merits and the candidate loop owns the policy: **rate limits** always re-run the same candidate (2 retries, `Retry-After` or exponential backoff + jitter); **other transient errors** re-run the same candidate only when there is nothing to fail over to, so a configured chain still switches immediately exactly as before; **timeouts** never re-run the same candidate, since each attempt costs the full timeout budget and a wedged host will not unwedge in seconds.
- `markHostDead` moved out of the attempt functions into the give-up branch — the ordering trap called out in the review, where marking before returning `retry` trips the `isHostDead` pre-flight on our own next attempt. It is additionally gated on `canFailover`: cooling off the sole provider after one 503 would break the *next* turn too.
- `!bytesEmitted` remains the precondition for every retry.

**Not done:** the status-strip "rate limited, retrying in 12s". The generation stream is raw SSE replayed to subscribers with no side channel to the client, so surfacing it means new stream protocol — out of place inside a correctness fix. It logs server-side today.

## Testing

```
npx tsc --noEmit
npm test
npm run test:check-coverage
```

Full-suite failures are byte-identical to the pre-change baseline (17 pre-existing environment failures: missing `electron`, missing `go`, asar packaging paths). Verified by stashing the changes and diffing the failing-test list.

Each fix was confirmed to fail before the change:

- the new `execute-tool-batch` test reproduces the original `TypeError` against unpatched `src/lib/` + `src/tools/`
- all three H4 integration tests fail against unpatched `server/generations/`

New coverage: a ≥7-call batch aborted mid-flight (no throw, outcomes in input order, one `onToolDone` per call); `repairUnpairedToolCalls` unit tests plus a `buildHeadlessApiMessages` send-path case; shell/MCP/plugin cache busting including the failed-command and read-only-shell negative cases; 429/529/`Retry-After` classification, `parseRetryAfterMs`, `computeRetryDelayMs`; and real `node:http` servers that 429 twice then stream, asserting one candidate, three attempts, no failover, no cooldown.

## Reviewer notes

- The `runWithConcurrency` return type changed. Both call sites are updated; `runMatrix`'s return was already discarded by its only consumer.
- `src/tools/client.ts` now imports `STOPPED_TOOL_MSG` from `./execute-tool-batch`. No new cycle — `chat-tool-batch` already imports both.
- H4 deliberately preserves existing failover latency for 5xx and network errors when a chain is configured, so the two existing failover tests are unchanged.

## End-to-end (from the review's Phase 1 checklist)

1. Build mode, ask for ten files in one turn, hit **Stop** mid-batch → clean stop, every tool row present, and the next message **sends** rather than 400ing.
2. Read a file, `npx prettier --write` it through `execute_command`, read again → formatted content, not the cached copy.

## Follow-up

`server/session/engine-bundle/engine-bundle.mjs` carries compiled copies of both `runWithConcurrency` and `executeToolCallBatch` (lines 18990, 19270). It is referenced by nothing, produced by no build script, now diverges further from source, and polluted every grep during this work. The Phase 3.4 housekeeping deletion is worth pulling forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
