### PR TITLE
Fix Est. cost metric cell overlap and equalize stat cell widths

### DIFF
--- a/src/styles/stats.css
+++ b/src/styles/stats.css
@@ -65,10 +65,9 @@
 
 .stats-panel {
   display: grid;
-  /* 4 inference stats + compact cost + token bars + model info (7 children) */
+  /* 5 inference stats (incl. cost) + token bars + model info (7 children) */
   grid-template-columns:
-    repeat(4, minmax(0, 1fr))
-    minmax(72px, max-content)
+    repeat(5, minmax(0, 1fr))
     minmax(120px, 1.4fr)
     minmax(100px, 1fr);
 }
@@ -116,16 +115,6 @@
 .stat-cell.red .stat-val { color: var(--mn-danger); }
 .stat-cell.purple .stat-val { color: color-mix(in srgb, var(--mn-accent) 70%, var(--mn-fg)); }
 .stat-val.blank { color: var(--mn-border-strong) !important; }
-
-/* Est. cost values are short; keep the column narrow so model info stays on one row */
-.stat-cell.purple {
-  min-width: 0;
-  padding-inline: 10px 12px;
-}
-
-.stat-cell.purple .stat-name {
-  gap: 6px;
-}
 
 /* File editor split: compact metrics in the chat column only (feature 26 / E6) */
 .workspace-split.viewer-open .stats-strip {


### PR DESCRIPTION
## What

Fixes the Est. cost cell in the bottom token-metrics strip: its icon was overlapping the label, and the five metric cells were not the same size.

## Why

The cost cell was deliberately squeezed to keep the model-info column on one row: it got a narrow `max-content` grid track plus `.stat-cell.purple` overrides that cut its padding to `10px 12px` and its icon gap to `6px`. That collision made the scale icon sit on top of the "Est. cost" label, and the uneven track made it visibly narrower than the other four metrics.

There is plenty of width available in the strip, so the squeeze isn't needed. All five metric cells should read as a uniform row of bench gauges.

## Changes

- `src/styles/stats.css` — desktop `.stats-panel` grid is now `repeat(5, minmax(0, 1fr))` so all five stat cells (Tokens/s, TTFT, Generation Time, Total Tokens, Est. cost) share equal tracks, instead of 4×`1fr` + one `max-content` cost column.
- Removed the `.stat-cell.purple` padding override and the `.stat-cell.purple .stat-name { gap: 6px }` override. The cost cell now uses the shared `.stat-cell` padding (`10px 14px`) and `.stat-name` gap (`15px`) like the others.

## Testing

- Verified in the running dev server: all five stat cells report identical computed widths, and the cost cell now carries the standard `15px` icon gap / `10px 14px` padding.
- CSS-only change; no new dependencies.
