### PR TITLE
Fix MCP tool dispatch and surface MCP tools in permissions

### DIFF
--- a/server/mcp/bridge.js
+++ b/server/mcp/bridge.js
@@ -1,5 +1,11 @@
 /**
  * MCP tool namespacing and OpenAI function definition mapping.
+ *
+ * Encoding folds `-` into `_` to stay inside the function-name charset, so it is
+ * lossy: `browser_navigate` and `browser-navigate` both encode to the same id.
+ * Decoding therefore cannot recover the server's own spelling — dispatch must
+ * resolve against the live tool listing (see `resolveMcpToolName` in registry.js)
+ * and treat this parse as a hint only.
  */
 
 /** mcp__<serverId>__<toolName> */
@@ -8,13 +14,23 @@ export function toNamespacedName(serverId, toolName) {
   return `mcp__${serverId}__${safeTool}`;
 }
 
+/**
+ * Split `mcp__<serverId>__<toolName>`.
+ * `toolName` keeps the encoded spelling; `toolNameCandidates` holds every
+ * spelling that could have produced it, most likely first.
+ */
 export function parseNamespacedName(name) {
-  if (!name.startsWith('mcp__')) return null;
+  if (typeof name !== 'string' || !name.startsWith('mcp__')) return null;
   const parts = name.slice(5).split('__');
   if (parts.length < 2) return null;
   const serverId = parts[0];
-  const toolName = parts.slice(1).join('__').replace(/_/g, '-');
-  return { serverId, toolName };
+  const encoded = parts.slice(1).join('__');
+  const dashed = encoded.replace(/_/g, '-');
+  return {
+    serverId,
+    toolName: encoded,
+    toolNameCandidates: dashed === encoded ? [encoded] : [encoded, dashed],
+  };
 }
 
 /**

--- a/server/mcp/middleware.js
+++ b/server/mcp/middleware.js
@@ -9,6 +9,7 @@ import {
   ensureMcpSeed,
   listServers,
   listEnabledMcpTools,
+  listMcpToolCatalog,
   callMcpTool,
   reloadMcp,
   createMcpServer,
@@ -92,6 +93,11 @@ export function createMcpMiddleware() {
       if (url === '/api/mcp/tools' && req.method === 'GET') {
         const tools = await listEnabledMcpTools();
         sendJson(res, 200, { tools });
+        return;
+      }
+
+      if (url === '/api/mcp/tools/catalog' && req.method === 'GET') {
+        sendJson(res, 200, { servers: await listMcpToolCatalog() });
         return;
       }
 

--- a/server/mcp/registry.js
+++ b/server/mcp/registry.js
@@ -65,6 +65,35 @@ function createFixtureClient() {
   };
 }
 
+/**
+ * Cache namespaced id → the server's own tool name, so dispatch never has to
+ * guess it back out of the lossy encoding.
+ * @param {string} serverId
+ * @param {Array<{ name: string }>} tools
+ */
+function rememberTools(serverId, tools) {
+  const map = new Map();
+  for (const tool of tools ?? []) {
+    const key = toNamespacedName(serverId, tool.name);
+    // `get-docs` and `get_docs` encode to the same id; the first listing wins.
+    if (!map.has(key)) map.set(key, tool.name);
+  }
+  toolMaps.set(serverId, map);
+  return map;
+}
+
+/**
+ * Real tool name for a namespaced id, preferring the live listing over the
+ * lossy decode. Returns `null` when the server does not expose the tool.
+ * @param {string} namespacedName
+ * @param {{ serverId: string, toolName: string }} parsed
+ */
+function resolveMcpToolName(namespacedName, parsed) {
+  const map = toolMaps.get(parsed.serverId);
+  if (!map) return { toolName: parsed.toolName, known: [] };
+  return { toolName: map.get(namespacedName) ?? null, known: [...map.values()] };
+}
+
 async function connectServer(serverId, config) {
   if (clients.has(serverId)) {
     return clients.get(serverId);
@@ -72,13 +101,9 @@ async function connectServer(serverId, config) {
 
   if (serverId === 'fixture') {
     const client = createFixtureClient();
-    const map = new Map();
-    map.set(toNamespacedName('fixture', 'echo'), {
-      serverId: 'fixture',
-      toolName: 'echo',
-    });
+    const listed = await client.listTools();
+    rememberTools(serverId, listed.tools ?? []);
     clients.set(serverId, client);
-    toolMaps.set(serverId, map);
     return client;
   }
 
@@ -102,16 +127,8 @@ async function connectServer(serverId, config) {
   );
   await client.connect(transport);
   const listed = await client.listTools();
-  const tools = listed.tools ?? [];
-  const map = new Map();
-  for (const tool of tools) {
-    map.set(toNamespacedName(serverId, tool.name), {
-      serverId,
-      toolName: tool.name,
-    });
-  }
+  rememberTools(serverId, listed.tools ?? []);
   clients.set(serverId, client);
-  toolMaps.set(serverId, map);
   return client;
 }
 
@@ -192,23 +209,62 @@ export async function listServers() {
   return out;
 }
 
-export async function listEnabledMcpTools() {
+/**
+ * Connect every enabled server and collect its live tool listing.
+ * Servers that fail to start are returned with `error` set rather than dropped,
+ * so callers can tell "no tools" apart from "never connected".
+ */
+async function collectEnabledServerTools() {
   const index = await loadIndex();
-  const defs = [];
+  const out = [];
   for (const [serverId, meta] of Object.entries(index.servers ?? {})) {
     if (meta.enabled === false) continue;
+    const entry = { id: serverId, label: serverId, tools: [], error: null };
     try {
       const config = await loadServerConfig(serverId);
+      entry.label = config.label ?? serverId;
       if (config.enabled === false) continue;
       const client = await connectServer(serverId, config);
       const listed = await client.listTools();
-      defs.push(...toOpenAIDefinitions(serverId, listed.tools ?? []));
+      entry.tools = listed.tools ?? [];
+      // Re-listing can differ from connect time; keep the dispatch map current.
+      rememberTools(serverId, entry.tools);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(`MCP server ${serverId} skipped: ${message}`);
+      entry.error = err instanceof Error ? err.message : String(err);
     }
+    out.push(entry);
+  }
+  return out;
+}
+
+export async function listEnabledMcpTools() {
+  const defs = [];
+  for (const server of await collectEnabledServerTools()) {
+    if (server.error) {
+      console.warn(`MCP server ${server.id} skipped: ${server.error}`);
+      continue;
+    }
+    defs.push(...toOpenAIDefinitions(server.id, server.tools));
   }
   return defs;
+}
+
+/**
+ * Per-server tool listing for Settings → Tools: namespaced ids for permission
+ * rows, without the JSON schemas the model-facing definitions carry.
+ */
+export async function listMcpToolCatalog() {
+  const servers = await collectEnabledServerTools();
+  return servers.map((server) => ({
+    id: server.id,
+    label: server.label,
+    error: server.error,
+    tools: server.tools.map((tool) => ({
+      name: tool.name,
+      namespacedName: toNamespacedName(server.id, tool.name),
+      description: tool.description ?? '',
+    })),
+  }));
 }
 
 export async function callMcpTool(namespacedName, args) {
@@ -227,8 +283,14 @@ export async function callMcpTool(namespacedName, args) {
 
   await connectServer(parsed.serverId, config);
   const client = clients.get(parsed.serverId);
+  const { toolName, known } = resolveMcpToolName(namespacedName, parsed);
+  if (!toolName) {
+    const available = known.length > 0 ? known.join(', ') : 'none';
+    return `Error: MCP server "${parsed.serverId}" has no tool "${parsed.toolName}". Available tools: ${available}`;
+  }
+
   const result = await client.callTool({
-    name: parsed.toolName,
+    name: toolName,
     arguments: args ?? {},
   });
 

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -43,6 +43,12 @@ export async function fetchMcpServers(): Promise<McpServerSummary[] | null> {
   }
 }
 
+export {
+  fetchMcpToolCatalog,
+  type McpCatalogTool,
+  type McpToolCatalogEntry,
+} from './tool-catalog';
+
 /** Payload for POST /api/mcp/servers (stdio transport). */
 export type CreateMcpServerPayload = {
   id: string;

--- a/src/mcp/tool-catalog.ts
+++ b/src/mcp/tool-catalog.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-server MCP tool listings for Settings → Tools (GET /api/mcp/tools/catalog).
+ * Kept free of app imports so settings UI can load it without the tool client.
+ */
+
+/** One tool as exposed to permissions. */
+export type McpCatalogTool = {
+  /** The server's own spelling, e.g. `browser_navigate`. */
+  name: string;
+  /** Permission id and dispatch key, e.g. `mcp__playwright__browser_navigate`. */
+  namespacedName: string;
+  description: string;
+};
+
+/** One enabled server and its live tool listing (`error` when it never started). */
+export type McpToolCatalogEntry = {
+  id: string;
+  label: string;
+  error: string | null;
+  tools: McpCatalogTool[];
+};
+
+/** Load per-server MCP tool listings; empty when the local server is unavailable. */
+export async function fetchMcpToolCatalog(): Promise<McpToolCatalogEntry[]> {
+  try {
+    const res = await fetch('/api/mcp/tools/catalog');
+    if (!res.ok) return [];
+    const body = (await res.json()) as { servers?: McpToolCatalogEntry[] };
+    return Array.isArray(body.servers) ? body.servers : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -323,6 +323,22 @@
   min-width: 0;
 }
 
+/* MCP tool names are the literal ids the agent calls, so they read as code. */
+.tool-label--code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+/* Server-supplied descriptions are model-facing prose; keep rows scannable. */
+.tool-desc--clamped {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+}
+
 .tool-desc {
   margin: 0 0 0 24px;
   font-size: 11px;

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -682,16 +682,21 @@ export async function resetBuiltInToolPermissionsToDefaults(
   refreshAllToolListUis(root);
 }
 
-/** Set one built-in tool permission mode and refresh UI. */
+/** True for MCP and plugin ids: persisted like built-ins, absent from the catalog. */
+function isDynamicToolId(id: string): boolean {
+  return id.startsWith('mcp__') || id.startsWith('plugin__');
+}
+
+/** Set one tool permission mode (built-in, MCP, or plugin) and refresh UI. */
 export function setToolPermission(
   id: string,
   mode: ToolPermissionMode,
   root: ParentNode = document,
 ): void {
   const tool = BUILT_IN_TOOLS.find((entry) => entry.id === id);
-  if (!tool) return;
+  if (!tool && !isDynamicToolId(id)) return;
 
-  if (mode !== 'off' && tool.previewRequired && !isMinnowElectronShell()) {
+  if (tool && mode !== 'off' && tool.previewRequired && !isMinnowElectronShell()) {
     setStatus(
       'err',
       'Browser tools require the Minnow desktop app window (not a separate browser tab).',
@@ -700,7 +705,7 @@ export function setToolPermission(
     return;
   }
 
-  if (mode !== 'off' && tool.serverRequired && !localServerAvailable) {
+  if (tool && mode !== 'off' && tool.serverRequired && !localServerAvailable) {
     setStatus('err', 'Open Minnow to use file and git tools.');
     refreshAllToolListUis(root);
     return;

--- a/src/ui/settings-mcp-tools.ts
+++ b/src/ui/settings-mcp-tools.ts
@@ -1,0 +1,135 @@
+/**
+ * Settings → Tools: permission rows for the tools each connected MCP server
+ * exposes, one collapsible group per server.
+ */
+
+import { fetchMcpToolCatalog, type McpToolCatalogEntry } from '../mcp/tool-catalog';
+import { isToolPermissionMode, loadToolConfig } from '../tools/config';
+import { bindToolsListChange, createDynamicToolGroup } from './tools-list';
+
+/** Test fixture server — hidden here as it is in the MCP servers list. */
+const MCP_TOOLS_HIDDEN_IDS = new Set(['fixture']);
+
+const GROUP_PREFIX = 'mcp:';
+
+/** Descriptions longer than this get the full text on hover. */
+const CLAMP_HINT_CHARS = 160;
+
+function createPermissionSelect(toolLabel: string, mode: string): HTMLSelectElement {
+  const select = document.createElement('select');
+  select.className = 'tool-permission-select';
+  select.setAttribute('aria-label', `${toolLabel} permission`);
+  for (const optDef of [
+    { value: 'off', label: 'Disabled' },
+    { value: 'ask', label: 'Requires permission' },
+    { value: 'full', label: 'Full permission' },
+  ] as const) {
+    const opt = document.createElement('option');
+    opt.value = optDef.value;
+    opt.textContent = optDef.label;
+    select.appendChild(opt);
+  }
+  // Unlisted MCP ids resolve to `ask` at call time; show the same default here.
+  select.value = isToolPermissionMode(mode) ? mode : 'ask';
+  return select;
+}
+
+function createMcpToolRow(
+  tool: McpToolCatalogEntry['tools'][number],
+  storedMode: unknown,
+): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'tool-row tool-row--mcp';
+  row.setAttribute('data-tool-id', tool.namespacedName);
+  row.setAttribute('data-server-required', '');
+  row.dataset.settingsSearchKey = `tools.item.${tool.namespacedName}`;
+
+  const controlWrap = document.createElement('div');
+  controlWrap.className = 'tool-permission-wrap';
+
+  const nameSpan = document.createElement('span');
+  nameSpan.className = 'tool-label tool-label--code';
+  nameSpan.textContent = tool.name;
+
+  controlWrap.append(
+    nameSpan,
+    createPermissionSelect(tool.name, String(storedMode ?? '')),
+  );
+  row.appendChild(controlWrap);
+
+  if (tool.description) {
+    const desc = document.createElement('p');
+    // MCP descriptions are written for the model and run to hundreds of words;
+    // the row clamps them (see settings.css) and keeps the rest on hover.
+    desc.className = 'tool-desc tool-desc--clamped';
+    desc.textContent = tool.description;
+    if (tool.description.length > CLAMP_HINT_CHARS) {
+      desc.title = tool.description;
+    }
+    row.appendChild(desc);
+  }
+
+  return row;
+}
+
+/** Why a server contributes no rows, phrased so the fix is obvious. */
+function createServerNotice(entry: McpToolCatalogEntry): HTMLElement {
+  const hint = document.createElement('p');
+  hint.className = 'tool-group-hint';
+  hint.textContent = entry.error
+    ? `Could not start this server: ${entry.error}. Check its command in Integrations → MCP servers.`
+    : 'Connected, but the server listed no tools.';
+  return hint;
+}
+
+/**
+ * Append one group per enabled MCP server to a tools list container.
+ * Replaces any groups from a previous render.
+ */
+export async function appendMcpToolsToList(listId: string): Promise<void> {
+  const container = document.getElementById(listId);
+  if (!container) return;
+
+  const catalog = await fetchMcpToolCatalog();
+
+  for (const stale of container.querySelectorAll(
+    `[data-tool-category^="${GROUP_PREFIX}"]`,
+  )) {
+    stale.remove();
+  }
+
+  const servers = catalog.filter((entry) => !MCP_TOOLS_HIDDEN_IDS.has(entry.id));
+  if (servers.length === 0) return;
+
+  const collapsible = container.classList.contains('tools-list--settings');
+  const config = loadToolConfig();
+
+  for (const entry of servers) {
+    const bodyNodes: HTMLElement[] = [];
+    if (entry.tools.length === 0) {
+      bodyNodes.push(createServerNotice(entry));
+    }
+    for (const tool of entry.tools) {
+      bodyNodes.push(
+        createMcpToolRow(tool, config.permissions.default[tool.namespacedName]),
+      );
+    }
+
+    const count = entry.error
+      ? 'Not connected'
+      : `${entry.tools.length} tool${entry.tools.length === 1 ? '' : 's'}`;
+
+    container.appendChild(
+      createDynamicToolGroup({
+        category: `${GROUP_PREFIX}${entry.id}`,
+        title: entry.label,
+        count,
+        searchKey: `tools.category.mcp.${entry.id}`,
+        collapsible,
+        bodyNodes,
+      }),
+    );
+  }
+
+  bindToolsListChange(container);
+}

--- a/src/ui/settings-plugins.ts
+++ b/src/ui/settings-plugins.ts
@@ -9,7 +9,7 @@ import {
   setToolPermission,
 } from '../tools/config';
 import type { PluginListItem } from '../tools/plugin-settings-types';
-import { bindToolsListChange } from './tools-list';
+import { bindToolsListChange, createDynamicToolGroup } from './tools-list';
 
 /** Fetch plugin metadata for settings rows. */
 export async function fetchPluginList(): Promise<PluginListItem[]> {
@@ -105,59 +105,16 @@ export async function appendPluginToolsToList(
     bodyNodes.push(row);
   }
 
-  if (isSettingsList) {
-    const details = document.createElement('details');
-    details.className = 'tool-group tool-group--collapsible';
-    details.setAttribute('data-tool-category', 'plugins');
-    details.dataset.settingsSearchKey = 'tools.category.plugins';
-
-    const summary = document.createElement('summary');
-    summary.className = 'tool-group-summary';
-
-    const main = document.createElement('span');
-    main.className = 'tool-group-summary__main';
-
-    const chevron = document.createElement('span');
-    chevron.className = 'tool-group-summary__chevron';
-    chevron.setAttribute('aria-hidden', 'true');
-
-    const title = document.createElement('span');
-    title.className = 'tool-group-header';
-    title.textContent = 'Plugins';
-
-    main.append(chevron, title);
-
-    const count = document.createElement('span');
-    count.className = 'tool-group-count';
-    count.textContent = `${plugins.length} tool${plugins.length === 1 ? '' : 's'}`;
-
-    summary.append(main, count);
-    details.append(summary);
-
-    const body = document.createElement('div');
-    body.className = 'tool-group-body';
-    for (const node of bodyNodes) body.appendChild(node);
-    details.appendChild(body);
-    container.appendChild(details);
-    bindToolsListChange(container);
-    return;
-  }
-
-  const group = document.createElement('section');
-  group.className = 'tool-group';
-  group.setAttribute('data-tool-category', 'plugins');
-
-  const head = document.createElement('div');
-  head.className = 'tool-group-head';
-  const header = document.createElement('h3');
-  header.className = 'tool-group-header';
-  header.textContent = 'Plugins';
-  head.appendChild(header);
-  group.appendChild(head);
-
-  for (const node of bodyNodes) group.appendChild(node);
-
-  container.appendChild(group);
+  container.appendChild(
+    createDynamicToolGroup({
+      category: 'plugins',
+      title: 'Plugins',
+      count: `${plugins.length} tool${plugins.length === 1 ? '' : 's'}`,
+      searchKey: 'tools.category.plugins',
+      collapsible: isSettingsList,
+      bodyNodes,
+    }),
+  );
   bindToolsListChange(container);
 }
 

--- a/src/ui/settings-sections.ts
+++ b/src/ui/settings-sections.ts
@@ -1427,7 +1427,9 @@ async function renderToolsSection(): Promise<void> {
 
   const lead = el('p', 'settings-section-lead');
   lead.append(
-    'Built-in tool permissions and session cache. Browser automation lives under ',
+    'Permissions for built-in, plugin, and MCP tools, plus the session cache. Servers are added under ',
+    linkToSettingsSection('MCP', 'mcp'),
+    '. Browser automation lives under ',
     linkToSettingsSection('Browser', 'browser'),
     '. Slash commands live under ',
     linkToSettingsSection('Skills', 'skills'),
@@ -1550,6 +1552,8 @@ async function renderToolsSection(): Promise<void> {
   fillToolsSection('settingsToolsList', { variant: 'settings' });
   const { appendPluginToolsToList } = await import('./settings-plugins');
   await appendPluginToolsToList('settingsToolsList');
+  const { appendMcpToolsToList } = await import('./settings-mcp-tools');
+  await appendMcpToolsToList('settingsToolsList');
   if (isAsyncSectionRenderStale('tools', generation)) return;
 
   if (!toolsSectionInitialized) {
@@ -1574,6 +1578,7 @@ async function renderToolsSection(): Promise<void> {
   );
 
   appendSettingsCrosslinks(content, [
+    { label: 'MCP servers', sectionId: 'mcp' },
     { label: 'Browser automation', sectionId: 'browser' },
     { label: 'Skills catalog', sectionId: 'skills' },
     { label: 'Web search', sectionId: 'search' },
@@ -1908,6 +1913,8 @@ function ensureMcpSettingsShell(mount: HTMLElement): {
   lead.append(
     'External MCP integrations connect over stdio and register as ',
     el('code', undefined, 'mcp__server__tool'),
+    '. Each connected server gets its own permission rows under ',
+    linkToSettingsSection('Tools', 'tools'),
     '. Language-server diagnostics live under ',
     linkToSettingsSection('Language servers', 'lsp'),
     '; AI ghost text lives under ',

--- a/src/ui/tools-list.ts
+++ b/src/ui/tools-list.ts
@@ -105,6 +105,72 @@ function wrapCollapsibleToolGroup(
   return details;
 }
 
+/**
+ * Group shell for dynamic tool sources (plugins, MCP servers) so their rows keep
+ * the same shape as built-in categories: collapsible in Settings, plain section
+ * in the drawer.
+ */
+export function createDynamicToolGroup(options: {
+  category: string;
+  title: string;
+  count: string;
+  searchKey: string;
+  collapsible: boolean;
+  bodyNodes: HTMLElement[];
+}): HTMLElement {
+  if (!options.collapsible) {
+    const group = document.createElement('section');
+    group.className = 'tool-group';
+    group.setAttribute('data-tool-category', options.category);
+    group.dataset.settingsSearchKey = options.searchKey;
+
+    const head = document.createElement('div');
+    head.className = 'tool-group-head';
+    const header = document.createElement('h3');
+    header.className = 'tool-group-header';
+    header.textContent = options.title;
+    head.appendChild(header);
+    group.appendChild(head);
+
+    for (const node of options.bodyNodes) group.appendChild(node);
+    return group;
+  }
+
+  const details = document.createElement('details');
+  details.className = 'tool-group tool-group--collapsible';
+  details.setAttribute('data-tool-category', options.category);
+  details.dataset.settingsSearchKey = options.searchKey;
+
+  const summary = document.createElement('summary');
+  summary.className = 'tool-group-summary';
+
+  const main = document.createElement('span');
+  main.className = 'tool-group-summary__main';
+
+  const chevron = document.createElement('span');
+  chevron.className = 'tool-group-summary__chevron';
+  chevron.setAttribute('aria-hidden', 'true');
+
+  const title = document.createElement('span');
+  title.className = 'tool-group-header';
+  title.textContent = options.title;
+
+  main.append(chevron, title);
+
+  const count = document.createElement('span');
+  count.className = 'tool-group-count';
+  count.textContent = options.count;
+
+  summary.append(main, count);
+
+  const body = document.createElement('div');
+  body.className = 'tool-group-body';
+  for (const node of options.bodyNodes) body.appendChild(node);
+
+  details.append(summary, body);
+  return details;
+}
+
 /** Build a per-category or global "select all" control. */
 function createToolSelectAllControl(
   scope: 'global' | ToolCategory,

--- a/test/fixtures/mock-mcp-server.mjs
+++ b/test/fixtures/mock-mcp-server.mjs
@@ -1,16 +1,26 @@
 /**
- * Minimal MCP stdio server — tools/list + tools/call echo → pong
+ * Minimal MCP stdio server — newline-delimited JSON-RPC, per the MCP stdio spec.
+ * Exposes plain, snake_case, and dashed tools so dispatch can be asserted to send
+ * the server's own spelling back (`called:<name>`), not a re-encoded guess.
  */
 
 import process from 'node:process';
 
+const TOOLS = [
+  { name: 'echo', description: 'Echo fixture' },
+  { name: 'echo_message', description: 'Snake_case fixture' },
+  { name: 'echo-dashed', description: 'Dashed fixture' },
+].map((tool) => ({
+  ...tool,
+  inputSchema: { type: 'object', properties: { message: { type: 'string' } } },
+}));
+
+const TOOL_NAMES = new Set(TOOLS.map((tool) => tool.name));
+
 let buffer = '';
 
 function send(msg) {
-  const body = JSON.stringify(msg);
-  process.stdout.write(
-    `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`,
-  );
+  process.stdout.write(`${JSON.stringify(msg)}\n`);
 }
 
 function handle(msg) {
@@ -19,7 +29,7 @@ function handle(msg) {
       jsonrpc: '2.0',
       id: msg.id,
       result: {
-        protocolVersion: '2024-11-05',
+        protocolVersion: msg.params?.protocolVersion ?? '2024-11-05',
         capabilities: { tools: {} },
         serverInfo: { name: 'fixture-mcp', version: '1.0.0' },
       },
@@ -28,36 +38,34 @@ function handle(msg) {
   }
 
   if (msg.method === 'tools/list') {
-    send({
-      jsonrpc: '2.0',
-      id: msg.id,
-      result: {
-        tools: [
-          {
-            name: 'echo',
-            description: 'Echo fixture',
-            inputSchema: {
-              type: 'object',
-              properties: { message: { type: 'string' } },
-            },
-          },
-        ],
-      },
-    });
+    send({ jsonrpc: '2.0', id: msg.id, result: { tools: TOOLS } });
     return;
   }
 
   if (msg.method === 'tools/call') {
+    const name = msg.params?.name ?? '';
+    if (!TOOL_NAMES.has(name)) {
+      send({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          isError: true,
+          content: [{ type: 'text', text: `unknown tool: ${name}` }],
+        },
+      });
+      return;
+    }
     send({
       jsonrpc: '2.0',
       id: msg.id,
       result: {
-        content: [{ type: 'text', text: 'pong' }],
+        content: [{ type: 'text', text: name === 'echo' ? 'pong' : `called:${name}` }],
       },
     });
     return;
   }
 
+  // Notifications carry no id and expect no reply.
   if (msg.id != null) {
     send({ jsonrpc: '2.0', id: msg.id, result: {} });
   }
@@ -65,21 +73,17 @@ function handle(msg) {
 
 process.stdin.on('data', (chunk) => {
   buffer += chunk.toString('utf8');
-  while (true) {
-    const headerEnd = buffer.indexOf('\r\n\r\n');
-    if (headerEnd < 0) break;
-    const header = buffer.slice(0, headerEnd);
-    const match = header.match(/Content-Length:\s*(\d+)/i);
-    if (!match) break;
-    const len = Number(match[1]);
-    const bodyStart = headerEnd + 4;
-    if (buffer.length < bodyStart + len) break;
-    const body = buffer.slice(bodyStart, bodyStart + len);
-    buffer = buffer.slice(bodyStart + len);
-    try {
-      handle(JSON.parse(body));
-    } catch {
-      /* ignore */
+  let newline = buffer.indexOf('\n');
+  while (newline >= 0) {
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    if (line) {
+      try {
+        handle(JSON.parse(line));
+      } catch {
+        /* ignore malformed line */
+      }
     }
+    newline = buffer.indexOf('\n');
   }
 });

--- a/test/mcp/bridge.test.mjs
+++ b/test/mcp/bridge.test.mjs
@@ -13,4 +13,36 @@ describe('MCP bridge', () => {
     assert.equal(parsed.serverId, 'fixture');
     assert.equal(parsed.toolName, 'echo');
   });
+
+  test('snake_case tool names survive the parse', () => {
+    const name = toNamespacedName('playwright', 'browser_navigate');
+    assert.equal(name, 'mcp__playwright__browser_navigate');
+    const parsed = parseNamespacedName(name);
+    assert.equal(parsed.serverId, 'playwright');
+    assert.equal(parsed.toolName, 'browser_navigate');
+    assert.deepEqual(parsed.toolNameCandidates, [
+      'browser_navigate',
+      'browser-navigate',
+    ]);
+  });
+
+  test('dashed tool names stay reachable through the candidate list', () => {
+    const parsed = parseNamespacedName(
+      toNamespacedName('context7', 'resolve-library-id'),
+    );
+    assert.ok(parsed.toolNameCandidates.includes('resolve-library-id'));
+  });
+
+  test('server ids keep hyphens', () => {
+    const parsed = parseNamespacedName(
+      toNamespacedName('playwright-mcp', 'browser_click'),
+    );
+    assert.equal(parsed.serverId, 'playwright-mcp');
+    assert.equal(parsed.toolName, 'browser_click');
+  });
+
+  test('non-MCP names parse to null', () => {
+    assert.equal(parseNamespacedName('plugin__x__y'), null);
+    assert.equal(parseNamespacedName('mcp__only'), null);
+  });
 });

--- a/test/mcp/registry.test.mjs
+++ b/test/mcp/registry.test.mjs
@@ -54,6 +54,39 @@ describe('MCP registry', () => {
     assert.equal(result, EXPECTED_CALL_RESULT);
   });
 
+  test('dispatch sends the server spelling for snake_case and dashed tools', async () => {
+    await createMcpServer({
+      id: 'stdio-fixture',
+      label: 'Stdio fixture',
+      description: 'Name round-trip fixture',
+      enabled: true,
+      transport: {
+        type: 'stdio',
+        command: process.execPath,
+        args: ['test/fixtures/mock-mcp-server.mjs'],
+      },
+    });
+
+    try {
+      // Regression: `browser_navigate` used to be dispatched as `browser-navigate`.
+      assert.equal(
+        await callMcpTool('mcp__stdio-fixture__echo_message', { message: 'x' }),
+        'called:echo_message',
+      );
+      // Dashed names (Context7 style) encode to the same shape and still resolve.
+      assert.equal(
+        await callMcpTool('mcp__stdio-fixture__echo_dashed', { message: 'x' }),
+        'called:echo-dashed',
+      );
+      assert.match(
+        await callMcpTool('mcp__stdio-fixture__not_a_tool', {}),
+        /has no tool "not_a_tool"\. Available tools: echo, echo_message, echo-dashed/,
+      );
+    } finally {
+      await deleteMcpServer('stdio-fixture');
+    }
+  });
+
   test('create and delete custom MCP server', async () => {
     const created = await createMcpServer({
       id: 'custom-test',

--- a/test/tools/mcp-tools-list.test.mjs
+++ b/test/tools/mcp-tools-list.test.mjs
@@ -1,0 +1,164 @@
+/**
+ * Settings → Tools rows for MCP servers: one group per server, permissions that
+ * persist to tools.json, and a readable state when a server never connected.
+ */
+
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+
+register('../test-loader.mjs', import.meta.url);
+
+const {
+  invalidateToolConfigCache,
+  getToolPermissionForId,
+  loadToolConfig,
+  setLocalServerAvailable,
+  TOOL_CONFIG_STORAGE_KEY,
+  flushToolListUiRefresh,
+} = await import('../../src/tools/config.ts');
+const { fillToolsSection } = await import('../../src/ui/tools-list.ts');
+const { appendMcpToolsToList } = await import('../../src/ui/settings-mcp-tools.ts');
+
+const NAVIGATE_ID = 'mcp__playwright__browser_navigate';
+
+const CATALOG = [
+  {
+    id: 'playwright',
+    label: 'Playwright',
+    error: null,
+    tools: [
+      {
+        name: 'browser_navigate',
+        namespacedName: NAVIGATE_ID,
+        description: 'Navigate to a URL',
+      },
+      {
+        name: 'browser_click',
+        namespacedName: 'mcp__playwright__browser_click',
+        description: 'Click an element',
+      },
+    ],
+  },
+  {
+    id: 'context7',
+    label: 'Context7',
+    error: null,
+    tools: [
+      {
+        name: 'resolve-library-id',
+        namespacedName: 'mcp__context7__resolve_library_id',
+        description: 'Resolve a library id',
+      },
+    ],
+  },
+  { id: 'fixture', label: 'Fixture MCP (tests)', error: null, tools: [] },
+  { id: 'broken', label: 'Broken server', error: 'spawn npx ENOENT', tools: [] },
+];
+
+/** Mount a settings tools list in happy-dom with a stubbed catalog endpoint. */
+function setupSettingsToolsList(catalog = CATALOG) {
+  const window = new Window();
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.HTMLInputElement = window.HTMLInputElement;
+  globalThis.HTMLSelectElement = window.HTMLSelectElement;
+  globalThis.HTMLButtonElement = window.HTMLButtonElement;
+  globalThis.HTMLLabelElement = window.HTMLLabelElement;
+  globalThis.Event = window.Event;
+  globalThis.localStorage = window.localStorage;
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), '/api/mcp/tools/catalog');
+    return { ok: true, json: async () => ({ servers: catalog }) };
+  };
+
+  invalidateToolConfigCache();
+  setLocalServerAvailable(true);
+  document.body.innerHTML = '<div id="settingsToolsList"></div>';
+  fillToolsSection('settingsToolsList', { variant: 'settings' });
+}
+
+function groupFor(serverId) {
+  return document.querySelector(`[data-tool-category="mcp:${serverId}"]`);
+}
+
+afterEach(() => {
+  invalidateToolConfigCache();
+  delete globalThis.fetch;
+});
+
+describe('MCP tool permission rows', () => {
+  test('renders one group per connected server', async () => {
+    setupSettingsToolsList();
+    await appendMcpToolsToList('settingsToolsList');
+
+    assert.ok(groupFor('playwright'), 'playwright group missing');
+    assert.ok(groupFor('context7'), 'context7 group missing');
+    assert.equal(groupFor('fixture'), null, 'test fixture server should stay hidden');
+
+    const rows = groupFor('playwright').querySelectorAll('[data-tool-id]');
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].getAttribute('data-tool-id'), NAVIGATE_ID);
+    assert.equal(
+      rows[0].querySelector('.tool-label').textContent,
+      'browser_navigate',
+      'row shows the spelling the server exposes',
+    );
+    assert.equal(
+      groupFor('playwright').querySelector('.tool-group-count').textContent,
+      '2 tools',
+    );
+  });
+
+  test('defaults to ask and persists a change to tools.json', async () => {
+    setupSettingsToolsList();
+    await appendMcpToolsToList('settingsToolsList');
+
+    const row = document.querySelector(`[data-tool-id="${NAVIGATE_ID}"]`);
+    const select = row.querySelector('select.tool-permission-select');
+    assert.equal(select.value, 'ask');
+
+    select.value = 'full';
+    select.dispatchEvent(new window.Event('change', { bubbles: true }));
+    await flushToolListUiRefresh();
+
+    assert.equal(getToolPermissionForId(loadToolConfig(), NAVIGATE_ID), 'full');
+    const saved = JSON.parse(localStorage.getItem(TOOL_CONFIG_STORAGE_KEY));
+    assert.equal(saved.permissions.default[NAVIGATE_ID], 'full');
+  });
+
+  test('disabling a tool is persisted so it can be withheld from the model', async () => {
+    setupSettingsToolsList();
+    await appendMcpToolsToList('settingsToolsList');
+
+    const select = document
+      .querySelector(`[data-tool-id="${NAVIGATE_ID}"]`)
+      .querySelector('select.tool-permission-select');
+    select.value = 'off';
+    select.dispatchEvent(new window.Event('change', { bubbles: true }));
+    await flushToolListUiRefresh();
+
+    assert.equal(getToolPermissionForId(loadToolConfig(), NAVIGATE_ID), 'off');
+  });
+
+  test('a server that never started explains itself instead of vanishing', async () => {
+    setupSettingsToolsList();
+    await appendMcpToolsToList('settingsToolsList');
+
+    const group = groupFor('broken');
+    assert.ok(group);
+    assert.equal(group.querySelector('.tool-group-count').textContent, 'Not connected');
+    assert.match(group.querySelector('.tool-group-hint').textContent, /spawn npx ENOENT/);
+  });
+
+  test('re-rendering replaces groups instead of duplicating rows', async () => {
+    setupSettingsToolsList();
+    await appendMcpToolsToList('settingsToolsList');
+    await appendMcpToolsToList('settingsToolsList');
+
+    assert.equal(document.querySelectorAll(`[data-tool-id="${NAVIGATE_ID}"]`).length, 1);
+    assert.equal(document.querySelectorAll('[data-tool-category^="mcp:"]').length, 3);
+  });
+});


### PR DESCRIPTION
Fixes a user report: adding a custom Playwright MCP server showed **Connected**, but asking Minnow to navigate launched the browser and then failed with `browser-navigate not found`, and none of the server's tools appeared under Settings → Tools.

## What was wrong

Three separate causes, each independently sufficient to break the feature.

**1. Tool names were corrupted on dispatch.** `toNamespacedName` folds `-` into `_` to stay inside the function-name charset; `parseNamespacedName` decoded by turning *every* `_` back into `-`. The model emitted the correct name and the registry mangled it:

```
browser_navigate         -> mcp__playwright__browser_navigate         -> dispatched as: browser-navigate    MISMATCH
resolve-library-id       -> mcp__context7__resolve_library_id         -> dispatched as: resolve-library-id  OK
```

Context7 worked only because its tools happen to be dash-named. `connectServer` already cached namespaced id → the server's own tool name, but `callMcpTool` never read it and went straight to the lossy decode. It now resolves through that map, the same way plugins already resolve through `pluginByNamespaced` (`server/tools/loader.js:123`). An unknown tool now returns the available list so the model can self-correct.

**2. Nothing rendered MCP tools in Settings.** The tools list was built from `BUILT_IN_TOOLS` plus a plugins group; MCP tools had no rows at all, and unlisted `mcp__*` ids silently defaulted to `ask`. New `src/ui/settings-mcp-tools.ts` adds one collapsible group per server.

**3. Permission writes were dropped.** `setToolPermission` returned early for any id not in the built-in catalog, so `mcp__*` and `plugin__*` changes never persisted — the existing plugin rows were inert for the same reason. Storage already preserved these keys; only the client-side guard was wrong.

## Notable choices

- **New `GET /api/mcp/tools/catalog`**, separate from `/api/mcp/tools`. The latter feeds model requests verbatim, so it can't carry display metadata. The catalog returns per-server tool names, namespaced ids, and descriptions, and reports servers that failed to spawn instead of dropping them.
- **A server that fails to start renders as "Not connected"** with its error and a pointer to Integrations → MCP, rather than vanishing — that silence is what the reporter actually hit.
- **Descriptions clamp to two lines** with the full text on hover. Context7's `resolve-library-id` description is 2006 characters; unclamped, one row measured ~400px tall.
- **Plugins and MCP now share one group shell** in `tools-list.ts` so the two dynamic tool sources can't drift apart visually.

## Verification

End-to-end through the running app's HTTP API against a real stdio MCP server:

```
snake:  "called:echo_message"      (previously dispatched as echo-message → not found)
dashed: "called:echo-dashed"       (Context7-style, still correct)
bogus:  Error: MCP server "dispatch-check" has no tool "nope_nope". Available tools: echo, echo_message, echo-dashed
```

In Settings → Tools: groups rendered for each connected server (test fixture hidden), a select change landed in `tools.json` on disk, and pre-existing stored values loaded back into the rows.

100 tests pass across `test/mcp/**`, `test/tools/**`, `test/security/untrusted`, `test/settings/**`, `test/headless/tool-config`, `test/config/api-crud`, `test/onboarding/context7-step`, `test/modes/tool-policy`. `tsc --noEmit` clean.

## For reviewers

- **The stdio mock never worked.** `test/fixtures/mock-mcp-server.mjs` spoke LSP `Content-Length` framing instead of MCP's newline-delimited JSON, so the real transport was never exercised (the `fixture` server id short-circuits to an in-process client). Rewritten; `test/mcp/registry.test.mjs` now drives it with snake_case and dashed tools to pin the exact dispatched spelling.
- **Left alone:** `server/tools/bridge.js:16` has the identical lossy decode, but plugins dispatch through their map, so it is only reachable in an error path.
- **Encoding unchanged on purpose.** Fixing the decode rather than the encode keeps existing `mcp__*` permission keys in users' `tools.json` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
