### PR TITLE
🐛 Stop web search handing decoy results to the model

### DIFF
--- a/server/research/search.js
+++ b/server/research/search.js
@@ -9,6 +9,7 @@ import { searchBraveStructured } from '../tools/web-search-brave.js';
 import { searchDdgStructured } from '../tools/web-search-ddg.js';
 import { searchSearxngStructured } from '../tools/web-search-searxng.js';
 import { searchTavilyStructured } from '../tools/web-search-tavily.js';
+import { looksUnrelated } from '../tools/search-result.js';
 import { getSearch, setSearch } from './cache.js';
 
 /** @typedef {'searxng' | 'tavily' | 'brave' | 'duckduckgo' | 'disabled'} SearchProviderId */
@@ -18,6 +19,9 @@ let lastSearchError = null;
 
 /** @type {SearchProviderId | null} */
 let lastSearchProvider = null;
+
+/** True when the last search discarded a result set as unrelated (not merely empty). */
+let lastSearchDiscardedUnrelated = false;
 
 const DEFAULT_FALLBACK_CHAIN = ['tavily', 'brave', 'duckduckgo'];
 const DEFAULT_SEARXNG_URL = 'http://localhost:8899';
@@ -37,6 +41,16 @@ export function getLastSearchError() {
  */
 export function getLastSearchProvider() {
   return lastSearchProvider;
+}
+
+/**
+ * True when at least one provider returned results that were discarded as unrelated to
+ * the query. Distinguishes "nothing found" from "the engine answered with junk", which
+ * point at different fixes.
+ * @returns {boolean}
+ */
+export function getLastSearchDiscardedUnrelated() {
+  return lastSearchDiscardedUnrelated;
 }
 
 /**
@@ -201,6 +215,7 @@ async function callProvider(providerId, query, settings) {
 export async function searchStructured(query, opts = {}) {
   lastSearchError = null;
   lastSearchProvider = null;
+  lastSearchDiscardedUnrelated = false;
 
   const trimmed = String(query ?? '').trim();
   if (!trimmed) {
@@ -222,7 +237,9 @@ export async function searchStructured(query, opts = {}) {
   const useCache = opts.useCache !== false;
   if (useCache) {
     const cached = await getSearch(cacheKey);
-    if (cached?.length) {
+    // Re-check on read: entries written before the guard existed (or by a provider that
+    // has since started decoying) would otherwise stay pinned for the full 2h TTL.
+    if (cached?.length && !looksUnrelated(trimmed, cached)) {
       lastSearchProvider = primary;
       return cached;
     }
@@ -240,6 +257,9 @@ export async function searchStructured(query, opts = {}) {
       return results;
     }
     if (error) {
+      if (error.includes('unrelated to')) {
+        lastSearchDiscardedUnrelated = true;
+      }
       errors.push(`${providerId}: ${error}`);
     }
   }

--- a/server/runtime/tools-middleware.js
+++ b/server/runtime/tools-middleware.js
@@ -98,8 +98,15 @@ import {
   formatDdgSearchResults,
   searchDdgStructured,
 } from '../tools/web-search-ddg.js';
-import { runTavilySearch } from '../tools/web-search-tavily.js';
-import { runSearxngSearch } from '../tools/web-search-searxng.js';
+import {
+  formatTavilySearchResults,
+  searchTavilyStructured,
+} from '../tools/web-search-tavily.js';
+import {
+  formatSearxngSearchResults,
+  searchSearxngStructured,
+} from '../tools/web-search-searxng.js';
+import { appendResultExcerpts } from '../tools/search-enrich.js';
 import { loadSearchSettings } from '../research/search.js';
 import { getFilesystemAccessFromConfig } from '../config/tool-security.js';
 import { callMcpTool, isMcpToolName } from '../mcp/registry.js';
@@ -208,6 +215,30 @@ async function readTavilyApiKeyFromConfig() {
   return settings.tavilyApiKey;
 }
 
+/** True when the caller asked for ranked page excerpts alongside the snippets. */
+function wantsDeepRead(args) {
+  return args?.deep_read === true || args?.deep_read === 'true';
+}
+
+/**
+ * Shared tail for the web search backends: format, then optionally read the top hits.
+ * @param {string} query
+ * @param {{ results: import('../tools/search-result.js').SearchResult[]; error?: string }} outcome
+ * @param {(query: string, results: import('../tools/search-result.js').SearchResult[]) => string} format
+ * @param {Record<string, unknown>} args
+ * @returns {Promise<string>}
+ */
+async function finishWebSearch(query, outcome, format, args) {
+  if (outcome.error) {
+    return outcome.error;
+  }
+  const formatted = format(query, outcome.results);
+  if (!wantsDeepRead(args)) {
+    return formatted;
+  }
+  return appendResultExcerpts(query, outcome.results, formatted);
+}
+
 /** DuckDuckGo HTML search (no API key); detects bot challenges before parsing. */
 async function toolWebSearchDdg(args) {
   const query = args?.query;
@@ -215,11 +246,8 @@ async function toolWebSearchDdg(args) {
     return 'Error: query is required';
   }
 
-  const { results, error } = await searchDdgStructured(query);
-  if (error) {
-    return error;
-  }
-  return formatDdgSearchResults(query, results);
+  const outcome = await searchDdgStructured(query);
+  return finishWebSearch(query, outcome, formatDdgSearchResults, args);
 }
 
 /** Tavily Search API (requires tavilyApiKey in search.json or tools.json). */
@@ -234,7 +262,8 @@ async function toolWebSearchTavily(args) {
     return 'Error: Tavily API key not configured. Add one in Settings → Tools.';
   }
 
-  return runTavilySearch(query, apiKey);
+  const outcome = await searchTavilyStructured(query, apiKey);
+  return finishWebSearch(query, outcome, formatTavilySearchResults, args);
 }
 
 /** SearXNG JSON search (requires searxngUrl in search.json). */
@@ -245,7 +274,8 @@ async function toolWebSearchSearxng(args) {
   }
 
   const settings = await loadSearchSettings();
-  return runSearxngSearch(query, settings.searxngUrl);
+  const outcome = await searchSearxngStructured(query, settings.searxngUrl);
+  return finishWebSearch(query, outcome, formatSearxngSearchResults, args);
 }
 
 // --- File tools ---

--- a/server/servers/searxng.js
+++ b/server/servers/searxng.js
@@ -321,26 +321,66 @@ function venvPythonPath(venvDir) {
 
 /**
  * Engine overrides merged into upstream defaults (see searx settings_loader.update_settings).
- * Bing is disabled in stock SearXNG but tends to stay up on loopback; brave/ddg/startpage
- * rate-limit automated metasearch and can leave general queries with zero hits.
+ *
+ * Bing is disabled in stock SearXNG but tends to stay up on loopback. It is NOT trusted
+ * alone: for queries it has no cached SERP for, Bing answers HTTP 200 with the correct
+ * <title> and searchbox echo but 10 `li.b_algo` blocks belonging to unrelated queries.
+ * That is a fail-open mode no result-count check can catch, so DuckDuckGo is kept on as
+ * a second general engine — it rate-limits to *zero* results, which the provider chain
+ * already handles, and its results corroborate or outrank Bing's junk.
+ *
+ * stackoverflow is promoted into `general` because dev queries are exactly the long-tail
+ * ones Bing decoys on. The rest of the `it` category stays out: mdn and docker hub are
+ * keyword matchers that dilute badly (e.g. "chokidar v4 watch options" -> MDN
+ * Geolocation.watchPosition).
+ *
+ * brave/startpage stay disabled — they rate-limit automated metasearch hard enough to
+ * return nothing useful, so they only cost latency.
  */
 export const SEARXNG_ENGINE_OVERRIDES_YAML = `
 engines:
   - name: bing
     disabled: false
-  - name: brave
-    disabled: true
   - name: duckduckgo
+    disabled: false
+  - name: stackoverflow
+    categories: [general, it, "q&a"]
+    disabled: false
+  - name: brave
     disabled: true
   - name: startpage
     disabled: true
 `;
 
+/** Matches the generated `secret_key: "<64 hex>"` line so it survives a rewrite. */
+const SECRET_KEY_RE = /secret_key:\s*"([0-9a-f]{64})"/;
+
+/**
+ * Reuse the secret key already in settings.yml.
+ *
+ * SearXNG derives its cache hash token from `server.secret_key`, so minting a new key on
+ * every launch made it truncate all cache tables on startup
+ * (`[DATA_CACHE] hash token changed`). Generate once, then keep.
+ * @returns {Promise<string>}
+ */
+async function readOrCreateSecretKey() {
+  try {
+    const existing = await fsp.readFile(getServerSettingsPath(SERVER_ID), 'utf8');
+    const match = SECRET_KEY_RE.exec(existing);
+    if (match) {
+      return match[1];
+    }
+  } catch {
+    /* first write */
+  }
+  return randomBytes(32).toString('hex');
+}
+
 /**
  * @param {number} port
  */
 export async function writeSearxngSettings(port) {
-  const secretKey = randomBytes(32).toString('hex');
+  const secretKey = await readOrCreateSecretKey();
   const yaml = `use_default_settings: true
 
 server:
@@ -351,6 +391,7 @@ server:
   public_instance: false
 
 search:
+  safe_search: 1
   formats:
     - html
     - json

--- a/server/tools/search-enrich.js
+++ b/server/tools/search-enrich.js
@@ -1,0 +1,102 @@
+/**
+ * Search result enrichment — fetch the top hits and return ranked excerpts.
+ *
+ * Result snippets are one line each and frequently too thin to answer from, which costs
+ * the model a second round-trip through fetch_web_content anyway. This pulls the top few
+ * pages and reuses the rag_web_content ranker so one call can be enough.
+ */
+
+import {
+  fetchUrlText,
+  rankWebContentByQuery,
+  truncateUtf8,
+  WEB_TEXT_MAX_BYTES,
+} from '../../src/lib/fetch-web-content.mjs';
+
+/** Pages fetched per enriched search. Kept small — each is a network round-trip. */
+export const DEEP_READ_PAGE_LIMIT = 3;
+
+/** Ranked excerpts kept per page. */
+export const DEEP_READ_EXCERPTS_PER_PAGE = 4;
+
+/**
+ * @typedef {import('./search-result.js').SearchResult} SearchResult
+ * @typedef {{ result: SearchResult; excerpts: string[]; error?: string }} EnrichedPage
+ */
+
+/**
+ * Fetch and rank the top results.
+ *
+ * Fetches run in parallel and never reject — a page that 404s or times out is reported
+ * inline rather than failing the search.
+ * @param {string} query
+ * @param {SearchResult[]} results
+ * @param {{ pageLimit?: number; excerptsPerPage?: number }} [opts]
+ * @returns {Promise<EnrichedPage[]>}
+ */
+export async function fetchResultExcerpts(query, results, opts = {}) {
+  const pageLimit = Math.min(Math.max(opts.pageLimit ?? DEEP_READ_PAGE_LIMIT, 1), 5);
+  const excerptsPerPage = Math.max(opts.excerptsPerPage ?? DEEP_READ_EXCERPTS_PER_PAGE, 1);
+  const targets = results.slice(0, pageLimit);
+
+  return Promise.all(
+    targets.map(async (result) => {
+      let text;
+      try {
+        text = await fetchUrlText(result.url);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { result, excerpts: [], error: `fetch failed (${message})` };
+      }
+      if (typeof text !== 'string' || text.startsWith('Error:')) {
+        return { result, excerpts: [], error: text || 'fetch failed' };
+      }
+      const capped = truncateUtf8(text, WEB_TEXT_MAX_BYTES);
+      return { result, excerpts: rankWebContentByQuery(capped, query, excerptsPerPage) };
+    }),
+  );
+}
+
+/**
+ * Render enriched pages as a block appended below the result list.
+ * @param {string} query
+ * @param {EnrichedPage[]} pages
+ * @returns {string}
+ */
+export function formatResultExcerpts(query, pages) {
+  const blocks = [];
+  for (const [index, page] of pages.entries()) {
+    const header = `[${index + 1}] ${page.result.title}\n    ${page.result.url}`;
+    if (page.error) {
+      blocks.push(`${header}\n    (could not read page: ${page.error})`);
+      continue;
+    }
+    if (!page.excerpts.length) {
+      blocks.push(`${header}\n    (no passages matched the query)`);
+      continue;
+    }
+    const body = page.excerpts.map((excerpt) => `    - ${excerpt}`).join('\n');
+    blocks.push(`${header}\n${body}`);
+  }
+
+  if (!blocks.length) {
+    return '';
+  }
+  return `\n\nPage excerpts for "${query}":\n\n${blocks.join('\n\n')}`;
+}
+
+/**
+ * Search-result text with ranked page excerpts appended.
+ * @param {string} query
+ * @param {SearchResult[]} results
+ * @param {string} formatted Already-formatted result listing.
+ * @param {{ pageLimit?: number; excerptsPerPage?: number }} [opts]
+ * @returns {Promise<string>}
+ */
+export async function appendResultExcerpts(query, results, formatted, opts = {}) {
+  if (!results.length) {
+    return formatted;
+  }
+  const pages = await fetchResultExcerpts(query, results, opts);
+  return `${formatted}${formatResultExcerpts(query, pages)}`;
+}

--- a/server/tools/search-result.js
+++ b/server/tools/search-result.js
@@ -26,6 +26,133 @@ export function normalizeSearchResults(results) {
 }
 
 /**
+ * Words carried by almost every query; they match everything and would mask a decoy.
+ */
+const QUERY_STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'are', 'how', 'what', 'why', 'when', 'where', 'does',
+  'did', 'can', 'from', 'that', 'this', 'you', 'your', 'has', 'have', 'was', 'were',
+  'not', 'but', 'all', 'any', 'its', 'use', 'using', 'get', 'set', 'best', 'vs',
+]);
+
+/**
+ * Distinctive lowercase tokens from a query.
+ *
+ * Keeps `+ # . -` so `c++`, `c#`, `node.js` and `happy-dom` survive; drops tokens
+ * shorter than three characters (version numbers, articles) and stopwords.
+ * @param {string} query
+ * @returns {string[]}
+ */
+export function tokenizeQuery(query) {
+  const cleaned = String(query ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9+#.\-]+/g, ' ');
+  const tokens = cleaned
+    .split(/\s+/)
+    .map((token) => token.replace(/^[.\-]+|[.\-]+$/g, ''))
+    .filter((token) => token.length >= 3 && !QUERY_STOPWORDS.has(token));
+  return [...new Set(tokens)];
+}
+
+/**
+ * Fraction of results mentioning at least one distinctive query token.
+ * @param {string} query
+ * @param {SearchResult[]} results
+ * @returns {number} 0..1, or 1 when there is nothing meaningful to judge
+ */
+export function resultSetCoverage(query, results) {
+  const tokens = tokenizeQuery(query);
+  const rows = normalizeSearchResults(results);
+  if (!tokens.length || !rows.length) {
+    return 1;
+  }
+
+  let hits = 0;
+  for (const row of rows) {
+    const haystack = `${row.title} ${row.url} ${row.snippet}`.toLowerCase();
+    if (tokens.some((token) => haystack.includes(token))) {
+      hits += 1;
+    }
+  }
+  return hits / rows.length;
+}
+
+/**
+ * Coverage at or above which a result set is trusted wholesale.
+ *
+ * Below it the set is treated as contaminated and filtered row by row. Measured against
+ * live multi-engine result sets: healthy sets scored 0.75–1.00, sets carrying Bing decoy
+ * rows scored 0.00–0.35. Filtering rather than discarding matters because a mixed set
+ * (good Stack Overflow rows + decoy Bing rows) can score as low as 0.23 — dropping it
+ * whole would throw away the good rows with the bad.
+ */
+export const HEALTHY_COVERAGE_THRESHOLD = 0.6;
+
+/** Result sets smaller than this are too thin to judge — a narrow query can legitimately return one hit. */
+const MIN_RESULTS_TO_JUDGE = 3;
+
+/** True when a single row mentions any distinctive query token. */
+function rowMatchesQuery(row, tokens) {
+  const haystack = `${row.title} ${row.url} ${row.snippet}`.toLowerCase();
+  return tokens.some((token) => haystack.includes(token));
+}
+
+/**
+ * True when nothing in a result set relates to the query.
+ *
+ * Used to reject poisoned cache entries. Deliberately strict: a set with even one
+ * relevant row is salvageable by {@link applyRelevanceGuard} and should not be thrown out.
+ * @param {string} query
+ * @param {SearchResult[]} results
+ * @returns {boolean}
+ */
+export function looksUnrelated(query, results) {
+  const rows = normalizeSearchResults(results);
+  const tokens = tokenizeQuery(query);
+  if (rows.length < MIN_RESULTS_TO_JUDGE || !tokens.length) {
+    return false;
+  }
+  return !rows.some((row) => rowMatchesQuery(row, tokens));
+}
+
+/**
+ * Strip results that do not answer the query.
+ *
+ * Guards against providers that fail *open*: Bing serves decoy SERPs (HTTP 200, correct
+ * page title, well-formed results belonging to entirely different queries) rather than an
+ * error or an empty page, so result count alone cannot detect the failure.
+ *
+ * A healthy set is passed through untouched — filtering there would drop results that are
+ * relevant but phrased differently from the query. A contaminated set is filtered down to
+ * its matching rows, and only a set with nothing left fails the provider so the caller
+ * falls through to the next one.
+ * @param {string} providerLabel
+ * @param {string} query
+ * @param {SearchResult[]} results
+ * @returns {{ results: SearchResult[]; error?: string }}
+ */
+export function applyRelevanceGuard(providerLabel, query, results) {
+  const rows = normalizeSearchResults(results);
+  const tokens = tokenizeQuery(query);
+  if (rows.length < MIN_RESULTS_TO_JUDGE || !tokens.length) {
+    return { results: rows };
+  }
+  if (resultSetCoverage(query, rows) >= HEALTHY_COVERAGE_THRESHOLD) {
+    return { results: rows };
+  }
+
+  const kept = rows.filter((row) => rowMatchesQuery(row, tokens));
+  if (!kept.length) {
+    return {
+      results: [],
+      error:
+        `Error: ${providerLabel} returned ${rows.length} results unrelated to "${query}" ` +
+        '(likely an anti-scraping decoy page); discarded.',
+    };
+  }
+  return { results: kept };
+}
+
+/**
  * Format structured rows for model-facing tool output.
  * @param {string} providerLabel
  * @param {string} query

--- a/server/tools/web-search-brave.js
+++ b/server/tools/web-search-brave.js
@@ -3,6 +3,7 @@
  */
 
 import {
+  applyRelevanceGuard,
   formatSearchResults,
   normalizeSearchResults,
 } from './search-result.js';
@@ -76,7 +77,7 @@ export async function searchBraveStructured(query, apiKey, count = BRAVE_DEFAULT
     return { results: [], error: `No Brave results found for: ${query}` };
   }
 
-  return { results };
+  return applyRelevanceGuard('Brave', query, results);
 }
 
 /**

--- a/server/tools/web-search-ddg.js
+++ b/server/tools/web-search-ddg.js
@@ -3,6 +3,7 @@
  */
 
 import {
+  applyRelevanceGuard,
   formatSearchResults,
   normalizeSearchResults,
 } from './search-result.js';
@@ -142,7 +143,7 @@ export async function searchDdgStructured(query) {
     return { results: [], error: `No DuckDuckGo results found for: ${query}` };
   }
 
-  return { results };
+  return applyRelevanceGuard('DuckDuckGo', query, results);
 }
 
 /** User-facing message when DDG serves a bot challenge instead of results. */

--- a/server/tools/web-search-searxng.js
+++ b/server/tools/web-search-searxng.js
@@ -3,6 +3,7 @@
  */
 
 import {
+  applyRelevanceGuard,
   formatSearchResults,
   normalizeSearchResults,
 } from './search-result.js';
@@ -88,7 +89,7 @@ export async function searchSearxngStructured(query, searxngBaseUrl, count = SEA
     return { results: [], error: `No SearXNG results found for: ${query}${engineHint}` };
   }
 
-  return { results };
+  return applyRelevanceGuard('SearXNG', query, results);
 }
 
 /**

--- a/server/tools/web-search-tavily.js
+++ b/server/tools/web-search-tavily.js
@@ -3,6 +3,7 @@
  */
 
 import {
+  applyRelevanceGuard,
   formatSearchResults,
   normalizeSearchResults,
 } from './search-result.js';
@@ -82,7 +83,7 @@ export async function searchTavilyStructured(query, apiKey, maxResults = TAVILY_
     return { results: [], error: `No Tavily results found for: ${query}` };
   }
 
-  return { results };
+  return applyRelevanceGuard('Tavily', query, results);
 }
 
 /**

--- a/src/headless/execute-tool.ts
+++ b/src/headless/execute-tool.ts
@@ -7,6 +7,7 @@ import { isToolAllowedForMode, filterToolsByMode } from '../chat/modes/tool-poli
 import { normalizeModeId, type ModeId } from '../chat/modes/types';
 import {
   ensureToolConfigReady,
+  getToolPermissionForId,
   isToolEnabled,
   loadToolConfig,
 } from '../tools/config';
@@ -170,7 +171,12 @@ export async function executeHeadlessTool(
           'Error: Brave web search requires the Minnow browser UI. Select Tavily or DuckDuckGo in Settings → Tools for headless mode.',
       };
     }
-    const serverTool = route.kind === 'tavily' ? 'web_search_tavily' : 'web_search_ddg';
+    const serverTool =
+      route.kind === 'tavily'
+        ? 'web_search_tavily'
+        : route.kind === 'searxng'
+          ? 'web_search_searxng'
+          : 'web_search_ddg';
     const blockedWeb = maybeBlockHeadlessToolApproval(
       'web_search',
       args,
@@ -179,11 +185,17 @@ export async function executeHeadlessTool(
       name,
     );
     if (blockedWeb) return blockedWeb;
-    return postServerTool(serverTool, { query: args.query }, modeId);
+    // Mirrors client.ts: deep_read fetches result pages, so it needs fetch_web_content.
+    const deepRead =
+      args.deep_read === true &&
+      getToolPermissionForId(config, 'fetch_web_content') !== 'off';
+    return postServerTool(serverTool, { query: args.query, deep_read: deepRead }, modeId);
   }
 
   const permissionId =
-    name === 'web_search_ddg' || name === 'web_search_tavily'
+    name === 'web_search_ddg' ||
+    name === 'web_search_tavily' ||
+    name === 'web_search_searxng'
       ? 'web_search'
       : (tool?.id ?? name);
   const blocked = maybeBlockHeadlessToolApproval(

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -12,6 +12,7 @@ import { executeIssueTool } from './issue-tools';
 import { executeSubAgentTool } from './sub-agent-executor';
 import {
   ensureToolConfigReady,
+  getToolPermissionForId,
   isLocalServerAvailable,
   isToolEnabled,
   loadToolConfig,
@@ -429,6 +430,12 @@ async function executeToolInner(
       return { content: route.message };
     }
 
+    // deep_read makes the search backend fetch result pages, which is what
+    // fetch_web_content is permissioned for — don't let web_search route around it.
+    const deepRead =
+      enrichedArgs.deep_read === true &&
+      getToolPermissionForId(config, 'fetch_web_content') !== 'off';
+
     return executeWithResultCache('web_search', enrichedArgs, context, async () => {
       if (route.kind === 'brave') {
         return { content: await executeBrowserTool(name, enrichedArgs) };
@@ -436,15 +443,18 @@ async function executeToolInner(
       if (route.kind === 'tavily') {
         return executeServerTool('web_search_tavily', {
           query: enrichedArgs.query,
+          deep_read: deepRead,
         });
       }
       if (route.kind === 'searxng') {
         return executeServerTool('web_search_searxng', {
           query: enrichedArgs.query,
+          deep_read: deepRead,
         });
       }
       return executeServerTool('web_search_ddg', {
         query: enrichedArgs.query,
+        deep_read: deepRead,
       });
     });
   }

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -164,7 +164,11 @@ export function getToolPermissionForId(
   const raw = config.permissions.default[id];
   if (isToolPermissionMode(raw)) return raw;
   if (id.startsWith('mcp__') || id.startsWith('plugin__')) return 'ask';
-  if (id === 'web_search_ddg' || id === 'web_search_tavily') {
+  if (
+    id === 'web_search_ddg' ||
+    id === 'web_search_tavily' ||
+    id === 'web_search_searxng'
+  ) {
     return getToolPermissionForId(config, 'web_search');
   }
   const tool = BUILT_IN_TOOLS.find((t) => t.id === id);

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -119,6 +119,11 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
       'Search the web for up-to-date information. Provider is configured in Settings → Tools (Brave API, Tavily API, or DuckDuckGo via local server).',
       {
         query: { type: 'string', description: 'Search query' },
+        deep_read: {
+          type: 'boolean',
+          description:
+            'Also fetch the top 3 results and return the passages most relevant to the query. Slower, but usually avoids a follow-up fetch_web_content call.',
+        },
         api_key: {
           type: 'string',
           description: 'Optional Brave Search API key (overrides saved key when Brave is selected)',

--- a/test/research/search-chain.test.mjs
+++ b/test/research/search-chain.test.mjs
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import { resetMinnowHomeCache } from '../../server/config/home.js';
 import {
   buildProviderChain,
+  getLastSearchDiscardedUnrelated,
   getLastSearchError,
   getLastSearchProvider,
   searchStructured,
@@ -118,6 +119,78 @@ describe('searchStructured', () => {
     const results = await searchStructured('no hits', { useCache: false });
     assert.equal(results.length, 0);
     assert.match(getLastSearchError() ?? '', /No SearXNG results|No Tavily|No DuckDuckGo/);
+  });
+
+  it('falls back to Tavily when SearXNG returns a decoy SERP', async () => {
+    const decoy = [
+      { title: 'Nick Jr. | Homepage', url: 'https://www.nickjr.com/', content: 'Preschool games' },
+      { title: 'Convert m to cm', url: 'https://unitconverters.net/', content: 'Length units' },
+      { title: 'Booking.com', url: 'https://www.booking.com/', content: 'Hotels and flights' },
+      { title: 'Speedtest by Ookla', url: 'https://www.speedtest.net/', content: 'Internet speed' },
+    ];
+
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.includes('localhost:18080')) {
+        return { ok: true, status: 200, json: async () => ({ results: decoy }) };
+      }
+      if (url.includes('api.tavily.com')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            results: [
+              {
+                title: 'chokidar v4 watch options',
+                url: 'https://github.com/paulmillr/chokidar',
+                content: 'chokidar watch options changed in v4',
+              },
+            ],
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    };
+
+    const results = await searchStructured('chokidar v4 watch options', { useCache: false });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].url, 'https://github.com/paulmillr/chokidar');
+    assert.equal(getLastSearchProvider(), 'tavily');
+    assert.equal(getLastSearchDiscardedUnrelated(), true);
+  });
+
+  it('ignores a cached result set that no longer matches its query', async () => {
+    const chain = ['searxng', 'tavily', 'duckduckgo'];
+    const key = JSON.stringify({ query: 'chokidar v4 watch options', chain, count: 5 });
+    await setSearch(key, [
+      { title: 'Nick Jr. | Homepage', url: 'https://www.nickjr.com/', snippet: 'Preschool games' },
+      { title: 'Convert m to cm', url: 'https://unitconverters.net/', snippet: 'Length units' },
+      { title: 'Booking.com', url: 'https://www.booking.com/', snippet: 'Hotels and flights' },
+    ]);
+
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.includes('localhost:18080')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            results: [
+              {
+                title: 'chokidar v4 release notes',
+                url: 'https://github.com/paulmillr/chokidar/releases',
+                content: 'New watch options in v4',
+              },
+            ],
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    };
+
+    const results = await searchStructured('chokidar v4 watch options');
+    assert.equal(results.length, 1);
+    assert.match(results[0].url, /chokidar/);
   });
 
   it('reads and writes disk search cache with TTL', async () => {

--- a/test/servers/searxng-provisioner.test.mjs
+++ b/test/servers/searxng-provisioner.test.mjs
@@ -132,6 +132,36 @@ describe('searxng provisioner', () => {
     assert.ok(yaml.includes('name: startpage'));
   });
 
+  it('writeSearxngSettings filters adult content by default', async () => {
+    await writeSearxngSettings(FIXED_PORT);
+    const yaml = await fsp.readFile(getServerSettingsPath('searxng'), 'utf8');
+    assert.match(yaml, /safe_search: 1/);
+  });
+
+  it('writeSearxngSettings keeps a second general engine alongside bing', async () => {
+    await writeSearxngSettings(FIXED_PORT);
+    const yaml = await fsp.readFile(getServerSettingsPath('searxng'), 'utf8');
+
+    // Bing fails open (decoy SERPs), so it must never be the only general engine.
+    assert.match(yaml, /name: duckduckgo\s*\n\s*disabled: false/);
+    assert.match(yaml, /name: stackoverflow\s*\n\s*categories: \[general, it, "q&a"\]\s*\n\s*disabled: false/);
+  });
+
+  it('writeSearxngSettings reuses the existing secret key across rewrites', async () => {
+    await writeSearxngSettings(FIXED_PORT);
+    const first = await fsp.readFile(getServerSettingsPath('searxng'), 'utf8');
+    const firstKey = /secret_key: "([0-9a-f]{64})"/.exec(first)?.[1];
+    assert.ok(firstKey);
+
+    // A port change rewrites settings; the key must survive or SearXNG truncates its cache.
+    await writeSearxngSettings(FIXED_PORT + 1);
+    const second = await fsp.readFile(getServerSettingsPath('searxng'), 'utf8');
+    const secondKey = /secret_key: "([0-9a-f]{64})"/.exec(second)?.[1];
+
+    assert.equal(secondKey, firstKey);
+    assert.match(second, new RegExp(`port: ${FIXED_PORT + 1}`));
+  });
+
   it('getSpawnSpec returns venv python, searx module, settings env, and cwd', async () => {
     await ensureTestVenv();
     const python = venvPythonPath();

--- a/test/tools/search-enrich.test.mjs
+++ b/test/tools/search-enrich.test.mjs
@@ -1,0 +1,74 @@
+/**
+ * Search enrichment — ranked page excerpts appended to a result listing.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  appendResultExcerpts,
+  formatResultExcerpts,
+} from '../../server/tools/search-enrich.js';
+
+const RESULT = {
+  title: 'chokidar - npm',
+  url: 'https://www.npmjs.com/package/chokidar',
+  snippet: 'Neat wrapper around fs.watch',
+};
+
+describe('formatResultExcerpts', () => {
+  it('renders title, url, and ranked passages', () => {
+    const text = formatResultExcerpts('chokidar watch options', [
+      { result: RESULT, excerpts: ['awaitWriteFinish stabilises writes.', 'usePolling falls back to stat polling.'] },
+    ]);
+
+    assert.match(text, /Page excerpts for "chokidar watch options"/);
+    assert.match(text, /\[1\] chokidar - npm/);
+    assert.match(text, /https:\/\/www\.npmjs\.com\/package\/chokidar/);
+    assert.match(text, /- awaitWriteFinish stabilises writes\./);
+    assert.match(text, /- usePolling falls back to stat polling\./);
+  });
+
+  it('reports an unreadable page inline instead of dropping it', () => {
+    const text = formatResultExcerpts('chokidar', [
+      { result: RESULT, excerpts: [], error: 'Error: HTTP 403' },
+    ]);
+    assert.match(text, /could not read page: Error: HTTP 403/);
+  });
+
+  it('notes when a page yielded no matching passages', () => {
+    const text = formatResultExcerpts('chokidar', [{ result: RESULT, excerpts: [] }]);
+    assert.match(text, /no passages matched the query/);
+  });
+
+  it('returns empty string when there is nothing to render', () => {
+    assert.equal(formatResultExcerpts('chokidar', []), '');
+  });
+});
+
+describe('appendResultExcerpts', () => {
+  it('returns the listing unchanged when there are no results', async () => {
+    const listing = 'No SearXNG results found for: chokidar';
+    assert.equal(await appendResultExcerpts('chokidar', [], listing), listing);
+  });
+
+  it('appends excerpts below the original listing', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/html' }),
+      text: async () =>
+        '<html><body><p>Chokidar exposes awaitWriteFinish to stabilise partial writes.</p></body></html>',
+    });
+
+    try {
+      const listing = 'SearXNG search results for "chokidar":\n\n1. chokidar - npm';
+      const text = await appendResultExcerpts('chokidar awaitWriteFinish', [RESULT], listing, {
+        pageLimit: 1,
+      });
+      assert.ok(text.startsWith(listing), 'original listing must be preserved');
+      assert.match(text, /Page excerpts for "chokidar awaitWriteFinish"/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/test/tools/search-relevance-guard.test.mjs
+++ b/test/tools/search-relevance-guard.test.mjs
@@ -1,0 +1,200 @@
+/**
+ * Relevance guard — discards anti-scraping decoy result sets (MIN-618).
+ *
+ * Fixtures are shaped after real captures: Bing answers long-tail queries with HTTP 200,
+ * the correct page title, and 10 well-formed results belonging to unrelated queries.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  applyRelevanceGuard,
+  HEALTHY_COVERAGE_THRESHOLD,
+  looksUnrelated,
+  resultSetCoverage,
+  tokenizeQuery,
+} from '../../server/tools/search-result.js';
+import { searchSearxngStructured } from '../../server/tools/web-search-searxng.js';
+
+/** Verbatim shape of an observed decoy SERP for "chokidar v4 watch options changes". */
+const DECOY_RESULTS = [
+  { title: 'Anmelden bei Hotmail | Microsoft Support', url: 'https://support.microsoft.com/hotmail', snippet: 'Hotmail anmelden' },
+  { title: 'Convert m to cm', url: 'https://www.unitconverters.net/length/m-to-cm.htm', snippet: 'Meters to centimeters' },
+  { title: 'Nick Jr. | Homepage', url: 'https://www.nickjr.com/', snippet: 'Games and videos for preschoolers' },
+  { title: 'Speedtest by Ookla', url: 'https://www.speedtest.net/', snippet: 'Test your internet speed' },
+  { title: 'Booking.com | Official site', url: 'https://www.booking.com/', snippet: 'Hotels, flights, car rentals' },
+  { title: 'Italy Population (2026) - Worldometer', url: 'https://www.worldometers.info/world-population/italy-population/', snippet: 'Population of Italy' },
+  { title: 'Fisherman’s Wharf San Francisco', url: 'https://www.fishermanswharf.org/', snippet: 'Visit the wharf' },
+];
+
+/** A genuine result set for the same query. */
+const GENUINE_RESULTS = [
+  { title: 'GitHub - paulmillr/chokidar: Minimal and efficient file watching', url: 'https://github.com/paulmillr/chokidar', snippet: 'Minimal and efficient cross-platform file watching library' },
+  { title: 'chokidar - npm', url: 'https://www.npmjs.com/package/chokidar', snippet: 'Neat wrapper around node.js fs.watch / fs.watchFile' },
+  { title: 'Chokidar v4 release notes', url: 'https://github.com/paulmillr/chokidar/releases', snippet: 'Dropped glob support, new watch options' },
+  { title: 'Migrating to chokidar 4', url: 'https://example.dev/blog/chokidar-4-migration', snippet: 'What changed in the v4 API' },
+];
+
+describe('tokenizeQuery', () => {
+  it('keeps distinctive tokens and drops stopwords and short tokens', () => {
+    assert.deepEqual(tokenizeQuery('chokidar v4 watch options changes'), [
+      'chokidar',
+      'watch',
+      'options',
+      'changes',
+    ]);
+  });
+
+  it('preserves punctuation that carries meaning', () => {
+    assert.deepEqual(tokenizeQuery('happy-dom vs node.js and c++'), [
+      'happy-dom',
+      'node.js',
+      'c++',
+    ]);
+  });
+
+  it('returns nothing for a query with no distinctive tokens', () => {
+    assert.deepEqual(tokenizeQuery('how do I use it'), []);
+    assert.deepEqual(tokenizeQuery('   '), []);
+  });
+});
+
+describe('resultSetCoverage', () => {
+  it('scores a genuine result set at 1', () => {
+    assert.equal(resultSetCoverage('chokidar v4 watch options changes', GENUINE_RESULTS), 1);
+  });
+
+  it('scores a decoy result set near zero', () => {
+    const coverage = resultSetCoverage('chokidar v4 watch options changes', DECOY_RESULTS);
+    assert.ok(coverage < 0.15, `expected near-zero coverage, got ${coverage}`);
+  });
+
+  it('matches tokens appearing only in the URL', () => {
+    const rows = [
+      { title: 'Minimal and efficient file watching', url: 'https://github.com/paulmillr/chokidar', snippet: '' },
+    ];
+    assert.equal(resultSetCoverage('chokidar', rows), 1);
+  });
+});
+
+describe('looksUnrelated', () => {
+  it('rejects a wholly unrelated result set', () => {
+    assert.equal(looksUnrelated('chokidar v4 watch options changes', DECOY_RESULTS), true);
+  });
+
+  it('accepts a genuine result set', () => {
+    assert.equal(looksUnrelated('chokidar v4 watch options changes', GENUINE_RESULTS), false);
+  });
+
+  it('keeps a set that still holds one relevant row', () => {
+    const salvageable = [...DECOY_RESULTS, GENUINE_RESULTS[0]];
+    assert.equal(looksUnrelated('chokidar v4 watch options changes', salvageable), false);
+  });
+
+  it('does not judge result sets too thin to be a decoy', () => {
+    assert.equal(looksUnrelated('chokidar watch options', DECOY_RESULTS.slice(0, 2)), false);
+  });
+
+  it('does not judge queries with no distinctive tokens', () => {
+    assert.equal(looksUnrelated('how do I use it', DECOY_RESULTS), false);
+  });
+});
+
+describe('applyRelevanceGuard', () => {
+  it('passes a healthy result set through untouched', () => {
+    const outcome = applyRelevanceGuard('SearXNG', 'chokidar v4 watch options', GENUINE_RESULTS);
+    assert.equal(outcome.error, undefined);
+    assert.deepEqual(outcome.results, GENUINE_RESULTS);
+  });
+
+  it('discards an all-decoy set and explains why', () => {
+    const outcome = applyRelevanceGuard('SearXNG', 'chokidar v4 watch options', DECOY_RESULTS);
+    assert.deepEqual(outcome.results, []);
+    assert.match(outcome.error ?? '', /unrelated to "chokidar v4 watch options"/);
+    assert.match(outcome.error ?? '', /decoy/);
+  });
+
+  it('salvages the relevant rows from a contaminated set', () => {
+    // Shaped after a real capture: 3 relevant Stack Overflow rows among 10 Bing decoys
+    // scored 0.23 coverage, which a set-level discard would have thrown away entirely.
+    const contaminated = [
+      GENUINE_RESULTS[0],
+      ...DECOY_RESULTS,
+      GENUINE_RESULTS[1],
+      GENUINE_RESULTS[2],
+    ];
+    const coverage = resultSetCoverage('chokidar v4 watch options', contaminated);
+    assert.ok(coverage < HEALTHY_COVERAGE_THRESHOLD, `expected contaminated set, got ${coverage}`);
+
+    const outcome = applyRelevanceGuard('SearXNG', 'chokidar v4 watch options', contaminated);
+    assert.equal(outcome.error, undefined);
+    assert.deepEqual(outcome.results, [
+      GENUINE_RESULTS[0],
+      GENUINE_RESULTS[1],
+      GENUINE_RESULTS[2],
+    ]);
+  });
+
+  it('leaves a healthy set alone even when one row is off-topic', () => {
+    // Filtering a healthy set would drop relevant results phrased differently.
+    const mostlyGood = [...GENUINE_RESULTS, DECOY_RESULTS[0]];
+    const outcome = applyRelevanceGuard('SearXNG', 'chokidar v4 watch options', mostlyGood);
+    assert.equal(outcome.results.length, mostlyGood.length);
+  });
+});
+
+describe('searchSearxngStructured relevance guard', () => {
+  /** @type {typeof globalThis.fetch | undefined} */
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('discards a decoy SERP so callers fall through to the next provider', async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        results: DECOY_RESULTS.map((row) => ({
+          title: row.title,
+          url: row.url,
+          content: row.snippet,
+        })),
+      }),
+    });
+
+    const { results, error } = await searchSearxngStructured(
+      'chokidar v4 watch options changes',
+      'http://127.0.0.1:8899',
+    );
+    assert.deepEqual(results, []);
+    assert.match(error ?? '', /unrelated/);
+  });
+
+  it('keeps a genuine SERP', async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        results: GENUINE_RESULTS.map((row) => ({
+          title: row.title,
+          url: row.url,
+          content: row.snippet,
+        })),
+      }),
+    });
+
+    const { results, error } = await searchSearxngStructured(
+      'chokidar v4 watch options changes',
+      'http://127.0.0.1:8899',
+    );
+    assert.equal(error, undefined);
+    assert.equal(results.length, GENUINE_RESULTS.length);
+  });
+});


### PR DESCRIPTION
## The bug

Web search returned results with no relation to the query. Dev queries came back as news sites, Eminem, box.com login pages — and porn.

The cause is not Minnow's parsing. For queries it has no cached SERP for, **Bing answers HTTP 200 with the correct `<title>` and searchbox echo, but the `li.b_algo` blocks belong to entirely different queries**, and the content differs on every request. Reproduced outside SearXNG with plain `fetch`; no combination of User-Agent, `Accept-Language`, cookies, or `adlt` changes it.

Measured, 6 runs each:

| Query | On-topic |
|---|---|
| `weather in london` | 6/6 |
| `electron latest stable version` | 6/6 |
| `chokidar` | 0/6 |
| `chokidar v4 API watch options changes` | 0/6 |

Head queries Bing has cached come back perfect. Long-tail queries — exactly what developers type — get filler.

**Nothing caught it because every fallback in the stack triggers on `results.length === 0`, and a decoy returns a full ten results.** Bing fails *open*; the code assumed providers fail closed.

## Relevance guard

`server/tools/search-result.js` scores each result set by the fraction of rows mentioning a distinctive query token.

- Healthy set → passed through untouched.
- Contaminated set → filtered to its matching rows.
- Nothing left → provider fails, and the chain falls through exactly as it already does for empty results.

Applied in the shared normalizer, so all four providers get it.

**Filtering rather than discarding matters.** The first cut used a set-level discard at 0.34 coverage, calibrated on pure-Bing sets. Testing against a live multi-engine instance showed that was wrong: a mix of good Stack Overflow rows and Bing decoys scored **0.31**, so a wholesale discard threw away the good rows with the bad, and `weather in london` scored 0.35 — one point from being dropped outright.

Live behaviour on the final design:

```
FALLBACK  cov=0.00  10 -> 0   chokidar v4 watch options changes
FALLBACK  cov=0.00   9 -> 0   happy-dom vs jsdom performance
FILTERED  cov=0.31  13 -> 4   lxml xpath contains class attribute
KEEP-ALL  cov=1.00  11 -> 11  esbuild external packages flag
KEEP-ALL  cov=0.75  20 -> 20  node test module mocks experimental
KEEP-ALL  cov=0.85  20 -> 20  weather in london
```

The research chain also re-checks cached entries on read — a decoy that landed in the 2h disk cache otherwise stayed pinned for its whole TTL, which is why the bad results looked persistent rather than intermittent.

## Engine configuration

Bing was the only general engine actually answering. Measured from an unauthenticated client: `brave`, `startpage`, `mojeek` return nothing; `google` is enabled but returns **zero silently** — it never appears in `unresponsive_engines`, so the config looked diverse while effectively having one engine.

- **DuckDuckGo re-enabled.** It rate-limits to *zero* results, which the chain handles, and it corroborates or outranks Bing's junk. It was disabled for rate-limiting, but that traded "sometimes empty" for "sometimes confidently wrong".
- **`stackoverflow` promoted into `general`**, since dev queries are the long-tail ones Bing decoys on. The rest of the `it` category stays out — `mdn` and `docker hub` are keyword matchers that dilute badly (`chokidar v4 watch options` → MDN `Geolocation.watchPosition`).
- **`safe_search: 1`.** It was unset, so `adlt=off` went to Bing and the decoys were unfiltered. This is the difference between "weird results" and "porn in tool output".
- **`server.secret_key` no longer regenerated on every launch.** SearXNG derives its cache hash token from it, so each start logged `[DATA_CACHE] hash token changed: truncate all cache tables`.

## Search quality

`web_search` takes an opt-in `deep_read` that fetches the top 3 results and returns ranked excerpts via the existing `rag_web_content` ranker, instead of one-line snippets that usually force a second round-trip anyway. Gated on the `fetch_web_content` permission so `web_search` cannot route around it.

## Also fixed in passing

- Headless routing sent the `searxng` provider to DuckDuckGo (`route.kind === 'tavily' ? … : 'web_search_ddg'`).
- `web_search_searxng` now maps onto the `web_search` permission like its siblings.

## Verification

- Generated `settings.yml` parses through the real `searx.settings_loader`; confirmed `safe_search = 1` and the enabled general engines on a live instance.
- Guard exercised against live result sets from that instance (table above).
- 46 new/updated assertions; `tsc --noEmit` clean; **full `npm test` green, exit 0**.

## Not included

Making Tavily the recommended provider. It's the strongest quality lever — DuckDuckGo contributed zero results in all four live dev queries, so it is not a reliable second engine on its own, and free-tier scraping is a permanently degrading base. But that's a settings/UX change rather than a bug fix, so it belongs in its own PR.

The Bing decoy behaviour was only tested from one IP; whether it affects all users or is network-specific is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
