### PR TITLE
Orchestrate board cleanup: concurrency+hands-off, worktree lifecycle, drag UX, always-on finish report

### DIFF
--- a/server/config/sessions-repo.js
+++ b/server/config/sessions-repo.js
@@ -382,6 +382,10 @@ export function readWholeSessionState() {
   if (typeof activeBoardGroupId === 'string' && activeBoardGroupId) {
     raw.activeBoardGroupId = activeBoardGroupId;
   }
+  const lastBoardGroupId = readSessionMeta(db, 'lastBoardGroupId');
+  if (typeof lastBoardGroupId === 'string' && lastBoardGroupId) {
+    raw.lastBoardGroupId = lastBoardGroupId;
+  }
   const codeChangeTotalsByWorkspace = readSessionMeta(db, 'codeChangeTotalsByWorkspace');
   if (codeChangeTotalsByWorkspace && typeof codeChangeTotalsByWorkspace === 'object') {
     raw.codeChangeTotalsByWorkspace = codeChangeTotalsByWorkspace;
@@ -714,6 +718,11 @@ function writeScalars(db, state) {
     writeSessionMeta(db, 'activeBoardGroupId', state.activeBoardGroupId);
   } else {
     writeSessionMeta(db, 'activeBoardGroupId', null);
+  }
+  if (typeof state.lastBoardGroupId === 'string') {
+    writeSessionMeta(db, 'lastBoardGroupId', state.lastBoardGroupId);
+  } else {
+    writeSessionMeta(db, 'lastBoardGroupId', null);
   }
   writeSessionMeta(db, 'lastActiveChatIdByWorkspace', state.lastActiveChatIdByWorkspace ?? {});
   writeSessionMeta(db, 'lastActiveChatIdByApp', state.lastActiveChatIdByApp ?? {});
@@ -1340,6 +1349,10 @@ export function readSessionSummariesState(filter = {}) {
   if (typeof activeBoardGroupId === 'string' && activeBoardGroupId) {
     raw.activeBoardGroupId = activeBoardGroupId;
   }
+  const lastBoardGroupId = readSessionMeta(db, 'lastBoardGroupId');
+  if (typeof lastBoardGroupId === 'string' && lastBoardGroupId) {
+    raw.lastBoardGroupId = lastBoardGroupId;
+  }
   const codeChangeTotalsByWorkspace = readSessionMeta(db, 'codeChangeTotalsByWorkspace');
   if (codeChangeTotalsByWorkspace && typeof codeChangeTotalsByWorkspace === 'object') {
     raw.codeChangeTotalsByWorkspace = codeChangeTotalsByWorkspace;
@@ -1521,6 +1534,13 @@ function applyPartialScalars(db, scalars) {
       db,
       'activeBoardGroupId',
       typeof scalars.activeBoardGroupId === 'string' ? scalars.activeBoardGroupId : null,
+    );
+  }
+  if (Object.prototype.hasOwnProperty.call(scalars, 'lastBoardGroupId')) {
+    writeSessionMeta(
+      db,
+      'lastBoardGroupId',
+      typeof scalars.lastBoardGroupId === 'string' ? scalars.lastBoardGroupId : null,
     );
   }
   if (Object.prototype.hasOwnProperty.call(scalars, 'lastActiveChatIdByWorkspace')) {

--- a/server/config/validators.js
+++ b/server/config/validators.js
@@ -1465,8 +1465,13 @@ export function mergeConfigMeta(existing, patch) {
   }
 
   if (p.autopilot !== undefined) {
-    const AUTOPILOT_EXECUTION_MODES = new Set(['manual', 'sequential', 'auto', 'afk']);
-    const AUTOPILOT_ISOLATION_MODES = new Set(['auto', 'off', 'per-task', 'per-wave']);
+    const AUTOPILOT_ISOLATION_MODES = new Set([
+      'auto',
+      'off',
+      'per-board',
+      'per-task',
+      'per-wave',
+    ]);
     const AUTOPILOT_SHELL_SANDBOX_MODES = new Set(['off', 'prefer', 'require']);
     const clampAutopilotConcurrency = (value, fallback) => {
       if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
@@ -1509,7 +1514,7 @@ export function mergeConfigMeta(existing, patch) {
     };
     const parseBool = (value, fallback) => (typeof value === 'boolean' ? value : fallback);
     const AUTOPILOT_DEFAULTS = {
-      defaultExecutionMode: 'manual',
+      defaultHandsOff: false,
       maxConcurrentTasks: 3,
       isolationMode: 'auto',
       shellSandbox: 'off',
@@ -1537,11 +1542,8 @@ export function mergeConfigMeta(existing, patch) {
           ? { .../** @type {Record<string, unknown>} */ (base.autopilot) }
           : { ...AUTOPILOT_DEFAULTS };
       const a = /** @type {Record<string, unknown>} */ (p.autopilot);
-      if (typeof a.defaultExecutionMode === 'string') {
-        const mode = a.defaultExecutionMode.trim();
-        if (AUTOPILOT_EXECUTION_MODES.has(mode)) {
-          existingAutopilot.defaultExecutionMode = mode;
-        }
+      if (typeof a.defaultHandsOff === 'boolean') {
+        existingAutopilot.defaultHandsOff = a.defaultHandsOff;
       }
       if (a.maxConcurrentTasks !== undefined) {
         existingAutopilot.maxConcurrentTasks = clampAutopilotConcurrency(

--- a/server/settings/registry-manifest.json
+++ b/server/settings/registry-manifest.json
@@ -1313,19 +1313,19 @@
     ]
   },
   {
-    "key": "agents.autopilot.executionMode",
-    "label": "Default execution mode",
+    "key": "agents.autopilot.handsOff",
+    "label": "Hands-off by default",
+    "keywords": [
+      "afk",
+      "autonomous",
+      "unattended",
+      "hands off"
+    ],
     "category": "agents",
     "area": "autopilot",
     "storage": "meta",
-    "path": "autopilot.defaultExecutionMode",
-    "type": "enum",
-    "allowedValues": [
-      "manual",
-      "sequential",
-      "auto",
-      "afk"
-    ],
+    "path": "autopilot.defaultHandsOff",
+    "type": "boolean",
     "sensitivity": "normal",
     "writable": true,
     "refreshAreas": [
@@ -1343,6 +1343,7 @@
     "allowedValues": [
       "auto",
       "off",
+      "per-board",
       "per-task",
       "per-wave"
     ],

--- a/server/worktree/paths.js
+++ b/server/worktree/paths.js
@@ -9,14 +9,12 @@ import path from 'node:path';
 import { getMinnowHome } from '../config/home.js';
 import { getWorkspaceRoot, normalizeWorkspacePathKey } from '../workspace/root.js';
 import { isResolvedPathUnderRoot } from '../workspace/safe-path.js';
+import { sanitizePathSegment } from '../../src/lib/sanitize-path-segment.mjs';
 
 const WORKTREES_DIR_NAME = 'worktrees';
 
-/** Sanitize an id into a safe single path segment. */
-function seg(value) {
-  const cleaned = String(value).replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-  return cleaned || 'x';
-}
+/** Sanitize an id into a safe single path segment (shared with the client helpers). */
+const seg = sanitizePathSegment;
 
 /** Absolute root for all board worktrees. */
 export function getWorktreesRoot() {

--- a/server/worktree/worktree-ops.js
+++ b/server/worktree/worktree-ops.js
@@ -501,14 +501,67 @@ export async function integrationStats({ boardId, baseRef }) {
 }
 
 /**
+ * Capability probe for the workspace checkout: whether `origin` and the `gh` CLI
+ * are usable for push / PR actions.
+ */
+async function workspaceGitCapabilities(workspace) {
+  const remote = await git(['remote', 'get-url', 'origin'], workspace);
+  const hasRemote = ok(remote) && Boolean(`${remote.stdout ?? ''}`.trim());
+  let hasGh = false;
+  try {
+    const gh = await runProcess('gh', ['--version'], { cwd: workspace, timeout: 10_000 });
+    hasGh = gh.code === 0;
+  } catch {
+    hasGh = false;
+  }
+  return { hasRemote, hasGh };
+}
+
+/**
+ * Diff stats for the *uncommitted* workspace checkout — the isolation-off case,
+ * where agents wrote straight into the user's tree and there is no branch to land.
+ * Untracked files never appear in `git diff`, so they are counted from status.
+ */
+async function workspaceDirtyStats() {
+  const workspace = getWorkspaceRoot();
+  const diff = await git(['diff', '--numstat', 'HEAD'], workspace);
+  if (!ok(diff)) return { ok: false, output: out(diff) };
+  const parsed = parseGitNumstat(diff.stdout ?? '');
+
+  const status = await git(['status', '--porcelain'], workspace);
+  const untracked = `${status.stdout ?? ''}`
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('?? ')).length;
+
+  const current = await git(['branch', '--show-current'], workspace);
+  const { hasRemote, hasGh } = await workspaceGitCapabilities(workspace);
+
+  return {
+    ok: true,
+    additions: parsed.additions,
+    deletions: parsed.deletions,
+    fileCount: parsed.paths.length + untracked,
+    untrackedCount: untracked,
+    hasRemote,
+    hasGh,
+    alreadyLanded: false,
+    dirtyWorkspace: true,
+    currentBranch: `${current.stdout ?? ''}`.trim() || null,
+  };
+}
+
+/**
  * Diff stats for landing board work: integration branch vs the workspace checkout
  * (`git diff --numstat HEAD...<branch>` when not yet merged).
- * @param {{ branch: string }} input
+ *
+ * With no branch it falls back to the uncommitted workspace diff instead of
+ * erroring — a board run with isolation off has no branch but still has work.
+ * @param {{ branch?: string }} input
  */
-export async function workspaceLandingStats({ branch }) {
+export async function workspaceLandingStats({ branch } = {}) {
   const workspace = getWorkspaceRoot();
   const intBranch = (branch && branch.trim()) || '';
-  if (!intBranch) return { ok: false, error: 'branch required' };
+  if (!intBranch) return workspaceDirtyStats();
   if (!(await branchExists(intBranch))) {
     return { ok: false, error: 'integration branch not found' };
   }
@@ -525,16 +578,7 @@ export async function workspaceLandingStats({ branch }) {
   if (!ok(diff)) return { ok: false, output: out(diff) };
   const parsed = parseGitNumstat(diff.stdout ?? '');
 
-  const remote = await git(['remote', 'get-url', 'origin'], workspace);
-  const hasRemote = ok(remote) && Boolean(`${remote.stdout ?? ''}`.trim());
-
-  let hasGh = false;
-  try {
-    const gh = await runProcess('gh', ['--version'], { cwd: workspace, timeout: 10_000 });
-    hasGh = gh.code === 0;
-  } catch {
-    hasGh = false;
-  }
+  const { hasRemote, hasGh } = await workspaceGitCapabilities(workspace);
 
   return {
     ok: true,

--- a/src/chat/modes/orchestrate-tool-filter.ts
+++ b/src/chat/modes/orchestrate-tool-filter.ts
@@ -15,6 +15,7 @@ import {
 
 const BOARD_MEMBER_STRIPPED_TOOLS = new Set([
   'board_init',
+  'board_add_tasks',
   'board_update_task',
   'board_set_autonomy',
   'delegate_tasks',

--- a/src/chat/modes/tool-groups.ts
+++ b/src/chat/modes/tool-groups.ts
@@ -61,6 +61,7 @@ export const TOOL_GROUP_IDS = {
   ],
   board: [
     'board_init',
+    'board_add_tasks',
     'board_update_task',
     'board_set_autonomy',
     'board_get_state',

--- a/src/chat/orchestrate/finish-recommendations.ts
+++ b/src/chat/orchestrate/finish-recommendations.ts
@@ -26,8 +26,14 @@ import { executeTool } from '../../tools/client.ts';
 import type { ApiMessage, Chat, ChatCompletionChunk, OrchestrateBoardState } from '../../types.ts';
 import {
   FINISH_REPORT_RECOMMENDATIONS_PLACEHOLDER,
+  FINISH_REPORT_RUN_PLACEHOLDER,
   mergeFinishReportRecommendations,
+  mergeFinishReportRunInstructions,
 } from './finish-stats.ts';
+import {
+  detectProjectRunInstructions,
+  formatDetectedRunInstructions,
+} from './run-instructions-detect.ts';
 
 const RECOMMENDATIONS_SYSTEM =
   'You recommend concrete follow-up engineering tasks after an Orchestrate board run completes. ' +
@@ -40,6 +46,49 @@ const MAX_RECOMMENDATION_TOKENS = 512;
 
 /** In-flight enrichment per board group — avoids duplicate generation calls. */
 const enrichInFlight = new Map<string, Promise<void>>();
+
+/** Same guard for the (cheaper, no-LLM) run-instructions detection pass. */
+const runDetectInFlight = new Map<string, Promise<void>>();
+
+/**
+ * Fill the run-instructions placeholder from the project's manifests.
+ *
+ * Only runs when the final tester reported nothing — a verified block is written
+ * straight into the report by `buildDeterministicFinishReport` and leaves no
+ * placeholder behind.
+ */
+export async function enrichFinishReportWithRunInstructions(
+  groupId: string,
+  plannerChat: Chat,
+  board: OrchestrateBoardState,
+): Promise<void> {
+  const report = board.finishReport?.trim();
+  if (!report || !report.includes(FINISH_REPORT_RUN_PLACEHOLDER)) return;
+
+  const existing = runDetectInFlight.get(groupId);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const work = (async (): Promise<void> => {
+    const detected = await detectProjectRunInstructions().catch(() => null);
+    board.finishReport = mergeFinishReportRunInstructions(
+      board.finishReport ?? report,
+      formatDetectedRunInstructions(detected),
+    );
+    touchChat(plannerChat);
+    scheduleSaveSessions();
+    emitBoardChange(groupId);
+  })();
+
+  runDetectInFlight.set(groupId, work);
+  try {
+    await work;
+  } finally {
+    runDetectInFlight.delete(groupId);
+  }
+}
 
 function truncatePlanText(text: string, maxChars = MAX_PLAN_CHARS): string {
   const trimmed = text.trim();

--- a/src/chat/orchestrate/finish-stats.ts
+++ b/src/chat/orchestrate/finish-stats.ts
@@ -5,6 +5,7 @@
 import { getOrchestrateBoardElapsedMs } from '../../state/orchestrate-board-store.ts';
 import { findChatById } from '../../state/sessions.ts';
 import { workspaceLandingStats } from '../../state/worktree-service.ts';
+import { resolveIsolationMode } from '../../state/worktree-isolation.ts';
 import type { Chat, OrchestrateBoardState, Usage } from '../../types.ts';
 import { sumUsageSegments } from './stats-math.ts';
 
@@ -21,6 +22,8 @@ export interface FinishBoardStats {
   hasGh: boolean;
   /** True when the integration branch is already merged into the workspace HEAD. */
   alreadyLanded?: boolean;
+  /** Stats came from the uncommitted workspace checkout (no integration branch). */
+  dirtyWorkspace?: boolean;
   gitStatsLoading: boolean;
   gitStatsError?: string;
 }
@@ -127,7 +130,10 @@ export function buildDeterministicFinishReport(
   const elapsed = formatElapsedMs(getOrchestrateBoardElapsedMs(board));
   const total = board.tasks.length;
   const waves = board.waves.length;
-  const branch = board.integrationBranch?.trim() || '(not set)';
+  const integrationBranch = board.integrationBranch?.trim() || '';
+  // No branch means the agents wrote straight into the user's checkout (isolation
+  // off), so every instruction about merging or reviewing a branch is a lie.
+  const isolated = Boolean(integrationBranch) && resolveIsolationMode(board) !== 'off';
   const usage = sumUsageSegments(collectBoardUsageSegments(plannerChat, board));
   const tokenLine =
     usage.total_tokens != null
@@ -145,13 +151,22 @@ export function buildDeterministicFinishReport(
     '',
     `**${planName}** finished with ${completeCount}/${total} tasks across ${waves} wave${waves === 1 ? '' : 's'} in **${elapsed}**.`,
     '',
-    `- Integration branch: \`${branch}\``,
+    isolated
+      ? `- Integration branch: \`${integrationBranch}\``
+      : '- Isolation off — the work is uncommitted in your workspace checkout',
     `- ${tokenLine}`,
     '',
     `## Next steps`,
     '',
-    '1. Review the integration branch diff and run the project locally.',
-    '2. Use **Commit & push** to merge the integration branch into your current branch, then push.',
+    ...(isolated
+      ? [
+          '1. Review the integration branch diff and run the project locally.',
+          '2. Use **Commit & push** to merge the integration branch into your current branch, then push.',
+        ]
+      : [
+          '1. Review the uncommitted changes in Source Control and run the project locally.',
+          '2. Use **Review & commit** to commit the workspace changes, then push.',
+        ]),
     '3. Start a follow-up chat if you want the assistant to continue from this board.',
     '',
     `## Completed tasks`,
@@ -178,7 +193,9 @@ export function buildDeterministicFinishReport(
     '',
     `## How to run`,
     '',
-    'From the workspace root (or the integration worktree):',
+    isolated
+      ? 'From the workspace root (or the integration worktree):'
+      : 'From the workspace root:',
     '',
     '```bash',
     'npm install',
@@ -210,7 +227,13 @@ export function computeLocalFinishStats(
   };
 }
 
-/** Fetch git diff stats and remote/gh capability flags for landing into workspace. */
+/**
+ * Fetch git diff stats and remote/gh capability flags for the finish dashboard.
+ *
+ * With no integration branch (isolation off) the server falls back to the
+ * uncommitted workspace diff, so the stats grid shows the work the agents did in
+ * the live checkout instead of a row of dashes.
+ */
 export async function fetchGitFinishStats(
   integrationBranch: string,
 ): Promise<
@@ -222,21 +245,12 @@ export async function fetchGitFinishStats(
     | 'hasRemote'
     | 'hasGh'
     | 'alreadyLanded'
+    | 'dirtyWorkspace'
     | 'gitStatsError'
   >
 > {
   const branch = integrationBranch.trim();
-  if (!branch) {
-    return {
-      filesTouched: null,
-      additions: null,
-      deletions: null,
-      hasRemote: false,
-      hasGh: false,
-      gitStatsError: 'No integration branch',
-    };
-  }
-  const res = await workspaceLandingStats({ branch });
+  const res = await workspaceLandingStats(branch ? { branch } : {});
   if (!res.ok) {
     return {
       filesTouched: null,
@@ -254,5 +268,6 @@ export async function fetchGitFinishStats(
     hasRemote: res.hasRemote === true,
     hasGh: res.hasGh === true,
     alreadyLanded: res.alreadyLanded === true,
+    dirtyWorkspace: res.dirtyWorkspace === true,
   };
 }

--- a/src/chat/orchestrate/finish-stats.ts
+++ b/src/chat/orchestrate/finish-stats.ts
@@ -6,7 +6,12 @@ import { getOrchestrateBoardElapsedMs } from '../../state/orchestrate-board-stor
 import { findChatById } from '../../state/sessions.ts';
 import { workspaceLandingStats } from '../../state/worktree-service.ts';
 import { resolveIsolationMode } from '../../state/worktree-isolation.ts';
-import type { Chat, OrchestrateBoardState, Usage } from '../../types.ts';
+import type {
+  BoardRunInstructions,
+  Chat,
+  OrchestrateBoardState,
+  Usage,
+} from '../../types.ts';
 import { sumUsageSegments } from './stats-math.ts';
 
 /** Local + async git stats shown on the finish dashboard. */
@@ -104,6 +109,41 @@ function shortPlanLabel(planPath: string): string {
 export const FINISH_REPORT_RECOMMENDATIONS_PLACEHOLDER =
   '_Generating recommendations from the plan…_';
 
+/**
+ * Placeholder for run instructions the final tester did not report, replaced
+ * asynchronously by manifest detection ({@link detectProjectRunInstructions}).
+ */
+export const FINISH_REPORT_RUN_PLACEHOLDER = '_Detecting run commands…_';
+
+/** Swap the run-instructions placeholder for detected (unverified) commands. */
+export function mergeFinishReportRunInstructions(
+  report: string,
+  runMarkdown: string,
+): string {
+  const body = runMarkdown.trim() || '_No run commands detected for this project._';
+  if (report.includes(FINISH_REPORT_RUN_PLACEHOLDER)) {
+    return report.replace(FINISH_REPORT_RUN_PLACEHOLDER, body);
+  }
+  return report;
+}
+
+/** Render the tester's verified commands as a fenced block. */
+function formatVerifiedRunInstructions(run: BoardRunInstructions): string[] {
+  const commands = [run.install, run.start, run.test].filter(
+    (cmd): cmd is string => Boolean(cmd?.trim()),
+  );
+  const lines: string[] = [];
+  if (commands.length) {
+    lines.push('```bash', ...commands, '```');
+  }
+  if (run.notes?.trim()) {
+    lines.push('', run.notes.trim());
+  }
+  if (!lines.length) return ['_The tester reported no runnable commands._'];
+  lines.push('', '_Verified by the final integration tester._');
+  return lines;
+}
+
 /** Swap the recommendations placeholder for LLM output (or a fallback line). */
 export function mergeFinishReportRecommendations(
   report: string,
@@ -189,6 +229,9 @@ export function buildDeterministicFinishReport(
     }
   }
 
+  // Verified commands from the final tester beat anything we could infer; the
+  // placeholder is filled in from the project's manifests only when it has none.
+  const reported = board.finalTest?.runInstructions;
   lines.push(
     '',
     `## How to run`,
@@ -197,15 +240,11 @@ export function buildDeterministicFinishReport(
       ? 'From the workspace root (or the integration worktree):'
       : 'From the workspace root:',
     '',
-    '```bash',
-    'npm install',
-    'npm start',
-    '```',
-    '',
-    planPath
-      ? `_Plan reference: \`${planPath}\`_`
-      : '_Set a plan path on the board for project-specific run instructions._',
+    ...(reported ? formatVerifiedRunInstructions(reported) : [FINISH_REPORT_RUN_PLACEHOLDER]),
   );
+  if (planPath) {
+    lines.push('', `_Plan reference: \`${planPath}\`_`);
+  }
 
   return lines.join('\n');
 }

--- a/src/chat/orchestrate/plan-complete-ui.ts
+++ b/src/chat/orchestrate/plan-complete-ui.ts
@@ -9,7 +9,10 @@ import {
   isOrchestratePlanComplete,
 } from './plan-complete.ts';
 import { buildDeterministicFinishReport } from './finish-stats.ts';
-import { enrichFinishReportWithRecommendations } from './finish-recommendations.ts';
+import {
+  enrichFinishReportWithRecommendations,
+  enrichFinishReportWithRunInstructions,
+} from './finish-recommendations.ts';
 import { reportBackgroundError } from '../../boot/report-background-error.ts';
 import { isChatStreaming, subscribeChatStreamEnd } from '../../chat/streaming-state.ts';
 import { isDomAvailable } from '../../lib/dom-available.ts';
@@ -199,6 +202,7 @@ export async function maybeEmitOrchestratePlanComplete(groupId: string): Promise
   }
 
   void enrichFinishReportWithRecommendations(groupId, planner, board);
+  void enrichFinishReportWithRunInstructions(groupId, planner, board);
 
   if (isDomAvailable()) {
     const activeId = sessionState?.activeId;

--- a/src/chat/orchestrate/plan-complete.ts
+++ b/src/chat/orchestrate/plan-complete.ts
@@ -41,12 +41,24 @@ export function isOrchestrateFinalTestFailedWithAllTasksComplete(
   return board.tasks.length > 0 && board.tasks.every((t) => t.status === 'complete');
 }
 
+/**
+ * The run is over and the final integration test failed.
+ *
+ * Deliberately looser than {@link isOrchestrateFinalTestFailedWithAllTasksComplete}:
+ * requiring *every* task to be `complete` meant one quarantined task hid the
+ * report entirely, which is exactly the run the user most needs to read.
+ */
+export function isOrchestrateFinalTestFailed(board: OrchestrateBoardState): boolean {
+  return board.finalTest?.status === 'failed' && isOrchestratePlanComplete(board);
+}
+
 /** Finish dashboard is available (passed final test, all-quarantined blocked, or final-test fail). */
 export function canAccessOrchestrateFinishDashboard(board: OrchestrateBoardState): boolean {
   if (isOrchestrateBoardFinished(board)) return true;
+  // A failed final test is a result, not a non-result — it always has a report.
+  if (isOrchestrateFinalTestFailed(board)) return true;
   if (board.completionShownAt == null) return false;
-  if (board.terminalBlocked === true) return true;
-  return isOrchestrateFinalTestFailedWithAllTasksComplete(board);
+  return board.terminalBlocked === true;
 }
 
 /** True when the finish dashboard should replace the kanban (MIN-208). */

--- a/src/chat/orchestrate/run-instructions-detect.ts
+++ b/src/chat/orchestrate/run-instructions-detect.ts
@@ -1,0 +1,138 @@
+/**
+ * Fallback run-command detection for the finish report.
+ *
+ * Only used when the final integration tester did not report `run_instructions`.
+ * Everything here is inferred from manifests, never executed, so the caller
+ * labels the block unverified — the old hardcoded `npm install && npm start`
+ * claimed more than it knew, on every project regardless of language.
+ */
+
+import { readWorkspaceTextFile } from '../../attachments/workspace-text-read.ts';
+
+export interface DetectedRunInstructions {
+  install?: string;
+  start?: string;
+  test?: string;
+  /** Manifest the commands were read from, named in the report. */
+  source: string;
+}
+
+async function readIfPresent(path: string): Promise<string | null> {
+  try {
+    const text = await readWorkspaceTextFile(path);
+    return text.trim() ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+/** First script name present in `scripts`, in preference order. */
+function pickScript(
+  scripts: Record<string, unknown>,
+  candidates: string[],
+): string | undefined {
+  for (const name of candidates) {
+    if (typeof scripts[name] === 'string') return name;
+  }
+  return undefined;
+}
+
+function fromPackageJson(text: string): DetectedRunInstructions | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const scriptsRaw = (parsed as Record<string, unknown>).scripts;
+  const scripts =
+    scriptsRaw && typeof scriptsRaw === 'object'
+      ? (scriptsRaw as Record<string, unknown>)
+      : {};
+
+  const start = pickScript(scripts, ['start', 'dev', 'serve']);
+  const test = pickScript(scripts, ['test']);
+  return {
+    install: 'npm install',
+    ...(start ? { start: start === 'start' ? 'npm start' : `npm run ${start}` } : {}),
+    ...(test ? { test: 'npm test' } : {}),
+    source: 'package.json',
+  };
+}
+
+/** Manifests checked in order; the first that parses wins. */
+const DETECTORS: Array<{
+  path: string;
+  parse: (text: string) => DetectedRunInstructions | null;
+}> = [
+  { path: 'package.json', parse: fromPackageJson },
+  {
+    path: 'Cargo.toml',
+    parse: () => ({
+      install: 'cargo build',
+      start: 'cargo run',
+      test: 'cargo test',
+      source: 'Cargo.toml',
+    }),
+  },
+  {
+    path: 'pyproject.toml',
+    parse: (text) => ({
+      install: /\[tool\.poetry\]/.test(text) ? 'poetry install' : 'pip install -e .',
+      ...(/\[tool\.pytest/.test(text) ? { test: 'pytest' } : {}),
+      source: 'pyproject.toml',
+    }),
+  },
+  {
+    path: 'Makefile',
+    parse: (text) => {
+      const targets = new Set(
+        [...text.matchAll(/^([A-Za-z0-9_.-]+):/gm)].map((m) => m[1]!),
+      );
+      if (!targets.size) return null;
+      return {
+        ...(targets.has('install') ? { install: 'make install' } : {}),
+        ...(targets.has('run')
+          ? { start: 'make run' }
+          : targets.has('start')
+            ? { start: 'make start' }
+            : {}),
+        ...(targets.has('test') ? { test: 'make test' } : {}),
+        source: 'Makefile',
+      };
+    },
+  },
+];
+
+/** Best-effort run commands inferred from the workspace's manifests. */
+export async function detectProjectRunInstructions(): Promise<DetectedRunInstructions | null> {
+  for (const detector of DETECTORS) {
+    const text = await readIfPresent(detector.path);
+    if (!text) continue;
+    const detected = detector.parse(text);
+    if (!detected) continue;
+    if (!detected.install && !detected.start && !detected.test) continue;
+    return detected;
+  }
+  return null;
+}
+
+/** Markdown for the finish report's "How to run" section, marked unverified. */
+export function formatDetectedRunInstructions(
+  detected: DetectedRunInstructions | null,
+): string {
+  if (!detected) {
+    return '_No run commands detected. Check the project README._';
+  }
+  const commands = [detected.install, detected.start, detected.test].filter(
+    (cmd): cmd is string => Boolean(cmd),
+  );
+  return [
+    '```bash',
+    ...commands,
+    '```',
+    '',
+    `_Inferred from \`${detected.source}\` — not verified by running them._`,
+  ].join('\n');
+}

--- a/src/chat/prompts/modes/orchestrate.full.md
+++ b/src/chat/prompts/modes/orchestrate.full.md
@@ -70,6 +70,7 @@ on the board before it activates.
 | Tool | Use |
 |------|-----|
 | `board_init` | Create/replace the board from parsed plan (required fields below) |
+| `board_add_tasks` | **Append** follow-up tasks to a board that already exists, in a new wave. Use this instead of `board_init`, which would throw the board away. |
 | `board_get_state` | Read board JSON (concurrency, hands-off, tasks, waves) |
 | `board_update_task` | Optional metadata; do not fake execution progress |
 | `board_set_autonomy` | Set `concurrency` (1–20) and/or request `handsOff`. Hands-off requires user confirmation before it activates. |
@@ -103,6 +104,28 @@ on the board before it activates.
 - Task chats are linked via `board_task_id` on `spawn_sub_agent` (set automatically — do not call `spawn_sub_agent`; the category field determines agent type)
 
 After `board_init`, end your turn. If the user enables **Auto** or **Sequential** on the board, the next ready wave starts automatically.
+
+### `board_add_tasks` shape
+
+Follow-up work on a board that is already running — never re-run `board_init` for this.
+
+```json
+{
+  "tasks": [
+    {
+      "id": "W3-FIX-A",
+      "title": "Fix failing integration test",
+      "category": "fix",
+      "build": "…what to change…",
+      "test": "…how to verify…"
+    }
+  ]
+}
+```
+
+- Omit `wave` to append a new wave after the highest existing one (the usual case).
+- `dependsOn` may reference **existing** task ids as well as new ones; cycles are rejected.
+- Ids must not collide with tasks already on the board.
 
 ### Skip per-task tests (board header)
 

--- a/src/chat/prompts/modes/orchestrate.full.md
+++ b/src/chat/prompts/modes/orchestrate.full.md
@@ -29,47 +29,51 @@ You are Minnow in **Orchestrate** mode. Your job is to **read a plan and initial
    - `tasks[]` — every task with `id`, `title`, `wave`, `category`, optional `build`, `test`, and optional `dependsOn` (array of task ids that must complete first)
 4. **Confirm.** Reply briefly, e.g. "Initialized N tasks across M waves on the board."
 
-### Manual mode (default)
+### How the board runs
 
-After `board_init`, **stop**. The user operates the Kanban (start/stop task chats, move cards). Do **not** call `delegate_tasks` unless Auto, Sequential, or AFK mode is enabled on the board.
+There are no execution "modes". A board is described by two things:
 
-### Auto mode
+- **Concurrency** (`maxConcurrentTasks`, 1–20) — how many tasks run at once. `1` runs
+  them one at a time in plan order.
+- **Hands-off** (`handsOff`) — whether the orchestrator may interrupt the user. Available
+  at any concurrency, including 1.
 
-When the board has **Auto** on (`executionMode: auto` — user toggle on the board):
+A board that has not been **Started** by the user does not run; the user can still start
+individual cards from the Kanban. Once Started:
 
-- **Delegation is automatic** — ready planned tasks start without you calling tools (respects **`dependsOn` first**, then wave barriers for tasks with no deps, and `maxConcurrentTasks`).
-- Task lifecycle reports (`completed` / `failed` / `stalled`) are delivered to this chat automatically — summarize progress or handle failures; do **not** call `delegate_tasks`.
-- A **`stalled`** or **`quarantined`** report means the task exhausted its automatic self-heal and is blocked. The auto-pilot has already retried programmatically, and for **environment/infra** failures (missing dependency, unstarted service, missing config) an **env-fixer sub-agent** has already run on the task worktree and re-verified — so a quarantine means even that could not unblock it. You have **no tool to re-run or fix it yourself** (`spawn_sub_agent` is denied; you cannot run git). **Investigate** with `board_get_state`, record the root cause on the task via `board_update_task` (`error` / `notes`), and **summarize the blocker here**. **Never wait for the user.**
-- You may call **`board_get_state`** and **`board_update_task`** for metadata only; do **not** mark tasks `complete` or run git — the board auto-commits and merges on tester pass.
+- **Delegation is automatic** — ready planned tasks start without you calling tools
+  (respects **`dependsOn` first**, then wave barriers for tasks with no deps, then
+  concurrency). Do **not** call `delegate_tasks`; it is internal.
+- Task lifecycle reports (`completed` / `failed` / `stalled`) arrive in this chat
+  automatically — summarize progress or handle failures.
+- A **`stalled`** or **`quarantined`** report means the task exhausted its automatic
+  self-heal and is blocked. The auto-pilot has already retried programmatically, and for
+  **environment/infra** failures (missing dependency, unstarted service, missing config)
+  an **env-fixer sub-agent** has already run on the task worktree and re-verified — so a
+  quarantine means even that could not unblock it. You have **no tool to re-run or fix it
+  yourself** (`spawn_sub_agent` is denied; you cannot run git). **Investigate** with
+  `board_get_state`, record the root cause on the task via `board_update_task`
+  (`error` / `notes`), and **summarize the blocker here**.
+- You may call **`board_get_state`** and **`board_update_task`** for metadata only; do
+  **not** mark tasks `complete` or run git — the board commits and merges on tester pass.
 
-### Sequential mode
+**Hands-off boards never prompt the user.** Treat `stalled` reports the same way:
+investigate, record the blocker, and keep going. Never wait for the user.
 
-When the board has **Sequential** on (`executionMode: sequential`):
-
-- Behaves like Auto but runs exactly **one task at a time** in plan order (wave rank, then position).
-- `dependsOn` is also respected — a dependent task only starts after all its deps are `complete`.
-- You receive the same lifecycle reports; do **not** call `delegate_tasks`.
-
-### AFK mode
-
-When the board has **AFK** on (`executionMode: afk`):
-
-- Behaves like Auto (concurrent delegation, per-task worktree isolation) but is **fully hands-off** — press **Start** on the board, then the orchestrator **never prompts the user** until Stop or board finish.
-- Treat **`stalled`** reports the same as Auto: investigate with `board_get_state` and record the blocker via `board_update_task`; do **not** ask the user.
-- You receive the same lifecycle reports; do **not** call `delegate_tasks`.
-- **You cannot enable AFK yourself** — call `board_set_autonomy` with `level: "afk"` to request it; the user must confirm on the board before AFK activates.
-
-You may raise or lower autonomy (`manual` / `sequential` / `auto`) yourself via **`board_set_autonomy`** except AFK, which always prompts the user.
+You may change concurrency yourself with **`board_set_autonomy`**
+(`{"concurrency": 3}`). You **cannot enable hands-off yourself** — calling
+`board_set_autonomy` with `{"handsOff": true}` only *requests* it; the user must confirm
+on the board before it activates.
 
 ## Board tools (this mode)
 
 | Tool | Use |
 |------|-----|
 | `board_init` | Create/replace the board from parsed plan (required fields below) |
-| `board_get_state` | Read board JSON (check `executionMode`, tasks, waves) |
+| `board_get_state` | Read board JSON (concurrency, hands-off, tasks, waves) |
 | `board_update_task` | Optional metadata; do not fake execution progress |
-| `board_set_autonomy` | Set autonomy level (`manual`/`sequential`/`auto`/`afk`). AFK requires user confirmation before it activates. |
-| `delegate_tasks` | Internal — auto/sequential starts tasks programmatically; do not call |
+| `board_set_autonomy` | Set `concurrency` (1–20) and/or request `handsOff`. Hands-off requires user confirmation before it activates. |
+| `delegate_tasks` | Internal — the board starts tasks programmatically; do not call |
 
 **Do not use:** `spawn_sub_agent`, `cancel_sub_agent`, `report_orchestrator_status` (removed).
 

--- a/src/config/autopilot-meta.ts
+++ b/src/config/autopilot-meta.ts
@@ -11,10 +11,15 @@ import {
 } from '../agents/sub-agent-config';
 import { detectConfigServer } from './storage-mode';
 
+/**
+ * @deprecated Boards derive this from concurrency + hands-off
+ * (src/state/board-execution-mode.ts). The alias survives only for the tool filter
+ * and permission gate signatures that still speak the legacy vocabulary.
+ */
 export type AutopilotExecutionMode = 'manual' | 'sequential' | 'auto' | 'afk';
 
-/** Stored isolation sentinel `auto` means derive from execution mode at resolve time. */
-export type AutopilotIsolationMode = 'auto' | 'off' | 'per-task' | 'per-wave';
+/** Stored isolation sentinel `auto` means derive from board concurrency at resolve time. */
+export type AutopilotIsolationMode = 'auto' | 'off' | 'per-task' | 'per-wave' | 'per-board';
 
 /** Board default for agent shell sandbox (MIN-553); overridable per board. */
 export type AutopilotShellSandboxMode = 'off' | 'prefer' | 'require';
@@ -23,7 +28,8 @@ export type AutopilotContinueSmartRoute = 'off' | 'conservative' | 'aggressive';
 
 /** Persisted global autopilot defaults for orchestrate boards. */
 export interface AutopilotMeta {
-  defaultExecutionMode: AutopilotExecutionMode;
+  /** New boards start fully hands-off (never prompt the user). */
+  defaultHandsOff: boolean;
   maxConcurrentTasks: number;
   isolationMode: AutopilotIsolationMode;
 /** @deprecated Boards use toolSecurity.shellSandbox; kept for legacy config.json reads. */
@@ -61,7 +67,7 @@ const FALLBACK_MAX_BUILD_ATTEMPTS = 2;
 const FALLBACK_MAX_FINAL_TEST_ATTEMPTS = 3;
 
 export const DEFAULT_AUTOPILOT_META: AutopilotMeta = {
-  defaultExecutionMode: 'manual',
+  defaultHandsOff: false,
   maxConcurrentTasks: FALLBACK_MAX_CONCURRENT,
   isolationMode: 'auto',
   shellSandbox: 'off',
@@ -84,18 +90,12 @@ export const DEFAULT_AUTOPILOT_META: AutopilotMeta = {
 
 const AUTOPILOT_META_STORAGE_KEY = 'minnow.autopilotMeta';
 
-const EXECUTION_MODES = new Set<AutopilotExecutionMode>([
-  'manual',
-  'sequential',
-  'auto',
-  'afk',
-]);
-
 const ISOLATION_MODES = new Set<AutopilotIsolationMode>([
   'auto',
   'off',
   'per-task',
   'per-wave',
+  'per-board',
 ]);
 
 const SHELL_SANDBOX_MODES = new Set<AutopilotShellSandboxMode>([
@@ -137,14 +137,6 @@ function parseBool(value: unknown, fallback: boolean): boolean {
   return fallback;
 }
 
-function parseExecutionMode(value: unknown): AutopilotExecutionMode {
-  const raw = typeof value === 'string' ? value.trim() : '';
-  if (EXECUTION_MODES.has(raw as AutopilotExecutionMode)) {
-    return raw as AutopilotExecutionMode;
-  }
-  return DEFAULT_AUTOPILOT_META.defaultExecutionMode;
-}
-
 function parseIsolationMode(value: unknown): AutopilotIsolationMode {
   const raw = typeof value === 'string' ? value.trim() : '';
   if (ISOLATION_MODES.has(raw as AutopilotIsolationMode)) {
@@ -180,7 +172,7 @@ export function parseAutopilotMeta(raw: unknown): AutopilotMeta {
   }
   const block = raw as Record<string, unknown>;
   return {
-    defaultExecutionMode: parseExecutionMode(block.defaultExecutionMode),
+    defaultHandsOff: parseBool(block.defaultHandsOff, DEFAULT_AUTOPILOT_META.defaultHandsOff),
     maxConcurrentTasks: clampConcurrency(
       block.maxConcurrentTasks,
       DEFAULT_AUTOPILOT_META.maxConcurrentTasks,

--- a/src/dev/test-board-seed.ts
+++ b/src/dev/test-board-seed.ts
@@ -12,6 +12,7 @@ import {
   TEST_BOARD_GROUP_ID,
   TEST_BOARD_PLANNER_ID,
 } from '../../server/orchestrate/board-testing/constants.js';
+import { applyLegacyExecutionMode } from '../lib/legacy-execution-mode.mjs';
 
 export { TEST_BOARD_GROUP_ID, TEST_BOARD_PLANNER_ID };
 
@@ -225,7 +226,9 @@ export function buildTestBoardSession(
   });
 
   const board = group.orchestrateBoard!;
-  board.executionMode = mode;
+  // Scenarios still describe themselves with the legacy mode vocabulary; fold it onto
+  // the two fields the board actually persists.
+  applyLegacyExecutionMode(board, mode);
   board.autoRunning = options.autoStart === true;
   board.integrationBranch = `minnow/integration/${groupId}`;
 

--- a/src/lib/legacy-execution-mode.d.mts
+++ b/src/lib/legacy-execution-mode.d.mts
@@ -1,0 +1,4 @@
+export declare function applyLegacyExecutionMode(
+  board: { handsOff?: boolean; maxConcurrentTasks?: number; autoRunning?: boolean },
+  mode: string | undefined,
+): void;

--- a/src/lib/legacy-execution-mode.mjs
+++ b/src/lib/legacy-execution-mode.mjs
@@ -1,0 +1,29 @@
+/**
+ * Migration of the retired four-value board `executionMode` onto the two fields that
+ * replaced it: `maxConcurrentTasks` (parallelism) and `handsOff` (autonomy).
+ *
+ * Shared by the session-schema normalizer (hydration/persistence) and the dev board
+ * seeder, so a legacy board lands the same way wherever it is read.
+ *
+ * @param {{ handsOff?: boolean, maxConcurrentTasks?: number, autoRunning?: boolean }} board
+ * @param {string | undefined} mode
+ */
+export function applyLegacyExecutionMode(board, mode) {
+  switch (mode) {
+    case 'afk':
+      board.handsOff = true;
+      break;
+    case 'sequential':
+      board.maxConcurrentTasks = 1;
+      break;
+    case 'manual':
+      // A board that was never started is the manual case now; pin it to
+      // one-at-a-time and leave it stopped.
+      board.maxConcurrentTasks = 1;
+      board.autoRunning = false;
+      break;
+    case 'auto':
+    default:
+      break;
+  }
+}

--- a/src/lib/sanitize-path-segment.d.mts
+++ b/src/lib/sanitize-path-segment.d.mts
@@ -1,0 +1,2 @@
+export declare const PATH_SEGMENT_MAX: number;
+export declare function sanitizePathSegment(raw: string | number): string;

--- a/src/lib/sanitize-path-segment.mjs
+++ b/src/lib/sanitize-path-segment.mjs
@@ -1,0 +1,25 @@
+/**
+ * Single sanitizer for worktree path segments and git ref fragments.
+ * Shared by the client isolation helpers (src/state/worktree-isolation.ts) and the
+ * server worktree paths (server/worktree/paths.js) so a slot name always resolves to
+ * the same directory on both sides.
+ */
+
+/** Max characters per segment — keeps deep worktree paths under Windows MAX_PATH. */
+export const PATH_SEGMENT_MAX = 64;
+
+/**
+ * Keep word chars, dot, dash and underscore; collapse everything else to a single
+ * dash; trim leading/trailing separators; bound length. Never returns an empty string.
+ * @param {string|number} raw
+ * @returns {string}
+ */
+export function sanitizePathSegment(raw) {
+  const cleaned = String(raw)
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, PATH_SEGMENT_MAX)
+    .replace(/[-.]+$/g, '');
+  return cleaned || 'x';
+}

--- a/src/settings/storage-overlay.ts
+++ b/src/settings/storage-overlay.ts
@@ -166,12 +166,11 @@ export const SETTINGS_STORAGE_OVERLAY: Record<string, OverlayEntry> = {
   'agents.agentPacks': section(['agent-packs']),
   'agents.subAgents': section(['agent-center']),
   'agents.autopilot': section(['autopilot']),
-  'agents.autopilot.executionMode': meta('autopilot.defaultExecutionMode', 'enum', {
-    allowedValues: ['manual', 'sequential', 'auto', 'afk'],
+  'agents.autopilot.handsOff': meta('autopilot.defaultHandsOff', 'boolean', {
     refreshAreas: ['autopilot'],
   }),
   'agents.autopilot.isolation': meta('autopilot.defaultIsolationMode', 'enum', {
-    allowedValues: ['auto', 'off', 'per-task', 'per-wave'],
+    allowedValues: ['auto', 'off', 'per-board', 'per-task', 'per-wave'],
     refreshAreas: ['autopilot'],
   }),
   'agents.autopilot.concurrency': meta('autopilot.maxConcurrentTasks', 'number', {

--- a/src/state/board-execution-mode.ts
+++ b/src/state/board-execution-mode.ts
@@ -1,0 +1,54 @@
+/**
+ * Derived board execution mode.
+ *
+ * Boards no longer persist a four-value `executionMode`. The user-facing controls
+ * are **how many at once** ({@link OrchestrateBoardState.maxConcurrentTasks}) and
+ * **may it interrupt me** ({@link OrchestrateBoardState.handsOff}); the legacy mode
+ * string is derived from those two so the ~60 downstream reads (tool filter,
+ * permission gate, prompt contract, log invariants) keep working unchanged.
+ *
+ * Pure — no session/UI imports — so the permission gate and tool filter can read it
+ * without pulling in the board store.
+ */
+
+import { getAutopilotMetaSync } from '../config/autopilot-meta.ts';
+import type { OrchestrateBoardState } from '../types.ts';
+
+/** Legacy mode vocabulary. `manual` is no longer producible (kept for hydration). */
+export type BoardExecutionMode = 'manual' | 'auto' | 'sequential' | 'afk';
+
+/** Hard fallback when neither the board nor global settings specify concurrency. */
+export const DEFAULT_MAX_CONCURRENT = 3;
+
+/** Board concurrency before OOM throttling: board ?? global ?? fallback, clamped to [1,20]. */
+export function resolveBoardConcurrency(
+  board: OrchestrateBoardState | null | undefined,
+): number {
+  const boardVal = board?.maxConcurrentTasks;
+  const raw =
+    typeof boardVal === 'number' && Number.isFinite(boardVal) && boardVal > 0
+      ? boardVal
+      : (getAutopilotMetaSync().maxConcurrentTasks ?? DEFAULT_MAX_CONCURRENT);
+  return Math.max(1, Math.min(20, Math.floor(raw)));
+}
+
+/** True when the board runs fully hands-off (never prompts the user). */
+export function isBoardHandsOff(
+  board: OrchestrateBoardState | null | undefined,
+): boolean {
+  return board?.handsOff === true;
+}
+
+/**
+ * Single derivation point for the legacy mode string:
+ * hands-off → `afk`; concurrency 1 → `sequential`; otherwise → `auto`.
+ */
+export function deriveBoardExecutionMode(
+  board: OrchestrateBoardState | null | undefined,
+): BoardExecutionMode {
+  if (!board) return 'sequential';
+  if (isBoardHandsOff(board)) return 'afk';
+  return resolveBoardConcurrency(board) === 1 ? 'sequential' : 'auto';
+}
+
+export { applyLegacyExecutionMode } from '../lib/legacy-execution-mode.mjs';

--- a/src/state/board-log-invariants.ts
+++ b/src/state/board-log-invariants.ts
@@ -73,7 +73,11 @@ export interface BoardLogCheckOptions {
   requireTerminal?: boolean;
   /** Make missing durable Phase-2 evidence affect `ok`; default is legacy-compatible. */
   strictEvidence?: boolean;
-  /** Explicit mode when the log starts after the mode_change event. */
+  /**
+   * Explicit derived mode when the log starts after the mode_change event.
+   * `manual` is no longer producible — a board that was never started simply has
+   * no run to audit.
+   */
   executionMode?: 'manual' | 'auto' | 'sequential' | 'afk';
   /** Board skipped per-task Tester (in_progress may jump to complete after merge). */
   skipPerTaskTesting?: boolean;
@@ -746,7 +750,11 @@ function auditDurableEvents(
   };
 
   for (const event of ctx.sorted) {
-    if (event.type === 'mode_change' && event.detail?.mode === 'afk') afk = true;
+    // Mode is derived from concurrency + hands-off now, so it can move *out* of
+    // AFK mid-run (the user unticks Hands-off). Track the latest value, not a latch.
+    if (event.type === 'mode_change' && event.detail?.mode) {
+      afk = event.detail.mode === 'afk';
+    }
     if (event.type === 'task_status' && event.taskId && event.detail?.to) {
       taskStatuses[event.taskId] = event.detail.to;
     } else if (event.type === 'task_quarantined' && event.taskId) {

--- a/src/state/chat-groups.ts
+++ b/src/state/chat-groups.ts
@@ -13,7 +13,6 @@ import { normalizeWorkspacePath } from '../lib/normalize-workspace-path';
 import type { Chat, ChatGroup } from '../types';
 import { getChatLastMessageAt } from './session-workspace-scope';
 import { collapseChatSidebarForBoardEnter } from '../ui/layout';
-import { boardWorktreeSlug } from './worktree-isolation.ts';
 import {
   markGroupDeleted,
   markGroupDirty,
@@ -209,13 +208,15 @@ function teardownBoardGroup(group: ChatGroup, chatIds: readonly string[]): void 
     getChatAbort(chatId)?.abort();
   }
   if (group.orchestrateBoard?.integrationBranch) {
-    void fetch('/api/worktree', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ op: 'cleanup', boardId: boardWorktreeSlug(group) }),
-    }).catch(() => {
-      /* best-effort on folder delete */
-    });
+    // The board folder is going away, so nothing is left to commit from the
+    // integration checkout — `includeIntegration` is what stops it (and the board
+    // worktree dir) leaking forever. Branches are kept; only directories go.
+    // Imported lazily: orchestrate-board-actions imports this module.
+    void import('./orchestrate-board-actions.ts')
+      .then((m) => m.cleanupBoardIsolation(group, { includeIntegration: true }))
+      .catch(() => {
+        /* best-effort on folder delete */
+      });
   }
 }
 

--- a/src/state/chat-groups.ts
+++ b/src/state/chat-groups.ts
@@ -13,6 +13,7 @@ import { normalizeWorkspacePath } from '../lib/normalize-workspace-path';
 import type { Chat, ChatGroup } from '../types';
 import { getChatLastMessageAt } from './session-workspace-scope';
 import { collapseChatSidebarForBoardEnter } from '../ui/layout';
+import { boardWorktreeSlug } from './worktree-isolation.ts';
 import {
   markGroupDeleted,
   markGroupDirty,
@@ -211,7 +212,7 @@ function teardownBoardGroup(group: ChatGroup, chatIds: readonly string[]): void 
     void fetch('/api/worktree', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ op: 'cleanup', boardId: group.id }),
+      body: JSON.stringify({ op: 'cleanup', boardId: boardWorktreeSlug(group) }),
     }).catch(() => {
       /* best-effort on folder delete */
     });

--- a/src/state/chat-groups.ts
+++ b/src/state/chat-groups.ts
@@ -240,6 +240,10 @@ export function deleteGroup(
     const chatIds = listBoardGroupChatIds(group, state.chats);
     teardownBoardGroup(group, chatIds);
     groups.splice(idx, 1);
+    if (state.lastBoardGroupId === id) {
+      delete state.lastBoardGroupId;
+      markSessionScalarsDirty();
+    }
 
     let lastRemoval: RemoveChatResult | undefined;
     let activeChanged = false;
@@ -310,6 +314,18 @@ export function getActiveBoardGroup(): ChatGroup | undefined {
   const state = sessionState;
   if (!state?.activeBoardGroupId) return undefined;
   return findGroupById(state.activeBoardGroupId);
+}
+
+/**
+ * Board folder the user was last inside — still set after they navigate away,
+ * which is what {@link getActiveBoardGroup} deliberately is not.
+ */
+export function getLastBoardGroup(): ChatGroup | undefined {
+  const state = sessionState;
+  const id = state?.lastBoardGroupId?.trim();
+  if (!id) return undefined;
+  const group = findGroupById(id);
+  return group?.orchestrateBoard ? group : undefined;
 }
 
 /** Clear board main-column focus (same as leaving board via switchChat). */
@@ -435,6 +451,8 @@ function activateBoardGroupView(groupId: string, group: ChatGroup): void {
   const state = requireSession();
   collapseChatSidebarForBoardEnter();
   state.activeBoardGroupId = groupId;
+  // Survives navigating away, so re-entering Orchestrator returns here.
+  state.lastBoardGroupId = groupId;
   markSessionScalarsDirty();
   group.viewMode = 'board';
   persistGroupChange(groupId);

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -11,7 +11,7 @@ import {
   sanitizeBoardReasoningForModel,
   type BoardReasoningPatch,
 } from '../chat/orchestrate/board-reasoning-binding.ts';
-import { isOrchestratePlanComplete, hasIncompleteOrchestrateWork } from '../chat/orchestrate/plan-complete.ts';
+import { isOrchestratePlanComplete, hasIncompleteOrchestrateWork, isBoardTaskRecoverableStatus } from '../chat/orchestrate/plan-complete.ts';
 import { isUserStoppedChat } from '../chat/orchestrate/user-stopped.ts';
 import { maybeEmitOrchestratePlanComplete } from '../chat/orchestrate/plan-complete-ui.ts';
 import {
@@ -5009,6 +5009,11 @@ export async function requeueBoardTask(
         selfHealRound: undefined,
         lastHealCategory: undefined,
         stopRetries: undefined,
+        // A requeue is a fresh run, so the retry budget resets with it —
+        // otherwise a maxed-out `buildAttempts` quarantines it again immediately.
+        buildAttempts: undefined,
+        testAttempts: undefined,
+        fixerAttempts: undefined,
         lifecycleRun: (existing?.lifecycleRun ?? 0) + 1,
         ...BOARD_REPORT_RESET_PATCH,
       },
@@ -5047,6 +5052,82 @@ export async function requeueAllFailedBoardTasks(
   const rootIds = listRecoverableBoardTaskRootIds(board);
   for (const id of rootIds) {
     await requeueBoardTask(group, id, plannerChat);
+  }
+  return rootIds;
+}
+
+/**
+ * Harder variant of {@link requeueBoardTask}: requeue *and* throw the task's
+ * worktree away, so `ensureTaskWorktree` mints a fresh one off the current
+ * integration tip instead of resuming a branch that may be half-broken.
+ *
+ * Requeue keeps the worktree (fast, preserves context); Reset does not.
+ */
+export async function resetBoardTask(
+  group: ChatGroup,
+  taskId: string,
+  plannerChat: Chat,
+): Promise<void> {
+  const board = group.orchestrateBoard;
+  if (!board) return;
+  const task = board.tasks.find((t) => t.id === taskId);
+  if (!task || !isBoardTaskRecoverableStatus(task.status)) return;
+
+  const mode = resolveIsolationMode(board);
+  const slotId = worktreeSlotId(mode, task);
+  // Per-board isolation shares the integration checkout with every other task —
+  // removing it would take the whole board's work with it.
+  const removable =
+    mode === 'per-task' && Boolean(slotId) && Boolean(task.worktreePath?.trim());
+
+  if (removable && slotId) {
+    const res = await removeWorktreeOp({
+      boardId: boardWorktreeSlug(group),
+      slotId,
+    }).catch((err) => {
+      reportBackgroundError('worktree-reset', err);
+      return { ok: false as const };
+    });
+    if (res.ok) {
+      updateTask(
+        group,
+        taskId,
+        {
+          worktreePath: undefined,
+          worktreeBranch: undefined,
+          devPort: undefined,
+          apiPort: undefined,
+        },
+        plannerChat,
+      );
+      logWorktreeReleased(group, taskId, task.worktreeBranch ?? '', {
+        slotId,
+        reason: 'reset',
+      });
+    }
+  }
+
+  // Drop the seeds a retry would otherwise replay into the fresh worktree.
+  updateTask(
+    group,
+    taskId,
+    { pendingBuildSeed: undefined, boardReport: undefined },
+    plannerChat,
+  );
+
+  await requeueBoardTask(group, taskId, plannerChat);
+}
+
+/** Reset (fresh worktree) every recoverable task — bulk sibling of requeue-all. */
+export async function resetAllFailedBoardTasks(
+  group: ChatGroup,
+  plannerChat: Chat,
+): Promise<string[]> {
+  const board = group.orchestrateBoard;
+  if (!board) return [];
+  const rootIds = listRecoverableBoardTaskRootIds(board);
+  for (const id of rootIds) {
+    await resetBoardTask(group, id, plannerChat);
   }
   return rootIds;
 }

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -88,7 +88,7 @@ import {
   getPlannerChatForGroup,
 } from './chat-groups.ts';
 import { emitBoardChange } from './orchestrate-board-events.ts';
-import { isTaskReadyForAuto, isTaskStalledForRestart, isBoardAutoMode, isBoardRunning, getBoardExecutionMode, syncOrchestrateBoardTimer, updateTask, logTaskStatus, logBoardReportNudge, logBuildVerdict, logTestVerdict, logMergeResult, logWorktreeAllocated, logTaskRetry, logModeChange, logAutoStart, logAutoStop, logFinalTestStarted, logFinalTestVerdict, logBoardPhase, logBoardSlot, logBoardHold, logBoardConcurrency, logBoardLifecycleOwner, quarantineTaskAndDependents, type OrchestrateBoardTimerContext } from './orchestrate-board-store.ts';
+import { isTaskReadyForAuto, isTaskStalledForRestart, isBoardAutoMode, isBoardRunning, getBoardExecutionMode, syncOrchestrateBoardTimer, updateTask, logTaskStatus, logBoardReportNudge, logBuildVerdict, logTestVerdict, logMergeResult, logWorktreeAllocated, logWorktreeReleased, logTaskRetry, logModeChange, logAutoStart, logAutoStop, logFinalTestStarted, logFinalTestVerdict, logBoardPhase, logBoardSlot, logBoardHold, logBoardConcurrency, logBoardLifecycleOwner, quarantineTaskAndDependents, type OrchestrateBoardTimerContext } from './orchestrate-board-store.ts';
 import {
   acquirePipelineHold,
   heldTaskIdsForOccupancy,
@@ -114,6 +114,8 @@ import {
   allocateTaskPorts,
   usedDevPorts,
   DEFAULT_BOARD_PORT_BASE,
+  tasksSharingSlot,
+  type IsolationMode,
 } from './worktree-isolation.ts';
 import { resolveBoardConcurrency } from './board-execution-mode.ts';
 import { teardownBoardTaskChatResources } from './board-task-teardown.ts';
@@ -129,6 +131,7 @@ import {
   verifyIntegrationMerge as verifyIntegrationMergeOp,
   refreshIntegrationDeps as refreshIntegrationDepsOp,
   cleanupBoardWorktrees as cleanupBoardWorktreesOp,
+  removeWorktree as removeWorktreeOp,
 } from './worktree-service.ts';
 
 const MAX_MERGE_FIXER_ATTEMPTS = 2;
@@ -2824,6 +2827,79 @@ async function ensureTaskWorktree(
 }
 
 /**
+ * Drop a task's worktree directory once its branch has landed in integration.
+ *
+ * The **branch is deliberately kept** — the work stays inspectable, and
+ * `ensureTaskWorktree` recreates the slot from the surviving branch on requeue
+ * (`worktree-ops.js` already has a branch-exists path), so this needs no undo.
+ *
+ * Only runs in `per-task` mode: `per-wave` slots are shared with tasks that may
+ * still be working, and `per-board` *is* the integration checkout.
+ */
+async function releaseMergedTaskWorktree(
+  group: ChatGroup,
+  task: BoardTask,
+  mode: IsolationMode,
+  boardId: string,
+  plannerChat: Chat,
+): Promise<void> {
+  if (mode !== 'per-task') return;
+  const board = group.orchestrateBoard;
+  if (!board) return;
+
+  const fresh = board.tasks.find((t) => t.id === task.id) ?? task;
+  if (!fresh.worktreePath?.trim()) return;
+
+  const slotId = worktreeSlotId(mode, fresh);
+  if (!slotId) return;
+
+  // Anything else still sharing this slot (never true for per-task, but the check
+  // is what makes it safe to widen the mode guard later) must be done with it.
+  const sharing = tasksSharingSlot(mode, fresh, board.tasks).filter((t) => t.id !== fresh.id);
+  if (sharing.some((t) => t.status !== 'complete' && t.status !== 'quarantined')) return;
+
+  // A live chat still writing into the directory outranks tidiness.
+  const chatIds = [fresh.chatId, fresh.testChatId, fresh.fixerChatId]
+    .map((id) => id?.trim())
+    .filter((id): id is string => Boolean(id));
+  if (chatIds.some((id) => isChatStreaming(id))) return;
+
+  // Stop dev servers/background runs bound to the worktree *before* the path is
+  // cleared — teardown resolves the root through the task's persisted path.
+  for (const id of chatIds) {
+    const chat = findChatById(id);
+    if (chat) teardownBoardTaskChatResources(chat, sessionState?.groups);
+  }
+
+  const res = await removeWorktreeOp({ boardId, slotId }).catch((err) => {
+    reportBackgroundError('worktree-release', err);
+    return { ok: false as const, error: err instanceof Error ? err.message : String(err) };
+  });
+  if (!res.ok) {
+    // A surviving directory is an orphan slot a later create would silently reuse,
+    // so keep pointing at it rather than pretending it is gone.
+    reportBackgroundError(
+      'worktree-release',
+      new Error(`Kept ${fresh.id} worktree: ${res.error || 'removal failed'}`),
+    );
+    return;
+  }
+
+  for (const id of chatIds) {
+    const chat = findChatById(id);
+    if (chat?.worktreeRoot) delete chat.worktreeRoot;
+  }
+  // Keep worktreeBranch: it is what makes requeue-after-cleanup work.
+  updateTask(
+    group,
+    fresh.id,
+    { worktreePath: undefined, devPort: undefined, apiPort: undefined },
+    plannerChat,
+  );
+  logWorktreeReleased(group, fresh.id, fresh.worktreeBranch ?? '', { slotId });
+}
+
+/**
  * Fold a passed task's branch into integration. Returns whether the merge landed.
  * Auto-commits the task worktree first (per-task isolation only). Serialized per board.
  */
@@ -2901,6 +2977,7 @@ async function mergeCompletedTaskWorktree(
           reportBackgroundError('worktree-refresh-deps', err);
         }
         logMergeResult(group, task.id, 'merged', { branch });
+        await releaseMergedTaskWorktree(group, task, mode, boardId, plannerChat);
         return { outcome: 'merged' };
       }
       const reasons = verified.reasons?.join('; ') || 'Integration merge verification failed';
@@ -3707,15 +3784,23 @@ async function finalizeEnvFixerOnStreamEnd(
 }
 
 /**
- * Remove all per-task/wave worktrees for a board (keeps the integration branch +
- * worktree so MIN-208 can commit/push from it). Call on board teardown/delete.
+ * Remove per-task/wave worktrees for a board. By default the integration branch +
+ * worktree survive so the finish dashboard can still commit/push from them; pass
+ * `includeIntegration` when the board itself is going away (folder delete), or the
+ * integration checkout is leaked with nothing left to reference it.
+ *
+ * Branches are never deleted — only the checked-out directories.
  */
-export function cleanupBoardIsolation(group: ChatGroup): void {
+export function cleanupBoardIsolation(
+  group: ChatGroup,
+  options: { includeIntegration?: boolean } = {},
+): void {
   const board = group.orchestrateBoard;
   if (!board?.integrationBranch) return;
-  void cleanupBoardWorktreesOp({ boardId: boardWorktreeSlug(group) }).catch((err) =>
-    reportBackgroundError('worktree-cleanup', err),
-  );
+  void cleanupBoardWorktreesOp({
+    boardId: boardWorktreeSlug(group),
+    includeIntegration: options.includeIntegration === true,
+  }).catch((err) => reportBackgroundError('worktree-cleanup', err));
 }
 
 /** Record that integration work was merged into the workspace and committed. */
@@ -5670,6 +5755,15 @@ export function trackDrainResumeCallsForTests(enabled: boolean): string[] {
   const captured = drainResumeCallsForTests ?? [];
   drainResumeCallsForTests = null;
   return captured;
+}
+
+/** Test-only: provision (or recreate) a task's worktree slot. */
+export async function ensureTaskWorktreeForTests(
+  group: ChatGroup,
+  task: BoardTask,
+  plannerChat: Chat,
+): Promise<string | null> {
+  return ensureTaskWorktree(group, task, plannerChat);
 }
 
 /** Test-only: run integration merge on the per-board queue (waits for fixers). */

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -107,10 +107,15 @@ import {
   worktreeBranchFor,
   worktreeSlotId,
   boardIntegrationBranch,
+  BOARD_INTEGRATION_SLOT,
+  boardWorktreeSlug,
+  deriveBoardWorktreeSlug,
+  sanitizeRefFragment,
   allocateTaskPorts,
   usedDevPorts,
   DEFAULT_BOARD_PORT_BASE,
 } from './worktree-isolation.ts';
+import { resolveBoardConcurrency } from './board-execution-mode.ts';
 import { teardownBoardTaskChatResources } from './board-task-teardown.ts';
 import {
   ensureIntegration as ensureIntegrationWorktree,
@@ -764,7 +769,7 @@ async function commitOrphanedWorkOnTerminalFailure(
   const mode = resolveIsolationMode(board);
   if (mode !== 'per-task') return baseError;
 
-  const boardId = group.id;
+  const boardId = boardWorktreeSlug(group);
   const slotId = worktreeSlotId(mode, task);
   const branch = task.worktreeBranch ?? worktreeBranchFor(mode, boardId, task);
   if (!slotId || !branch) return baseError;
@@ -1745,14 +1750,14 @@ function ensureStreamEndSubscription(): void {
   }
 }
 
-/** Resolved max concurrent tasks: sequential → 1; else board ?? global ?? fallback. */
+/**
+ * Resolved max concurrent tasks: board ?? global ?? fallback.
+ * The execution mode derives *from* this value, so it must not be consulted here.
+ */
 export function resolveBoardMaxConcurrent(
   board: NonNullable<ChatGroup['orchestrateBoard']>,
 ): number {
-  if (board.executionMode === 'sequential') return 1;
-  const boardVal = board.maxConcurrentTasks;
-  if (typeof boardVal === 'number' && boardVal > 0) return boardVal;
-  return getAutopilotMetaSync().maxConcurrentTasks ?? DEFAULT_MAX_CONCURRENT;
+  return resolveBoardConcurrency(board);
 }
 
 /** Apply OOM recovery cap on top of board/global concurrency settings. */
@@ -2657,6 +2662,29 @@ function enqueueTaskAtFront(groupId: string, taskId: string): void {
 }
 
 /**
+ * Mint (once) and return the frozen human-readable worktree directory segment for a
+ * board. Every `/api/worktree` op keys its directory off this value, so it must stay
+ * stable for the life of the board — see `deriveBoardWorktreeSlug`.
+ */
+export function ensureBoardWorktreeSlug(group: ChatGroup): string {
+  const board = group.orchestrateBoard;
+  if (!board) return sanitizeRefFragment(group.id);
+  const existing = board.worktreeSlug?.trim();
+  if (existing) return existing;
+
+  const taken: string[] = [];
+  for (const other of sessionState?.groups ?? []) {
+    if (other.id === group.id) continue;
+    const slug = other.orchestrateBoard?.worktreeSlug?.trim();
+    if (slug) taken.push(slug);
+  }
+  const slug = deriveBoardWorktreeSlug(group, taken);
+  board.worktreeSlug = slug;
+  scheduleSaveSessions();
+  return slug;
+}
+
+/**
  * Ensure an isolated git worktree for a task when board isolation is active, and
  * return its absolute path (also persisted on the task). Best-effort: returns null
  * when isolation is off or any git/server step fails, so the task falls back to the
@@ -2672,18 +2700,60 @@ async function ensureTaskWorktree(
   const mode = resolveIsolationMode(board);
   if (mode === 'off') return null;
 
-  const boardId = group.id;
-  const branch = worktreeBranchFor(mode, boardId, task);
+  const boardId = ensureBoardWorktreeSlug(group);
+  // A task that already owns a worktree keeps it, whatever the current naming
+  // scheme would mint — boards provisioned before the rename must not be orphaned.
+  const branch = task.worktreeBranch?.trim() || worktreeBranchFor(mode, boardId, task);
   const slotId = worktreeSlotId(mode, task);
   if (!branch || !slotId) return null;
 
-  // Mint the integration branch + its worktree once per board (lazy).
+  // Mint the integration branch + its worktree once per board (lazy). In per-board
+  // mode this *is* the task worktree, so its path is needed on every call.
   const integrationBranch = board.integrationBranch ?? boardIntegrationBranch(boardId);
-  if (!board.integrationBranch) {
+  let integrationPath: string | undefined;
+  if (!board.integrationBranch || mode === 'per-board') {
     const ensured = await ensureIntegrationWorktree({ boardId, branch: integrationBranch });
     if (!ensured.ok) return null;
-    board.integrationBranch = integrationBranch;
-    scheduleSaveSessions();
+    integrationPath = ensured.path?.trim() || undefined;
+    if (!board.integrationBranch) {
+      board.integrationBranch = integrationBranch;
+      scheduleSaveSessions();
+    }
+  }
+
+  // Per-board mode: every task works in the single integration checkout and commits
+  // straight onto the integration branch — there is nothing to create and nothing
+  // to merge later (see mergeCompletedTaskWorktree).
+  if (mode === 'per-board') {
+    const sibling = board.tasks.find(
+      (t) => t.id !== task.id && Boolean(t.worktreePath) && typeof t.devPort === 'number',
+    );
+    const path = integrationPath ?? sibling?.worktreePath?.trim();
+    if (!path) return null;
+    const ports =
+      typeof sibling?.devPort === 'number' && typeof sibling?.apiPort === 'number'
+        ? { devPort: sibling.devPort, apiPort: sibling.apiPort }
+        : allocateTaskPorts(DEFAULT_BOARD_PORT_BASE, usedDevPorts(board.tasks));
+    if (
+      task.worktreePath !== path ||
+      task.worktreeBranch !== integrationBranch ||
+      task.devPort !== ports.devPort ||
+      task.apiPort !== ports.apiPort
+    ) {
+      updateTask(
+        group,
+        task.id,
+        {
+          worktreePath: path,
+          worktreeBranch: integrationBranch,
+          devPort: ports.devPort,
+          apiPort: ports.apiPort,
+        },
+        plannerChat,
+      );
+      logWorktreeAllocated(group, task.id, integrationBranch, ports.devPort, ports.apiPort);
+    }
+    return path;
   }
 
   // Per-wave mode: reuse a sibling task's already-created worktree for this wave.
@@ -2767,14 +2837,34 @@ async function mergeCompletedTaskWorktree(
     logMergeResult(group, task.id, 'skipped');
     return { outcome: 'skipped' };
   }
+  const mode = resolveIsolationMode(board);
+  const boardId = boardWorktreeSlug(group);
+
+  // Per-board isolation: the board branch *is* the integration branch, so the work
+  // is already on it. Commit in sequence and report merged — no git merge, which is
+  // what makes the whole merge-fixer path unreachable in this mode.
+  if (mode === 'per-board') {
+    try {
+      await commitTaskWorktree({
+        boardId,
+        slotId: BOARD_INTEGRATION_SLOT,
+        message: `Board task ${task.id}: ${task.title}`,
+      });
+    } catch (err) {
+      reportBackgroundError('worktree-commit', err);
+      const message = err instanceof Error ? err.message : String(err);
+      logMergeResult(group, task.id, 'error', { branch: board.integrationBranch, error: message });
+      return { outcome: 'error', message };
+    }
+    logMergeResult(group, task.id, 'merged', { branch: board.integrationBranch });
+    return { outcome: 'merged' };
+  }
+
   const branch = task.worktreeBranch;
   if (!branch || branch === board.integrationBranch) {
     logMergeResult(group, task.id, 'skipped', { branch });
     return { outcome: 'skipped' };
   }
-
-  const mode = resolveIsolationMode(board);
-  const boardId = group.id;
 
   if (mode === 'per-task') {
     const slotId = worktreeSlotId(mode, task);
@@ -2953,7 +3043,7 @@ export async function startMergeConflictFixer(
 
   const hold = acquireBoardPipelineHold(group, task.id, 'merge-fixer-start');
   try {
-  const boardId = group.id;
+  const boardId = boardWorktreeSlug(group);
 
   const ensured = await ensureIntegrationWorktree({
     boardId,
@@ -3154,7 +3244,7 @@ async function finalizeMergeFixerOnStreamEnd(
       return;
     }
 
-    const boardId = group.id;
+    const boardId = boardWorktreeSlug(group);
     const attempts = fresh.fixerAttempts ?? 0;
 
     // Neutral stop (user Stop / board paused): no automatic retry follows, so do
@@ -3623,7 +3713,7 @@ async function finalizeEnvFixerOnStreamEnd(
 export function cleanupBoardIsolation(group: ChatGroup): void {
   const board = group.orchestrateBoard;
   if (!board?.integrationBranch) return;
-  void cleanupBoardWorktreesOp({ boardId: group.id }).catch((err) =>
+  void cleanupBoardWorktreesOp({ boardId: boardWorktreeSlug(group) }).catch((err) =>
     reportBackgroundError('worktree-cleanup', err),
   );
 }
@@ -3648,7 +3738,7 @@ export async function clearBoardWorktreesAfterLanding(
   if (board.worktreesClearedAt) return { ok: true, removed: 0 };
 
   const res = await cleanupBoardWorktreesOp({
-    boardId: group.id,
+    boardId: boardWorktreeSlug(group),
     includeIntegration: true,
   });
   if (!res.ok) {
@@ -4407,7 +4497,7 @@ export async function startFinalIntegrationTest(
   // merged), not the main checkout. Only applies when board isolation is active.
   if (board.integrationBranch) {
     const ensured = await ensureIntegrationWorktree({
-      boardId: group.id,
+      boardId: boardWorktreeSlug(group),
       branch: board.integrationBranch,
     });
     const integrationPath = ensured.path?.trim();
@@ -4502,7 +4592,9 @@ export function tryTriggerFinalIntegrationTest(
     return;
   }
 
-  if (isBoardAutoMode(group)) {
+  // Only a started board launches the tester itself. A board the user never
+  // Started (the old "manual" case) just arms it and waits.
+  if (isBoardRunning(group)) {
     void startFinalIntegrationTest(group, plannerChat);
     return;
   }
@@ -4921,43 +5013,36 @@ export async function restartBoardAfterRequeueFailures(
   }
 }
 
-/** Persist auto/manual/sequential execution mode. Does not start execution — use startBoardAutoRun. */
-export function setBoardExecutionMode(
+/**
+ * Persist hands-off autonomy. Does not start execution — use startBoardAutoRun.
+ * Available at any concurrency, including 1.
+ */
+export function setBoardHandsOff(
   group: ChatGroup,
-  mode: 'manual' | 'auto' | 'sequential' | 'afk',
-  plannerChat: Chat,
+  on: boolean,
+  _plannerChat?: Chat,
 ): void {
   const board = group.orchestrateBoard;
   if (!board) return;
   const prevMode = getBoardExecutionMode(board);
-  board.executionMode = mode;
-  // Sequential → AFK must not silently lift the one-at-a-time cap. Sequential
-  // disables the concurrency stepper (ui/orchestrate-board.ts), so the user
-  // never had a chance to pick a value; pin it to 1 and let them raise it in AFK.
-  if (mode === 'afk' && prevMode === 'sequential' && board.maxConcurrentTasks === undefined) {
-    board.maxConcurrentTasks = 1;
-  }
-  if (mode !== 'afk') delete board.pendingAfk;
-  if (mode === 'manual') board.autoRunning = false;
+  if (on) board.handsOff = true;
+  else delete board.handsOff;
+  if (!on) delete board.pendingAfk;
   board.lastUpdatedAt = Date.now();
-  // Flush stop state immediately so reload cannot resurrect auto execution.
-  if (mode === 'manual') {
-    saveSessionsNow(group);
-  } else {
-    scheduleSaveSessions(group);
-  }
-  if (prevMode !== mode) {
-    logModeChange(group, mode);
+  scheduleSaveSessions(group);
+  const nextMode = getBoardExecutionMode(board);
+  if (prevMode !== nextMode) {
+    logModeChange(group, nextMode);
   }
   emitBoardChange(group.id);
 }
 
-/** Shared AFK activation after user confirmation (slider or pending banner). Does not start execution — user presses Start like Auto. */
+/** Shared AFK activation after user confirmation (checkbox or pending banner). Does not start execution — user presses Start. */
 export function activateAfk(group: ChatGroup, plannerChat: Chat): void {
   const board = group.orchestrateBoard;
   if (!board) return;
   delete board.pendingAfk;
-  setBoardExecutionMode(group, 'afk', plannerChat);
+  setBoardHandsOff(group, true, plannerChat);
 }
 
 /** Orchestrator requested AFK — show confirmation banner; mode unchanged until accepted. */
@@ -4983,7 +5068,7 @@ export function cancelPendingAfk(group: ChatGroup): void {
 /** Set per-board isolation override; `auto` clears the field (global / derived). */
 export function setBoardIsolationMode(
   group: ChatGroup,
-  mode: 'auto' | 'off' | 'per-task' | 'per-wave',
+  mode: 'auto' | 'off' | 'per-task' | 'per-wave' | 'per-board',
   _plannerChat: Chat,
 ): void {
   const board = group.orchestrateBoard;
@@ -5011,10 +5096,13 @@ export function setBoardMaxConcurrent(
   if (!board) return;
   const clamped = Math.max(1, Math.min(20, Math.floor(value)));
   if (board.maxConcurrentTasks === clamped) return;
+  const prevMode = getBoardExecutionMode(board);
   board.maxConcurrentTasks = clamped;
   board.lastUpdatedAt = Date.now();
   scheduleSaveSessions();
   emitBoardChange(group.id);
+  const nextMode = getBoardExecutionMode(board);
+  if (prevMode !== nextMode) logModeChange(group, nextMode);
   if (isBoardAutoMode(group)) {
     void drainTaskQueue(group, plannerChat);
   }

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -88,7 +88,7 @@ import {
   getPlannerChatForGroup,
 } from './chat-groups.ts';
 import { emitBoardChange } from './orchestrate-board-events.ts';
-import { isTaskReadyForAuto, isTaskStalledForRestart, isBoardAutoMode, isBoardRunning, getBoardExecutionMode, syncOrchestrateBoardTimer, updateTask, logTaskStatus, logBoardReportNudge, logBuildVerdict, logTestVerdict, logMergeResult, logWorktreeAllocated, logWorktreeReleased, logTaskRetry, logModeChange, logAutoStart, logAutoStop, logFinalTestStarted, logFinalTestVerdict, logBoardPhase, logBoardSlot, logBoardHold, logBoardConcurrency, logBoardLifecycleOwner, quarantineTaskAndDependents, type OrchestrateBoardTimerContext } from './orchestrate-board-store.ts';
+import { isTaskReadyForAuto, isTaskStalledForRestart, isBoardAutoMode, isBoardRunning, getBoardExecutionMode, syncOrchestrateBoardTimer, updateTask, logTaskStatus, logBoardReportNudge, logBuildVerdict, logTestVerdict, logMergeResult, logWorktreeAllocated, logWorktreeReleased, logTaskRetry, logModeChange, logAutoStart, logAutoStop, logFinalTestStarted, logFinalTestVerdict, logBoardPhase, logBoardSlot, logBoardHold, logBoardConcurrency, logBoardLifecycleOwner, quarantineTaskAndDependents, appendBoardTasks, nextBoardWaveId, type OrchestrateBoardTimerContext } from './orchestrate-board-store.ts';
 import {
   acquirePipelineHold,
   heldTaskIdsForOccupancy,
@@ -2119,7 +2119,12 @@ export function buildFinalIntegrationTestSeedMessage(
     taskList,
     '',
     'Exercise the whole app end-to-end. On failure, identify responsible task ids via board_get_state.',
-    `Report exactly once via board_report({ task_id: "${FULL_BOARD_TEST_ID}", outcome: "pass" | "fail", summary: "...", failing_tasks: [...] }).`,
+    '',
+    'Also determine how a person runs this project: actually run the install, start,',
+    'and test commands and note which ones worked. Report only commands you ran and',
+    'verified — omit anything you did not run rather than guessing from the manifest.',
+    '',
+    `Report exactly once via board_report({ task_id: "${FULL_BOARD_TEST_ID}", outcome: "pass" | "fail", summary: "...", failing_tasks: [...], run_instructions: { install, start, test, notes } }).`,
   ].join('\n');
 }
 
@@ -4802,6 +4807,11 @@ export function finalizeFinalTestOnStreamEnd(
     attempts,
     summary,
   };
+  // Reachable on the *first* failure, not only once retries are exhausted — the
+  // finish dashboard is where the user reads what failed and asks for a fix.
+  if (board.completionShownAt == null && isOrchestratePlanComplete(board)) {
+    board.completionShownAt = Date.now();
+  }
   board.lastUpdatedAt = Date.now();
   scheduleSaveSessions();
   emitBoardChange(group.id);
@@ -5130,6 +5140,117 @@ export async function resetAllFailedBoardTasks(
     await resetBoardTask(group, id, plannerChat);
   }
   return rootIds;
+}
+
+/** Task id for an appended integration-fix task, de-duped against the board. */
+function mintFixTaskId(board: OrchestrateBoardState, waveId: number | string): string {
+  const taken = new Set(board.tasks.map((t) => t.id));
+  const base = `${waveId}-FIX`;
+  if (!taken.has(base)) return base;
+  for (let n = 2; n < 100; n += 1) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base}-${Date.now()}`;
+}
+
+/** Build the spec for the appended fix task from what the final tester reported. */
+function buildFinalTestFixSpec(board: OrchestrateBoardState): string {
+  const summary = board.finalTest?.summary?.trim() || 'The final integration test failed.';
+  const failing = board.finalTest?.failingTaskIds ?? [];
+  const lines = [
+    'The full-board integration test failed after every task was merged.',
+    '',
+    'Reported failure:',
+    summary,
+  ];
+  if (failing.length) {
+    const named = failing
+      .map((id) => {
+        const task = board.tasks.find((t) => t.id === id);
+        return task ? `- ${task.id} — ${task.title}` : `- ${id}`;
+      })
+      .join('\n');
+    lines.push('', 'Tasks the tester held responsible:', named);
+  }
+  const testerChatId = board.finalTest?.chatId?.trim();
+  if (testerChatId) {
+    lines.push('', `Final tester chat: ${testerChatId}`);
+  }
+  lines.push(
+    '',
+    'Fix the integration failure across whatever files it touches, then report what you changed.',
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Explicit "Fix integration failures" path from the finish dashboard.
+ *
+ * Appends one real `fix` task in a new wave rather than reopening the tasks that
+ * already passed their own tests — the failure is *between* them. Resets the
+ * final-test gate so `syncBoardRunCompletion` re-fires it once the fix goes
+ * terminal; no new trigger is needed.
+ *
+ * The automatic AFK path stays {@link applyFinalTestFailureReopens}.
+ */
+export async function appendFinalTestFixTask(
+  group: ChatGroup,
+  plannerChat: Chat,
+): Promise<string | null> {
+  const board = group.orchestrateBoard;
+  if (!board || board.finalTest?.status !== 'failed') return null;
+
+  const waveId = nextBoardWaveId(board);
+  const taskId = mintFixTaskId(board, waveId);
+  const spec = buildFinalTestFixSpec(board);
+
+  const appended = appendBoardTasks(
+    group,
+    [
+      {
+        id: taskId,
+        title: 'Fix final integration test failure',
+        wave: waveId,
+        category: 'fix',
+        build: spec,
+        test: 'Re-run the full test suite and confirm the integration failure is gone.',
+      },
+    ],
+    plannerChat,
+    { waveId },
+  );
+  if (!appended.length) return null;
+
+  // Same reset block restartBoardAfterRequeueFailures uses, so the dashboard
+  // stops claiming a finished run and the final test can fire again.
+  const chatId = board.finalTest.chatId;
+  const attempts = board.finalTest.attempts;
+  board.finalTest = {
+    ...(chatId ? { chatId } : {}),
+    ...(attempts != null ? { attempts } : {}),
+    status: 'pending',
+    recordedVerdict: undefined,
+    summary: undefined,
+    failingTaskIds: undefined,
+  };
+  delete board.completionShownAt;
+  delete board.finishReport;
+  delete board.wrapUpPending;
+  board.terminalBlocked = false;
+  board.dashboardDismissed = true;
+  board.lastUpdatedAt = Date.now();
+  scheduleSaveSessions();
+  emitBoardChange(group.id);
+
+  // Start it now when the board is running; otherwise it waits on the board's
+  // own Start, exactly like any other planned task.
+  if (isBoardRunning(group)) {
+    await autoDelegateNext(group, plannerChat);
+  } else {
+    await startTask(group, taskId, plannerChat);
+  }
+  return taskId;
 }
 
 /**

--- a/src/state/orchestrate-board-store.ts
+++ b/src/state/orchestrate-board-store.ts
@@ -26,6 +26,7 @@ import type {
   ChatGroup,
   OrchestrateBoardState,
 } from '../types.ts';
+import { deriveBoardExecutionMode } from './board-execution-mode.ts';
 import { getBoardGroupForChat, getPlannerChatForGroup, linkPlannerChatToBoardFolder } from './chat-groups.ts';
 import { emitBoardChange } from './orchestrate-board-events.ts';
 import { hasPipelineHold } from './orchestrate-pipeline-holds.ts';
@@ -1000,22 +1001,25 @@ export function markBoardTaskInProgressFromChat(chat: Chat): void {
   }
 }
 
-/** Resolved execution mode (defaults to manual). */
+/**
+ * Resolved execution mode, derived from concurrency + hands-off.
+ * See {@link file://./board-execution-mode.ts} — this is the single derivation point.
+ */
 export function getBoardExecutionMode(
   board: OrchestrateBoardState | null | undefined,
 ): 'manual' | 'auto' | 'sequential' | 'afk' {
-  const m = board?.executionMode;
-  if (m === 'auto' || m === 'sequential' || m === 'afk') return m;
-  return 'manual';
+  return deriveBoardExecutionMode(board);
 }
 
-/** True when the board is in auto-pilot delegation mode (auto, sequential, or afk). */
+/**
+ * True when the board delegates automatically. Every board with a plan does now —
+ * a board that has not been Started is the "manual" case, see {@link isBoardRunning}.
+ */
 export function isBoardAutoMode(group: ChatGroup): boolean {
-  const mode = getBoardExecutionMode(group.orchestrateBoard);
-  return mode === 'auto' || mode === 'sequential' || mode === 'afk';
+  return Boolean(group.orchestrateBoard);
 }
 
-/** True when auto/sequential mode is active AND the user has pressed Start. */
+/** True when the user has pressed Start on the board. */
 export function isBoardRunning(group: ChatGroup): boolean {
   return isBoardAutoMode(group) && group.orchestrateBoard?.autoRunning === true;
 }
@@ -1133,7 +1137,7 @@ export function initBoard(
     lastUpdatedAt: now,
     timerAccumulatedMs: 0,
     maxConcurrentTasks: getAutopilotMetaSync().maxConcurrentTasks ?? 3,
-    executionMode: getAutopilotMetaSync().defaultExecutionMode ?? 'manual',
+    ...(getAutopilotMetaSync().defaultHandsOff === true ? { handsOff: true } : {}),
   };
   const modelBinding = resolveBoardModelBinding(plannerChat);
   if (modelBinding.modelId) {

--- a/src/state/orchestrate-board-store.ts
+++ b/src/state/orchestrate-board-store.ts
@@ -293,6 +293,26 @@ export function logWorktreeAllocated(
   });
 }
 
+/**
+ * Counterpart to {@link logWorktreeAllocated}: the task's worktree directory was
+ * removed after its branch landed in integration. The branch is deliberately kept,
+ * so a later requeue can recreate the slot from it.
+ */
+export function logWorktreeReleased(
+  group: ChatGroup,
+  taskId: string,
+  branch: string,
+  detail?: Record<string, unknown>,
+): void {
+  appendBoardLog(group, {
+    type: 'worktree_released',
+    level: 'info',
+    taskId,
+    message: `${taskId}: worktree released (branch ${branch} kept)`,
+    detail: { branch, ...detail },
+  });
+}
+
 export function logTaskRetry(
   group: ChatGroup,
   taskId: string,

--- a/src/state/orchestrate-board-store.ts
+++ b/src/state/orchestrate-board-store.ts
@@ -1192,6 +1192,89 @@ export function initBoard(
   return board;
 }
 
+/**
+ * Wave id to use for tasks appended to a running board: one past the highest
+ * existing wave, in whatever spelling the board already uses (`3`, `W3`, …).
+ */
+export function nextBoardWaveId(board: OrchestrateBoardState): number | string {
+  const ids = board.waves.map((w) => w.id);
+  const taken = new Set(ids.map((id) => String(id)));
+
+  const numeric = ids.every((id) => typeof id === 'number' && Number.isFinite(id));
+  if (numeric && ids.length) {
+    let next = Math.max(...(ids as number[])) + 1;
+    while (taken.has(String(next))) next += 1;
+    return next;
+  }
+
+  const prefixed = ids
+    .map((id) => /^([A-Za-z]+)(\d+)$/.exec(String(id)))
+    .filter((m): m is RegExpExecArray => Boolean(m));
+  if (prefixed.length === ids.length && prefixed.length) {
+    const prefix = prefixed[0]![1]!;
+    if (prefixed.every((m) => m[1] === prefix)) {
+      let next = Math.max(...prefixed.map((m) => Number(m[2]))) + 1;
+      while (taken.has(`${prefix}${next}`)) next += 1;
+      return `${prefix}${next}`;
+    }
+  }
+
+  let n = ids.length + 1;
+  while (taken.has(`W${n}`)) n += 1;
+  return `W${n}`;
+}
+
+/**
+ * Append tasks to an existing board in a brand-new wave.
+ *
+ * Distinct from {@link initBoard}, which *replaces* the board wholesale, and from
+ * {@link updateTask}, which throws on an unknown id. Callers must validate the
+ * **merged** task set first (`validateBoardAddTasksArgs`) — cycles and unknown
+ * dependencies only show up once new tasks are read against the existing ones.
+ */
+export function appendBoardTasks(
+  group: ChatGroup,
+  input: InitBoardInput['tasks'],
+  plannerChat: Chat,
+  options: { waveId?: number | string } = {},
+): BoardTask[] {
+  const board = group.orchestrateBoard;
+  if (!board || !input.length) return [];
+
+  const waveId = options.waveId ?? nextBoardWaveId(board);
+  if (!board.waves.some((w) => String(w.id) === String(waveId))) {
+    board.waves.push({ id: waveId, status: 'planned' });
+  }
+
+  const appended: BoardTask[] = input.map((t) => ({
+    id: t.id,
+    title: t.title,
+    wave: t.wave ?? waveId,
+    category: t.category,
+    status: 'planned' as BoardTaskStatus,
+    ...(t.build?.trim() ? { buildSpec: t.build.trim() } : {}),
+    ...(t.test?.trim() ? { testSpec: t.test.trim() } : {}),
+    ...(t.dependsOn && t.dependsOn.length ? { dependsOn: [...t.dependsOn] } : {}),
+  }));
+  board.tasks.push(...appended);
+
+  recomputeWaveRollup(board);
+  board.lastUpdatedAt = boardNowMs();
+  touchChat(plannerChat);
+  appendBoardLog(group, {
+    type: 'board_init',
+    level: 'info',
+    message: `Added ${appended.length} task${appended.length === 1 ? '' : 's'} in wave ${waveId}`,
+    detail: {
+      summary: `${appended.length} tasks appended`,
+      waveId: String(waveId),
+      taskIds: appended.map((t) => t.id),
+    },
+  });
+  persistBoardGroup(group);
+  return appended;
+}
+
 export type UpdateTaskPatch = Partial<
   Pick<
     BoardTask,

--- a/src/state/session-schema.mjs
+++ b/src/state/session-schema.mjs
@@ -4,6 +4,8 @@
  * client load stay on one allowlist (sessions SQLite migration Phase B.1).
  */
 
+import { applyLegacyExecutionMode } from '../lib/legacy-execution-mode.mjs';
+
 /** Inline copy of server/config/orchestrate-plan-path.js (avoid server→client coupling). */
 const ORCHESTRATE_PLANS_PREFIX = 'documentation/plans/';
 const ORCHESTRATE_PLANS_PREFIX_LEN = ORCHESTRATE_PLANS_PREFIX.length;
@@ -619,24 +621,27 @@ function ensureOrchestrateBoard(raw) {
   if (typeof r.finishReport === 'string' && r.finishReport.trim()) {
     out.finishReport = r.finishReport.trim();
   }
-  const executionModeRaw =
-    typeof r.executionMode === 'string' ? r.executionMode.trim() : '';
-  const executionMode =
-    executionModeRaw === 'auto' ||
-    executionModeRaw === 'manual' ||
-    executionModeRaw === 'sequential' ||
-    executionModeRaw === 'afk'
-      ? executionModeRaw
-      : 'manual';
-  out.executionMode = executionMode;
   if (r.autoRunning === true) out.autoRunning = true;
+  if (r.handsOff === true) out.handsOff = true;
   if (r.pendingAfk === true) out.pendingAfk = true;
+  // Legacy four-value executionMode folds into concurrency + hands-off, then is
+  // dropped from the persisted shape. The mode is derived from those two now
+  // (src/state/board-execution-mode.ts); persisting it would make that circular.
+  if (typeof r.executionMode === 'string') {
+    applyLegacyExecutionMode(out, r.executionMode.trim());
+    if (out.autoRunning !== true) delete out.autoRunning;
+    if (out.handsOff !== true) delete out.handsOff;
+  }
+  if (typeof r.worktreeSlug === 'string' && r.worktreeSlug.trim()) {
+    out.worktreeSlug = r.worktreeSlug.trim().slice(0, 64);
+  }
   const isolationModeRaw =
     typeof r.isolationMode === 'string' ? r.isolationMode.trim() : '';
   if (
     isolationModeRaw === 'off' ||
     isolationModeRaw === 'per-task' ||
-    isolationModeRaw === 'per-wave'
+    isolationModeRaw === 'per-wave' ||
+    isolationModeRaw === 'per-board'
   ) {
     out.isolationMode = isolationModeRaw;
   }

--- a/src/state/session-schema.mjs
+++ b/src/state/session-schema.mjs
@@ -1104,6 +1104,9 @@ export function normalizeSessionScalars(raw, options = {}) {
     ) {
       out.activeBoardGroupId = parsed.activeBoardGroupId.trim();
     }
+    if (typeof parsed.lastBoardGroupId === 'string' && parsed.lastBoardGroupId.trim()) {
+      out.lastBoardGroupId = parsed.lastBoardGroupId.trim();
+    }
     if (
       parsed.codeChangeTotalsByWorkspace &&
       typeof parsed.codeChangeTotalsByWorkspace === 'object' &&
@@ -1128,6 +1131,13 @@ export function normalizeSessionScalars(raw, options = {}) {
         out.activeBoardGroupId = parsed.activeBoardGroupId.trim();
       } else {
         out.activeBoardGroupId = null;
+      }
+    }
+    if (has('lastBoardGroupId')) {
+      if (typeof parsed.lastBoardGroupId === 'string' && parsed.lastBoardGroupId.trim()) {
+        out.lastBoardGroupId = parsed.lastBoardGroupId.trim();
+      } else {
+        out.lastBoardGroupId = null;
       }
     }
     if (has('codeChangeTotalsByWorkspace')) {

--- a/src/state/session-schema.mjs
+++ b/src/state/session-schema.mjs
@@ -243,6 +243,7 @@ const BOARD_LOG_TYPES = new Set([
   'test_verdict',
   'merge_result',
   'worktree_allocated',
+  'worktree_released',
   'task_retry',
   'nudge',
   'task_error',

--- a/src/state/session-schema.mjs
+++ b/src/state/session-schema.mjs
@@ -557,7 +557,21 @@ function ensureOrchestrateFinalTest(raw) {
   if (typeof r.summary === 'string' && r.summary.trim()) {
     out.summary = r.summary.trim();
   }
+  const runInstructions = ensureBoardRunInstructions(r.runInstructions);
+  if (runInstructions) out.runInstructions = runInstructions;
   return out;
+}
+
+/** Verified project commands reported by the final tester (board_report FULL_BOARD). */
+function ensureBoardRunInstructions(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const r = /** @type {Record<string, unknown>} */ (raw);
+  const out = {};
+  for (const key of ['install', 'start', 'test', 'notes']) {
+    const value = r[key];
+    if (typeof value === 'string' && value.trim()) out[key] = value.trim();
+  }
+  return Object.keys(out).length ? out : undefined;
 }
 
 function ensureOrchestrateBoard(raw) {

--- a/src/state/sessions.ts
+++ b/src/state/sessions.ts
@@ -385,6 +385,7 @@ export function buildSessionsPatchDelta(state: SessionState): SessionsPatchDelta
     // Optional keys: send explicit null so PATCH can clear them.
     scalars.sidebarWidth = state.sidebarWidth ?? null;
     scalars.activeBoardGroupId = state.activeBoardGroupId ?? null;
+    scalars.lastBoardGroupId = state.lastBoardGroupId ?? null;
     if (state.codeChangeTotalsByWorkspace) {
       scalars.codeChangeTotalsByWorkspace = state.codeChangeTotalsByWorkspace;
     }
@@ -728,6 +729,7 @@ function sessionStateFromSummaries(remote: SessionSummariesState): SessionState 
     chats: inflatedChats,
     groups: remote.groups,
     activeBoardGroupId: remote.activeBoardGroupId,
+    lastBoardGroupId: remote.lastBoardGroupId,
     lastActiveChatIdByWorkspace: remote.lastActiveChatIdByWorkspace,
     lastActiveChatIdByApp: remote.lastActiveChatIdByApp,
     sidebarWidth: remote.sidebarWidth,
@@ -1082,6 +1084,12 @@ export function parseSessionStateFromJson(parsed: RawSessionJson | null): Sessio
     rawSession.activeBoardGroupId.trim()
   ) {
     state.activeBoardGroupId = rawSession.activeBoardGroupId.trim();
+  }
+  if (
+    typeof rawSession.lastBoardGroupId === 'string' &&
+    rawSession.lastBoardGroupId.trim()
+  ) {
+    state.lastBoardGroupId = rawSession.lastBoardGroupId.trim();
   }
   if (ver < 5 || state.chats.some((c) => c.orchestrateBoard)) {
     migrateSessionV4ToV5(state);

--- a/src/state/worktree-isolation.ts
+++ b/src/state/worktree-isolation.ts
@@ -6,11 +6,13 @@
  */
 
 import { getAutopilotMetaSync } from '../config/autopilot-meta.ts';
+import { sanitizePathSegment } from '../lib/sanitize-path-segment.mjs';
+import { resolveBoardConcurrency } from './board-execution-mode.ts';
 import { normalizeWorkspacePath } from '../lib/normalize-workspace-path.ts';
 import { isMinnowSandboxWorkspacePath } from '../lib/workspace-sandbox.ts';
 import type { BoardTask, Chat, ChatGroup, OrchestrateBoardState } from '../types.ts';
 
-export type IsolationMode = 'off' | 'per-task' | 'per-wave';
+export type IsolationMode = 'off' | 'per-task' | 'per-wave' | 'per-board';
 
 /** Default base port for isolated dev servers (server may override via env). */
 export const DEFAULT_BOARD_PORT_BASE = 5200;
@@ -18,33 +20,33 @@ export const DEFAULT_BOARD_PORT_BASE = 5200;
 /** Offset above {@link DEFAULT_BOARD_PORT_BASE} client port for the API server port. */
 export const DEFAULT_BOARD_API_PORT_OFFSET = 100;
 
+const ISOLATION_MODES: readonly IsolationMode[] = ['off', 'per-task', 'per-wave', 'per-board'];
+
+function asIsolationMode(value: unknown): IsolationMode | undefined {
+  return ISOLATION_MODES.includes(value as IsolationMode)
+    ? (value as IsolationMode)
+    : undefined;
+}
+
 /**
  * Effective isolation mode: per-board override, then global default (when not `auto`),
- * then derive from execution mode.
- * - `auto` / `afk` execution → `per-task`
- * - `sequential` / `manual` / unset → `off`
+ * then derive from concurrency.
+ * - concurrency `1` → `per-board` (one worktree for the whole board; its branch *is*
+ *   the integration branch, so tasks commit in sequence and never merge)
+ * - concurrency `>1` → `per-task`
+ *
+ * `off` stays selectable but is no longer any board's default — it is what left work
+ * uncommitted in the user's live checkout with no integration branch to land.
  */
 export function resolveIsolationMode(
   board: OrchestrateBoardState | null | undefined,
 ): IsolationMode {
   if (!board) return 'off';
-  const explicit = board.isolationMode;
-  if (explicit === 'off' || explicit === 'per-task' || explicit === 'per-wave') {
-    return explicit;
-  }
-  const globalIso = getAutopilotMetaSync().isolationMode;
-  if (globalIso === 'off' || globalIso === 'per-task' || globalIso === 'per-wave') {
-    return globalIso;
-  }
-  switch (board.executionMode) {
-    case 'auto':
-    case 'afk':
-      return 'per-task';
-    case 'sequential':
-    case 'manual':
-    default:
-      return 'off';
-  }
+  const explicit = asIsolationMode(board.isolationMode);
+  if (explicit) return explicit;
+  const globalIso = asIsolationMode(getAutopilotMetaSync().isolationMode);
+  if (globalIso) return globalIso;
+  return resolveBoardConcurrency(board) === 1 ? 'per-board' : 'per-task';
 }
 
 /** True when the board isolates task work into separate git worktrees. */
@@ -59,17 +61,18 @@ export function isIsolationActive(
  * dot, dash, underscore; collapse the rest to a single dash; bound length.
  */
 export function sanitizeRefFragment(raw: string | number): string {
-  const cleaned = String(raw)
-    .trim()
-    .replace(/[^a-zA-Z0-9._-]+/g, '-')
-    .replace(/^[-.]+|[-.]+$/g, '')
-    .slice(0, 64);
-  return cleaned || 'x';
+  return sanitizePathSegment(raw);
 }
 
-/** Board integration branch — task/wave branches merge into this. */
-export function boardIntegrationBranch(boardId: string): string {
-  return `minnow/board/${sanitizeRefFragment(boardId)}/integration`;
+/**
+ * Board integration branch — task/wave branches merge into this. In `per-board`
+ * mode it is the *only* branch: tasks commit straight onto it.
+ *
+ * The `minnow/board/` prefix is load-bearing — `server/git/git-ops.js` and
+ * `src/lib/worktree-list-parse.ts` identify board branches by it.
+ */
+export function boardIntegrationBranch(boardSlug: string): string {
+  return `minnow/board/${sanitizeRefFragment(boardSlug)}/integration`;
 }
 
 /** Worktree slot directory name for the board integration checkout. */
@@ -84,12 +87,15 @@ export function integrationWorktreePathFromSlotPath(slotPath: string): string | 
   if (!normalized) return undefined;
   const parts = normalized.split('/');
   const slot = parts[parts.length - 1];
-  if (!slot) return undefined;
+  const boardDir = parts[parts.length - 2];
+  if (!slot || !boardDir) return undefined;
+  // Slot names are free-form now (`T1-add-login`, `wave-2`, …), so the integration
+  // sibling is identified structurally: any slot directly under a board directory.
+  if (!parts.includes('worktrees')) return undefined;
+  // `<repo>/chat/<chatId>` is a regular-chat worktree (MIN-276), not a board slot.
+  if (boardDir === 'chat') return undefined;
   if (slot === BOARD_INTEGRATION_SLOT) return normalized;
-  if (/^(task|wave)-/.test(slot)) {
-    return [...parts.slice(0, -1), BOARD_INTEGRATION_SLOT].join('/');
-  }
-  return undefined;
+  return [...parts.slice(0, -1), BOARD_INTEGRATION_SLOT].join('/');
 }
 
 /** True when a chat belongs to the given orchestrate board folder. */
@@ -137,36 +143,100 @@ export function resolveBoardIntegrationWorktreePath(
   return undefined;
 }
 
+/**
+ * Readable directory/branch fragment for one task: `<taskId>-<title-slug>`.
+ * Long titles are truncated by the shared segment cap, so they degrade to a prefix
+ * rather than collide — the leading task id keeps the slot unique either way.
+ */
+export function taskWorktreeSlot(task: Pick<BoardTask, 'id' | 'title'>): string {
+  const id = sanitizeRefFragment(task.id);
+  const title = task.title?.trim()
+    ? sanitizeRefFragment(task.title.trim().toLowerCase())
+    : '';
+  return title ? sanitizeRefFragment(`${id}-${title}`) : id;
+}
+
 /** Per-task branch (per-task mode). */
-export function taskWorktreeBranch(boardId: string, taskId: string): string {
-  return `minnow/board/${sanitizeRefFragment(boardId)}/task/${sanitizeRefFragment(taskId)}`;
+export function taskWorktreeBranch(
+  boardSlug: string,
+  task: Pick<BoardTask, 'id' | 'title'>,
+): string {
+  return `minnow/board/${sanitizeRefFragment(boardSlug)}/${taskWorktreeSlot(task)}`;
 }
 
 /** Shared per-wave branch (per-wave mode). */
-export function waveWorktreeBranch(boardId: string, waveId: string | number): string {
-  return `minnow/board/${sanitizeRefFragment(boardId)}/wave/${sanitizeRefFragment(waveId)}`;
+export function waveWorktreeBranch(boardSlug: string, waveId: string | number): string {
+  return `minnow/board/${sanitizeRefFragment(boardSlug)}/wave-${sanitizeRefFragment(waveId)}`;
 }
 
 /**
  * Worktree slot id for a task under the given mode — identifies the worktree dir
- * within the board. `per-task` → one per task; `per-wave` → shared per wave.
- * Returns null when isolation is off.
+ * within the board. `per-task` → one per task; `per-wave` → shared per wave;
+ * `per-board` → the single integration checkout. Null when isolation is off.
  */
 export function worktreeSlotId(mode: IsolationMode, task: BoardTask): string | null {
-  if (mode === 'per-task') return `task-${sanitizeRefFragment(task.id)}`;
+  if (mode === 'per-task') return taskWorktreeSlot(task);
   if (mode === 'per-wave') return `wave-${sanitizeRefFragment(task.wave)}`;
+  if (mode === 'per-board') return BOARD_INTEGRATION_SLOT;
   return null;
 }
 
 /** Branch backing a task's worktree under the given mode, or null when off. */
 export function worktreeBranchFor(
   mode: IsolationMode,
-  boardId: string,
+  boardSlug: string,
   task: BoardTask,
 ): string | null {
-  if (mode === 'per-task') return taskWorktreeBranch(boardId, task.id);
-  if (mode === 'per-wave') return waveWorktreeBranch(boardId, task.wave);
+  if (mode === 'per-task') return taskWorktreeBranch(boardSlug, task);
+  if (mode === 'per-wave') return waveWorktreeBranch(boardSlug, task.wave);
+  if (mode === 'per-board') return boardIntegrationBranch(boardSlug);
   return null;
+}
+
+/**
+ * Human-readable board directory segment. Minted once and frozen onto
+ * `board.worktreeSlug` (see `ensureBoardWorktreeSlug` in orchestrate-board-actions)
+ * so renaming the board never orphans a worktree.
+ *
+ * Boards that already provisioned worktrees keep the opaque group id — their
+ * directories and branches exist on disk under that name.
+ */
+export function deriveBoardWorktreeSlug(
+  group: ChatGroup,
+  takenSlugs: Iterable<string> = [],
+): string {
+  const board = group.orchestrateBoard;
+  const existing = board?.worktreeSlug?.trim();
+  if (existing) return existing;
+
+  const provisioned =
+    Boolean(board?.integrationBranch?.trim()) ||
+    Boolean(board?.tasks?.some((t) => t.worktreePath?.trim()));
+  if (provisioned) return sanitizeRefFragment(group.id);
+
+  const planPath = group.orchestratePlanPath?.trim();
+  const planLabel = planPath
+    ? planPath.replace(/\\/g, '/').split('/').pop()?.replace(/\.[^.]+$/, '')
+    : '';
+  const source = planLabel || group.name?.trim() || 'board';
+  const base = sanitizeRefFragment(source.toLowerCase());
+
+  const taken = new Set<string>();
+  for (const slug of takenSlugs) {
+    const trimmed = slug?.trim();
+    if (trimmed) taken.add(trimmed);
+  }
+  if (!taken.has(base)) return base;
+  for (let n = 2; n < 1000; n += 1) {
+    const candidate = sanitizeRefFragment(`${base}-${n}`);
+    if (!taken.has(candidate)) return candidate;
+  }
+  return sanitizeRefFragment(`${base}-${group.id}`);
+}
+
+/** Frozen board worktree slug for path/branch construction (falls back to group id). */
+export function boardWorktreeSlug(group: ChatGroup): string {
+  return group.orchestrateBoard?.worktreeSlug?.trim() || sanitizeRefFragment(group.id);
 }
 
 /**
@@ -179,6 +249,7 @@ export function tasksSharingSlot(
   task: BoardTask,
   allTasks: BoardTask[],
 ): BoardTask[] {
+  if (mode === 'per-board') return [...allTasks];
   if (mode === 'per-wave') {
     return allTasks.filter((t) => String(t.wave) === String(task.wave));
   }

--- a/src/state/worktree-service.ts
+++ b/src/state/worktree-service.ts
@@ -53,6 +53,9 @@ export interface WorktreeOpResult {
   hasRemote?: boolean;
   hasGh?: boolean;
   alreadyLanded?: boolean;
+  /** Stats came from the uncommitted workspace checkout (no integration branch). */
+  dirtyWorkspace?: boolean;
+  untrackedCount?: number;
   currentBranch?: string | null;
 }
 
@@ -191,9 +194,12 @@ export function integrationStats(input: {
   return postWorktree('integration_stats', input);
 }
 
-/** Numstat diff for landing integration work into the workspace checkout. */
+/**
+ * Numstat diff for landing integration work into the workspace checkout. With no
+ * branch the server reports the uncommitted workspace diff instead (isolation off).
+ */
 export function workspaceLandingStats(input: {
-  branch: string;
+  branch?: string;
 }): Promise<WorktreeOpResult> {
   return postWorktree('workspace_landing_stats', input);
 }

--- a/src/styles/ob-page.css
+++ b/src/styles/ob-page.css
@@ -337,6 +337,25 @@ main#chatArea.chat-area:has(.ob-page) {
   letter-spacing: 0.01em;
 }
 
+/*
+ * Live-run marker on a board row. Deliberately static: a running CSS animation
+ * pins the compositor at refresh rate, and this dot is only ever on screen while
+ * a board (often a local model) is doing work.
+ */
+.ob-row__running-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: var(--mn-success, var(--success));
+  vertical-align: baseline;
+}
+
+.ob-row.is-running .ob-row__title {
+  font-weight: 600;
+}
+
 .ob-row.is-active {
   background: var(--mn-accent-soft);
 }

--- a/src/styles/orchestrate-board.css
+++ b/src/styles/orchestrate-board.css
@@ -1020,6 +1020,30 @@
   min-height: 44px;
 }
 
+/* ---------- final-test failure detail (finish dashboard) ---------- */
+
+.board-finish-dashboard__final-test {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--mn-danger-border, var(--mn-border));
+  border-radius: var(--radius-sm, 6px);
+  background: var(--mn-danger-soft, transparent);
+}
+
+.board-finish-dashboard__final-test-summary {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.board-finish-dashboard__final-test-tasks {
+  margin: 8px 0 0;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--mn-fg-muted, var(--text-dim));
+}
+
 /* ---------- run-settings help lightbox ---------- */
 
 .board-header__run-help {

--- a/src/styles/orchestrate-board.css
+++ b/src/styles/orchestrate-board.css
@@ -525,139 +525,6 @@
   white-space: nowrap;
 }
 
-.board-header__auto-pilot {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 32px;
-  padding: 0 10px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--mn-muted);
-  border: 1px solid var(--mn-border);
-  border-radius: var(--radius-sm);
-  background: var(--mn-bg);
-  cursor: pointer;
-  user-select: none;
-}
-
-.board-header__auto-pilot-input {
-  margin: 0;
-  accent-color: var(--mn-accent);
-}
-
-.board-header__auto-pilot-label {
-  white-space: nowrap;
-}
-
-/* Execution autonomy: segmented control (composer mode-segment family). */
-.board-header__exec-mode {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  min-width: 0;
-}
-
-.board-header__exec-mode-segments {
-  display: inline-flex;
-  flex-wrap: nowrap;
-  gap: 2px;
-  padding: 2px;
-  border-radius: var(--radius-sm);
-  background: var(--mn-bg);
-  border: 1px solid var(--mn-border);
-}
-
-.board-header__exec-mode-segment {
-  appearance: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 28px;
-  padding: 0 9px;
-  border: 1px solid transparent;
-  border-radius: calc(var(--radius-sm) - 2px);
-  background: transparent;
-  color: var(--mn-fg-muted);
-  font-family: var(--font-ui);
-  font-size: 0.6875rem;
-  font-weight: 600;
-  line-height: 1.2;
-  white-space: nowrap;
-  cursor: pointer;
-  transition:
-    background 0.2s var(--ease-out),
-    color 0.2s var(--ease-out),
-    border-color 0.2s var(--ease-out);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .board-header__exec-mode-segment:hover:not([aria-checked='true']) {
-    color: var(--mn-fg);
-    border-color: var(--mn-border);
-    background: color-mix(in srgb, var(--mn-fg) 4%, var(--mn-bg));
-  }
-}
-
-.board-header__exec-mode-segment[aria-checked='true'] {
-  background: var(--mn-accent);
-  border-color: var(--mn-accent);
-  color: var(--mn-accent-fg, var(--mn-fg-on-accent));
-}
-
-.board-header__exec-mode-segment:focus-visible {
-  outline: 2px solid var(--mn-accent);
-  outline-offset: 2px;
-}
-
-.board-header__exec-mode-hint {
-  position: absolute;
-  top: calc(100% + 5px);
-  right: 0;
-  z-index: 2;
-  margin: 0;
-  box-sizing: border-box;
-  width: max-content;
-  max-width: min(20rem, calc(100vw - 24px));
-  padding: 4px 8px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--mn-border);
-  background: var(--mn-bg);
-  font-family: var(--font-ui);
-  font-size: 0.625rem;
-  font-weight: 500;
-  line-height: 1.35;
-  color: var(--mn-fg-muted);
-  white-space: normal;
-  overflow-wrap: break-word;
-  pointer-events: none;
-  box-shadow: 0 2px 8px color-mix(in srgb, var(--mn-fg) 8%, transparent);
-  opacity: 0;
-  visibility: hidden;
-  transition:
-    opacity 0.4s var(--ease-out),
-    visibility 0s linear 0.4s;
-}
-
-.board-header__exec-mode-hint.is-visible {
-  opacity: 1;
-  visibility: visible;
-  transition:
-    opacity 0.4s var(--ease-out),
-    visibility 0s linear 0s;
-}
-
-.board-header__exec-mode-hint[hidden] {
-  display: none;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .board-header__exec-mode-hint,
-  .board-header__exec-mode-hint.is-visible {
-    transition: none;
-  }
-}
-
 .board-header__concurrency {
   display: inline-flex;
   align-items: center;
@@ -711,6 +578,8 @@
   border-radius: var(--radius-sm);
 }
 
+/* Hands-off: autonomy is a checkbox now, not a stop on a segmented control. */
+.board-header__hands-off,
 .board-header__skip-per-task-tests {
   display: inline-flex;
   align-items: center;
@@ -724,6 +593,7 @@
   user-select: none;
 }
 
+.board-header__hands-off-input,
 .board-header__skip-per-task-tests-input {
   margin: 0;
   accent-color: var(--mn-accent);
@@ -734,8 +604,13 @@
   opacity: 0.55;
 }
 
+.board-header__hands-off-label,
 .board-header__skip-per-task-tests-label {
   white-space: nowrap;
+}
+
+.board-header__hands-off:has(.board-header__hands-off-input:checked) {
+  color: var(--mn-accent);
 }
 
 /* Long spelling by default; the narrow container query swaps in the short one. */
@@ -2134,19 +2009,6 @@
   .board-header__controls {
     justify-content: flex-start;
     column-gap: 8px;
-  }
-
-  .board-header__exec-mode,
-  .board-header__exec-mode-segments {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-
-  .board-header__exec-mode-segment {
-    flex: 1 1 auto;
-    min-height: var(--touch-min);
-    padding: 0 10px;
-    font-size: 0.75rem;
   }
 
   /* Touch-sized, but never stretched: a 300px-wide "Start" reads as a banner. */

--- a/src/styles/orchestrate-board.css
+++ b/src/styles/orchestrate-board.css
@@ -2864,6 +2864,36 @@
   border-bottom-right-radius: 0;
 }
 
+/* The review link shares the split-button row, so it must be allowed to wrap. */
+.board-finish-dashboard__commit-split--workspace {
+  flex-wrap: wrap;
+}
+
+/* Workspace-commit path only: review the live diff before committing it. */
+.board-finish-dashboard__review-link {
+  align-self: center;
+  margin-left: 10px;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  font-size: 13px;
+  color: var(--mn-accent, var(--accent));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.board-finish-dashboard__review-link:hover {
+  color: var(--mn-accent-strong, var(--accent));
+}
+
+.board-finish-dashboard__review-link:focus-visible {
+  outline: 2px solid var(--mn-focus, var(--accent));
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
 .board-finish-dashboard__commit-caret {
   min-width: 36px;
   padding: 0 8px;
@@ -2976,6 +3006,11 @@
 
   .board-finish-dashboard__commit-primary {
     flex: 1;
+  }
+
+  .board-finish-dashboard__review-link {
+    margin-left: 0;
+    margin-top: 8px;
   }
 }
 

--- a/src/styles/orchestrate-board.css
+++ b/src/styles/orchestrate-board.css
@@ -1016,7 +1016,238 @@
   flex-direction: column;
   gap: 8px;
   padding: 8px;
+  /* An empty lane still has to be a drop target. */
+  min-height: 44px;
 }
+
+/* ---------- run-settings help lightbox ---------- */
+
+.board-header__run-help {
+  flex: 0 0 auto;
+}
+
+.board-run-help-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  background: var(--mn-overlay);
+}
+
+.board-run-help-overlay.hidden {
+  display: none;
+}
+
+.board-run-help-lightbox {
+  display: flex;
+  flex-direction: column;
+  width: min(40rem, calc(100vw - 1.5rem));
+  max-height: min(88dvh, calc(100dvh - 1.5rem));
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-md);
+  background: var(--mn-bg);
+  color: var(--mn-fg);
+  outline: none;
+  animation: minnow-panel-reveal var(--duration-normal) var(--ease-out);
+  /* The dialog is its own container: board surfaces live inside MinnowOS windows,
+     so a viewport @media query would not track the width that matters here. */
+  container: board-run-help / inline-size;
+}
+
+.board-run-help-header {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 14px 12px 16px;
+  border-bottom: 1px solid var(--mn-border);
+}
+
+.board-run-help-header__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.board-run-help-close.icon-btn {
+  width: 32px;
+  height: 32px;
+}
+
+.board-run-help-body {
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.board-run-help-intro,
+.board-run-help-modes__intro {
+  margin: 0 0 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--mn-fg-muted, var(--text-dim));
+}
+
+.board-run-help-settings {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  margin-bottom: 20px;
+}
+
+.board-run-help-setting {
+  padding: 12px;
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--mn-surface, transparent);
+}
+
+.board-run-help-setting__title {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.board-run-help-setting__body {
+  margin: 0 0 8px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.board-run-help-setting__list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--mn-fg-muted, var(--text-dim));
+}
+
+.board-run-help-modes__title {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.board-run-help-mode {
+  display: grid;
+  align-items: start;
+  gap: 4px 10px;
+  grid-template-columns: auto 7rem 1fr;
+  padding: 10px 0;
+  border-top: 1px solid var(--mn-border);
+}
+
+.board-run-help-mode__icon {
+  --mn-icon-size: 16px;
+
+  margin-top: 2px;
+  color: var(--mn-accent, var(--accent));
+}
+
+.board-run-help-mode__name {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.board-run-help-mode__line {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.board-run-help-mode__line--merge {
+  margin-top: 3px;
+  color: var(--mn-fg-muted, var(--text-dim));
+}
+
+@container board-run-help (max-width: 34rem) {
+  .board-run-help-mode {
+    grid-template-columns: auto 1fr;
+  }
+
+  .board-run-help-mode__detail {
+    grid-column: 2;
+  }
+}
+
+/* ---------- bulk recovery split-button (header) ---------- */
+
+.board-header__bulk-requeue {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.board-header__bulk-requeue-primary {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.board-header__bulk-requeue-caret {
+  min-width: 24px;
+  padding: 0 6px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 0;
+}
+
+.board-header__bulk-requeue-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 5;
+  margin-top: 4px;
+  min-width: 180px;
+  padding: 4px;
+  border: 1px solid var(--mn-border);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--mn-bg, var(--bg));
+  box-shadow: var(--mn-shadow, 0 4px 16px oklch(0.1 0.02 250 / 0.12));
+}
+
+.board-header__bulk-requeue-menuitem {
+  display: block;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  text-align: left;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .board-header__bulk-requeue-menuitem:hover {
+    background: var(--mn-surface-elevated, var(--surface-elevated));
+  }
+}
+
+/* ---------- card drag between lanes (orchestrate-board-dnd.ts) ---------- */
+
+.kanban-column.is-drag-over {
+  background: var(--mn-bg-hover, rgb(255 255 255 / 4%));
+  border-radius: 6px;
+}
+
+.board-task-card--dragging {
+  opacity: 0.5;
+}
+
+.board-drop-indicator {
+  height: 2px;
+  margin: 0 4px;
+  background: var(--mn-accent, var(--accent));
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+/* No cursor override: cards are click-to-open first, draggable second, and a
+   grab cursor would hide the primary affordance. */
 
 /* Kanban task tile: scannable id + title, compact bench controls in the footer. */
 .board-task-card {

--- a/src/tools/board-tools.ts
+++ b/src/tools/board-tools.ts
@@ -25,7 +25,10 @@ import {
 import {
   requestPendingAfk,
   moveTaskStatus,
-  setBoardExecutionMode,
+  setBoardHandsOff,
+  setBoardMaxConcurrent,
+  getBoardExecutionMode,
+  isBoardAutoMode,
   startBoardAutoRun,
 } from '../state/orchestrate-board-actions.ts';
 import { emitBoardChange } from '../state/orchestrate-board-events.ts';
@@ -516,37 +519,75 @@ export function normalizeVerdict(raw: unknown): 'pass' | 'fail' | null {
   return null;
 }
 
-const BOARD_AUTONOMY_LEVELS = new Set(['manual', 'sequential', 'auto', 'afk']);
-
 export type BoardSetAutonomyArgs = {
-  level: 'manual' | 'sequential' | 'auto' | 'afk';
+  /** Max tasks running at once, 1–20. Omitted leaves the board's current value. */
+  concurrency?: number;
+  /** Fully autonomous. Turning it on always needs the user's confirmation. */
+  handsOff?: boolean;
 };
 
 export type ValidateBoardSetAutonomyResult =
   | { ok: true; args: BoardSetAutonomyArgs }
   | { ok: false; error: string };
 
-/** Validate board_set_autonomy arguments (exported for tests). */
+/**
+ * Validate board_set_autonomy arguments (exported for tests).
+ *
+ * The old four-value `level` is gone — a board is described by how many tasks run at
+ * once plus whether it may interrupt the user. Legacy `level` strings are still
+ * accepted and folded onto the two fields so in-flight planner turns do not break.
+ */
 export function validateBoardSetAutonomyArgs(
   args: Record<string, unknown>,
 ): ValidateBoardSetAutonomyResult {
-  const raw =
+  const out: BoardSetAutonomyArgs = {};
+
+  const legacyRaw =
     typeof args.level === 'string'
       ? args.level
       : typeof args.mode === 'string'
         ? args.mode
         : '';
-  const level = raw.trim().toLowerCase();
-  if (!level) {
-    return { ok: false, error: 'Error: board_set_autonomy requires "level"' };
+  const legacy = legacyRaw.trim().toLowerCase();
+  if (legacy) {
+    if (legacy === 'afk') out.handsOff = true;
+    else if (legacy === 'sequential' || legacy === 'manual') out.concurrency = 1;
+    else if (legacy !== 'auto') {
+      return {
+        ok: false,
+        error:
+          'Error: board_set_autonomy takes "concurrency" (1-20) and/or "handsOff" (boolean)',
+      };
+    }
   }
-  if (!BOARD_AUTONOMY_LEVELS.has(level)) {
+
+  const rawConcurrency = args.concurrency ?? args.max_concurrent_tasks;
+  if (rawConcurrency != null) {
+    const value = Number(rawConcurrency);
+    if (!Number.isFinite(value) || value < 1 || value > 20) {
+      return {
+        ok: false,
+        error: 'Error: board_set_autonomy "concurrency" must be a number between 1 and 20',
+      };
+    }
+    out.concurrency = Math.floor(value);
+  }
+
+  const rawHandsOff = args.handsOff ?? args.hands_off;
+  if (rawHandsOff != null) {
+    if (typeof rawHandsOff !== 'boolean') {
+      return { ok: false, error: 'Error: board_set_autonomy "handsOff" must be a boolean' };
+    }
+    out.handsOff = rawHandsOff;
+  }
+
+  if (out.concurrency == null && out.handsOff == null) {
     return {
       ok: false,
-      error: 'Error: board_set_autonomy requires level manual, sequential, auto, or afk',
+      error: 'Error: board_set_autonomy requires "concurrency" and/or "handsOff"',
     };
   }
-  return { ok: true, args: { level: level as BoardSetAutonomyArgs['level'] } };
+  return { ok: true, args: out };
 }
 
 /** Execute board_* tools; returns JSON string or Error: prefix. */
@@ -704,30 +745,36 @@ async function executeBoardSetAutonomy(
     return 'Error: orchestrate board is not initialized';
   }
 
-  const { level } = validated.args;
-  if (level === 'manual') {
-    setBoardExecutionMode(group, 'manual', chat);
-  } else if (level === 'afk') {
-    requestPendingAfk(group, chat);
-    return JSON.stringify({
-      level,
-      executionMode: board.executionMode ?? 'manual',
-      autoRunning: board.autoRunning === true,
-      pendingAfk: true,
-      message:
-        'AFK is pending user confirmation and will not activate until the user accepts on the board.',
-    });
-  } else {
-    setBoardExecutionMode(group, level, chat);
-    startBoardAutoRun(group, chat);
+  const { concurrency, handsOff } = validated.args;
+
+  if (concurrency != null) {
+    setBoardMaxConcurrent(group, concurrency, chat);
   }
+
+  // Hands-off can only be *requested* — the user confirms it on the board.
+  let pendingHandsOff = false;
+  if (handsOff === true && board.handsOff !== true) {
+    requestPendingAfk(group, chat);
+    pendingHandsOff = true;
+  } else if (handsOff === false) {
+    setBoardHandsOff(group, false, chat);
+  }
+
+  if (!pendingHandsOff) startBoardAutoRun(group, chat);
 
   const current = group.orchestrateBoard!;
   return JSON.stringify({
-    level,
-    executionMode: current.executionMode ?? 'manual',
+    concurrency: current.maxConcurrentTasks ?? null,
+    handsOff: current.handsOff === true,
+    executionMode: getBoardExecutionMode(current),
     autoRunning: current.autoRunning === true,
-    pendingAfk: current.pendingAfk === true,
+    pendingHandsOff,
+    ...(pendingHandsOff
+      ? {
+          message:
+            'Hands-off is pending user confirmation and will not activate until the user accepts on the board.',
+        }
+      : {}),
   });
 }
 
@@ -773,10 +820,10 @@ async function executeDelegateTasks(
   if (!board) {
     return 'Error: orchestrate board is not initialized';
   }
-  if (board.executionMode !== 'auto') {
+  if (!isBoardAutoMode(group)) {
     return (
-      'Error: delegate_tasks requires Auto-pilot (executionMode auto). ' +
-      'Enable Auto-pilot on the board or call board_get_state to confirm mode.'
+      'Error: delegate_tasks requires an initialized orchestrate board. ' +
+      'Call board_get_state to confirm the board exists.'
     );
   }
 

--- a/src/tools/board-tools.ts
+++ b/src/tools/board-tools.ts
@@ -18,8 +18,10 @@ import {
   isTaskReadyForAuto,
 } from '../state/orchestrate-board-store.ts';
 import {
+  appendBoardTasks,
   getBoardStateForPlanner,
   initBoard,
+  nextBoardWaveId,
   updateTask,
 } from '../state/orchestrate-board-store.ts';
 import {
@@ -33,7 +35,7 @@ import {
 } from '../state/orchestrate-board-actions.ts';
 import { emitBoardChange } from '../state/orchestrate-board-events.ts';
 import { findChatById, scheduleSaveSessions } from '../state/sessions.ts';
-import type { BoardCategory, BoardTask, BoardTaskStatus, Chat, OrchestrateBoardState } from '../types.ts';
+import type { BoardCategory, BoardRunInstructions, BoardTask, BoardTaskStatus, Chat, OrchestrateBoardState } from '../types.ts';
 
 export interface BoardExecutorContext {
   chatId: string;
@@ -364,6 +366,77 @@ export function validateBoardInitArgs(
   };
 }
 
+export type BoardAddTasksArgs = {
+  tasks: BoardInitArgs['tasks'];
+  wave: number | string;
+};
+
+export type ValidateBoardAddTasksResult =
+  | { ok: true; args: BoardAddTasksArgs }
+  | { ok: false; error: string };
+
+/**
+ * Validate board_add_tasks against the **merged** task set.
+ *
+ * Validating only the new tasks would miss every interesting failure: a new task
+ * duplicating an existing id, depending on a task that does not exist, or closing
+ * a cycle through existing tasks. So the existing board is folded into a synthetic
+ * board_init payload and run through {@link validateBoardInitArgs}, then the
+ * appended tail is sliced back off.
+ */
+export function validateBoardAddTasksArgs(
+  args: Record<string, unknown>,
+  board: OrchestrateBoardState | null | undefined,
+): ValidateBoardAddTasksResult {
+  if (!board) return { ok: false, error: 'Error: orchestrate board is not initialized' };
+
+  const rawTasks = coerceToolArrayField(args.tasks);
+  if (!rawTasks || !rawTasks.length) {
+    return { ok: false, error: 'Error: board_add_tasks requires non-empty "tasks"' };
+  }
+
+  const waveId = args.wave != null ? parseWaveId(args.wave) : nextBoardWaveId(board);
+  if (waveId === null) {
+    return { ok: false, error: 'Error: board_add_tasks "wave" must be a number or string id' };
+  }
+
+  // Every new task lands in the appended wave unless it names an existing one.
+  const knownWaves = new Set(board.waves.map((w) => String(w.id)));
+  const newTasks = rawTasks.map((item) => {
+    const r = (item && typeof item === 'object' ? item : {}) as Record<string, unknown>;
+    const named = r.wave != null ? parseWaveId(r.wave) : null;
+    const wave = named != null && knownWaves.has(String(named)) ? named : waveId;
+    return { ...r, wave };
+  });
+
+  const merged = validateBoardInitArgs(
+    {
+      plan_path: board.planPath || 'board',
+      waves: [...board.waves.map((w) => ({ id: w.id })), { id: waveId }].filter(
+        // The appended wave may already exist when the caller named one.
+        (w, i, all) => all.findIndex((o) => String(o.id) === String(w.id)) === i,
+      ),
+      tasks: [
+        ...board.tasks.map((t) => ({
+          id: t.id,
+          title: t.title,
+          wave: t.wave,
+          category: t.category,
+          ...(t.dependsOn?.length ? { dependsOn: t.dependsOn } : {}),
+        })),
+        ...newTasks,
+      ],
+    },
+    null,
+  );
+  if (merged.ok === false) {
+    return { ok: false, error: merged.error.replace('board_init', 'board_add_tasks') };
+  }
+
+  const appended = merged.args.tasks.slice(board.tasks.length);
+  return { ok: true, args: { tasks: appended, wave: waveId } };
+}
+
 export type BoardUpdateTaskArgs = {
   task_id: string;
   status: BoardTaskStatus;
@@ -418,7 +491,26 @@ export type BoardReportArgs = {
   summary: string;
   blockers?: string[];
   failing_tasks?: string[];
+  /** FULL_BOARD only: commands the tester ran and verified. */
+  run_instructions?: BoardRunInstructions;
 };
+
+/** Read `run_instructions` off a board_report payload; only verified strings survive. */
+function parseRunInstructions(raw: unknown): BoardRunInstructions | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const r = raw as Record<string, unknown>;
+  const pick = (key: string): string | undefined => {
+    const value = r[key];
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  };
+  const out: BoardRunInstructions = {
+    ...(pick('install') ? { install: pick('install') } : {}),
+    ...(pick('start') ? { start: pick('start') } : {}),
+    ...(pick('test') ? { test: pick('test') } : {}),
+    ...(pick('notes') ? { notes: pick('notes') } : {}),
+  };
+  return Object.keys(out).length ? out : undefined;
+}
 
 export type ValidateBoardReportResult =
   | { ok: true; args: BoardReportArgs }
@@ -489,6 +581,9 @@ export function validateBoardReportArgs(
       if (!failing_tasks.includes(id)) failing_tasks.push(id);
     }
   }
+  const run_instructions = parseRunInstructions(
+    args.run_instructions ?? args.runInstructions,
+  );
   return {
     ok: true,
     args: {
@@ -497,6 +592,7 @@ export function validateBoardReportArgs(
       summary,
       ...(blockers?.length ? { blockers } : {}),
       ...(failing_tasks?.length ? { failing_tasks } : {}),
+      ...(run_instructions ? { run_instructions } : {}),
     },
   };
 }
@@ -620,6 +716,14 @@ export async function executeBoardTool(
     return executeBoardUpdateTask(plannerChat, args);
   }
 
+  if (name === 'board_add_tasks') {
+    const plannerChat = resolveOrchestratePlannerChat(options?.chatId);
+    if (!plannerChat) {
+      return 'Error: board tools require an active Orchestrate chat';
+    }
+    return executeBoardAddTasks(plannerChat, args);
+  }
+
   if (name === 'board_set_autonomy') {
     const plannerChat = resolveOrchestratePlannerChat(options?.chatId);
     if (!plannerChat) {
@@ -676,6 +780,41 @@ async function executeBoardInit(
   );
   executorContext = { chatId: chat.id, groupId: group.id };
   return JSON.stringify(board, null, 2);
+}
+
+async function executeBoardAddTasks(
+  chat: Chat,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const group = getOrCreateBoardGroup(chat);
+  const board = group.orchestrateBoard;
+  const validated = validateBoardAddTasksArgs(args, board);
+  if (validated.ok === false) return validated.error;
+
+  const appended = appendBoardTasks(
+    group,
+    validated.args.tasks.map((t) => ({
+      id: t.id,
+      title: t.title,
+      wave: t.wave,
+      category: t.category,
+      build: t.build,
+      test: t.test,
+      dependsOn: t.dependsOn,
+    })),
+    chat,
+    { waveId: validated.args.wave },
+  );
+
+  return JSON.stringify(
+    {
+      wave: validated.args.wave,
+      added: appended.map((t: BoardTask) => ({ id: t.id, title: t.title, wave: t.wave })),
+      totalTasks: group.orchestrateBoard?.tasks.length ?? 0,
+    },
+    null,
+    2,
+  );
 }
 
 async function executeBoardUpdateTask(
@@ -891,7 +1030,8 @@ async function executeBoardReport(
     return 'Error: board_report requires a chat linked to an orchestrate board';
   }
   const { group, board } = ctx;
-  const { task_id, outcome, summary, blockers, failing_tasks } = validated.args;
+  const { task_id, outcome, summary, blockers, failing_tasks, run_instructions } =
+    validated.args;
   const callerChatId = resolveActiveChatId(overrideChatId);
   const callerChat = callerChatId ? findChatById(callerChatId) : null;
 
@@ -916,6 +1056,10 @@ async function executeBoardReport(
       recordedVerdict: outcomeToTestVerdict(outcome),
       summary,
       failingTaskIds: validatedFailing,
+      // Keep a previously reported set when this report omits them.
+      ...(run_instructions ?? priorFinal?.runInstructions
+        ? { runInstructions: run_instructions ?? priorFinal?.runInstructions }
+        : {}),
     };
     board.lastUpdatedAt = Date.now();
     scheduleSaveSessions();
@@ -926,6 +1070,9 @@ async function executeBoardReport(
         outcome,
         summary,
         failingTaskIds: validatedFailing,
+        ...(board.finalTest.runInstructions
+          ? { runInstructions: board.finalTest.runInstructions }
+          : {}),
       },
       null,
       2,

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -37,6 +37,7 @@ import { normalizeModeId, type ModeId } from '../chat/modes/types';
 import { filterToolsByExpertSnapshot } from '../chat/experts/expert-tool-policy';
 import type { Chat } from '../types';
 import { getBoardGroupForChat, isBoardTaskChat } from '../state/chat-groups';
+import { deriveBoardExecutionMode } from '../state/board-execution-mode.ts';
 import type { CodeChangeStats, ToolExecutionResult } from '../types';
 import { findChatById } from '../state/sessions';
 import { normalizeCodeChangePayload } from '../usage/code-change-payload';
@@ -643,7 +644,9 @@ export function getEnabledToolDefinitionsForChat(
   const normalized = normalizeModeId(chat.modeId);
   let defs = getEnabledToolDefinitionsForMode(normalized);
   defs = filterToolsByExpertSnapshot(chat, defs);
-  const executionMode = getBoardGroupForChat(chat)?.orchestrateBoard?.executionMode;
+  const executionMode = deriveBoardExecutionMode(
+    getBoardGroupForChat(chat)?.orchestrateBoard,
+  );
   if (isBoardTaskChat(chat)) {
     defs = injectBoardMemberSubsetTools(defs);
   }

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1148,20 +1148,24 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
     id: 'board_set_autonomy',
     label: 'Board set autonomy',
     description:
-      'Set board execution autonomy (manual, sequential, auto, or afk). AFK requires explicit user confirmation before it activates.',
+      'Set board concurrency and/or request hands-off autonomy. Hands-off requires explicit user confirmation before it activates.',
     category: 'agents',
     serverRequired: false,
     definition: toolSchema(
       'board_set_autonomy',
-      'Change orchestrate board autonomy level. manual stops auto-run; sequential/auto start delegation. afk requests hands-off mode but needs user confirmation on the board before it takes effect.',
+      'Change how the orchestrate board runs: concurrency is how many tasks run at once; handsOff requests fully autonomous execution but needs user confirmation on the board before it takes effect. Pass either or both.',
       {
-        level: {
-          type: 'string',
-          enum: ['manual', 'sequential', 'auto', 'afk'],
-          description: 'Target autonomy level',
+        concurrency: {
+          type: 'number',
+          description: 'Max tasks running at once (1-20). 1 runs them one at a time.',
+        },
+        handsOff: {
+          type: 'boolean',
+          description:
+            'Request fully hands-off execution (never prompt the user). Requires user confirmation.',
         },
       },
-      ['level'],
+      [],
     ),
   },
   {

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1117,6 +1117,49 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
     ),
   },
   {
+    id: 'board_add_tasks',
+    label: 'Board add tasks',
+    description:
+      'Append follow-up tasks to a running board in a new wave (board_init replaces the whole board).',
+    category: 'agents',
+    serverRequired: false,
+    definition: toolSchema(
+      'board_add_tasks',
+      'Append tasks to the existing board in a new wave. Use this for follow-up work — board_init would discard the board. Tasks may depend on existing task ids.',
+      {
+        tasks: {
+          type: 'array',
+          minItems: 1,
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              title: { type: 'string' },
+              category: {
+                type: 'string',
+                enum: ['build', 'fix', 'test', 'research'],
+              },
+              build: { type: 'string' },
+              test: { type: 'string' },
+              dependsOn: {
+                type: 'array',
+                description: 'Existing or new task ids this task waits on',
+                items: { type: 'string' },
+              },
+            },
+            required: ['id', 'title', 'category'],
+          },
+        },
+        wave: {
+          type: 'string',
+          description:
+            'Optional wave id. Omit to append a new wave after the highest existing one.',
+        },
+      },
+      ['tasks'],
+    ),
+  },
+  {
     id: 'board_update_task',
     label: 'Board update task',
     description: 'Update one board task status and metadata after board_init.',
@@ -1209,6 +1252,17 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
           type: 'array',
           items: { type: 'string' },
           description: 'FULL_BOARD fail only: board task ids responsible for the failure',
+        },
+        run_instructions: {
+          type: 'object',
+          description:
+            'FULL_BOARD only: commands you actually ran and verified in this project. Omit any command you did not run — the finish report presents these as verified.',
+          properties: {
+            install: { type: 'string', description: 'e.g. npm install' },
+            start: { type: 'string', description: 'e.g. npm run dev' },
+            test: { type: 'string', description: 'e.g. npm test' },
+            notes: { type: 'string', description: 'Prerequisites or caveats worth stating' },
+          },
         },
       },
       ['task_id', 'outcome', 'summary'],

--- a/src/tools/permission-gate.ts
+++ b/src/tools/permission-gate.ts
@@ -5,6 +5,7 @@
 import { getWorkspaceLabel, getWorkspacePath } from '../state/workspace';
 import { findChatById, isGoalLoopActive } from '../state/sessions';
 import { getBoardGroupForChat } from '../state/chat-groups.ts';
+import { isBoardHandsOff } from '../state/board-execution-mode.ts';
 import { logInteractionRequired } from '../state/orchestrate-board-store.ts';
 import {
   getToolSecurityMetaCached,
@@ -47,7 +48,7 @@ export function blockAfkInteractionAttempt(
   const chatId = context.chatId?.trim();
   const chat = chatId ? findChatById(chatId) : undefined;
   const group = chat ? getBoardGroupForChat(chat) : undefined;
-  if (group?.orchestrateBoard?.executionMode !== 'afk') return null;
+  if (!group || !isBoardHandsOff(group.orchestrateBoard)) return null;
   logInteractionRequired(group, kind, reason, chat?.boardTaskId?.trim());
   return {
     content: `Error: AFK execution denied user interaction (${reason}).`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -696,6 +696,7 @@ export type BoardLogEventType =
   | 'test_verdict'
   | 'merge_result'
   | 'worktree_allocated'
+  | 'worktree_released'
   | 'task_retry'
   | 'nudge'
   | 'task_error'

--- a/src/types.ts
+++ b/src/types.ts
@@ -604,8 +604,20 @@ export interface OrchestrateBoardState {
   reasoningEffort?: ReasoningEffortOption;
   /** Per-board thinking override for off/on-only models (planner + linked task chats). */
   thinkingMode?: ThinkingTriState;
-  /** Manual board vs auto-pilot delegation (default manual). */
+  /**
+   * @deprecated Replaced by {@link maxConcurrentTasks} + {@link handsOff}. Kept only
+   * so legacy sessions can hydrate and migrate; never written by new code. Read the
+   * derived value via `getBoardExecutionMode`.
+   */
   executionMode?: 'manual' | 'auto' | 'sequential' | 'afk';
+  /** Fully autonomous: never prompt the user until Stop or board finish. */
+  handsOff?: boolean;
+  /**
+   * Frozen, human-readable directory segment for this board's worktrees
+   * (`~/.minnow/worktrees/<repo>-<hash>/<worktreeSlug>/…`). Minted once from the
+   * board title so renaming the board never orphans a worktree.
+   */
+  worktreeSlug?: string;
   /** When true, skip per-task Tester; only final integration test runs verification. */
   skipPerTaskTesting?: boolean;
   /** True when the user has pressed Start in auto/sequential mode. */
@@ -626,9 +638,9 @@ export interface OrchestrateBoardState {
   systemPaused?: boolean;
   /**
    * Filesystem/process isolation for parallel tasks (MIN-275). When unset it is
-   * resolved from {@link executionMode} (sequential/manual → off, auto/afk → per-task).
+   * resolved from concurrency (1 → per-board, >1 → per-task).
    */
-  isolationMode?: 'off' | 'per-task' | 'per-wave';
+  isolationMode?: 'off' | 'per-task' | 'per-wave' | 'per-board';
   /**
    * Agent shell sandbox for this board (MIN-553). When unset, inherits Autopilot
    * default (`require`). Complementary to {@link isolationMode} (git worktrees).

--- a/src/types.ts
+++ b/src/types.ts
@@ -1293,6 +1293,7 @@ export interface SessionSummariesState {
   chats: ChatSummary[];
   groups?: ChatGroup[];
   activeBoardGroupId?: string;
+  lastBoardGroupId?: string;
   lastActiveChatIdByWorkspace?: Record<string, string>;
   lastActiveChatIdByApp?: Record<string, string>;
   codeChangeTotalsByWorkspace?: Record<string, ChatCodeChangeTotals>;
@@ -1478,6 +1479,12 @@ export interface SessionState {
   groups?: ChatGroup[];
   /** Folder whose board fills #chatArea when viewMode is board. */
   activeBoardGroupId?: string;
+  /**
+   * Board folder the user was last inside, kept after they navigate away so
+   * re-entering Orchestrator lands back on it instead of the hub.
+   * Unlike `activeBoardGroupId` this does *not* mean a board is mounted.
+   */
+  lastBoardGroupId?: string;
   /** Last selected chat per normalized workspace key ('' = unassigned bucket). */
   lastActiveChatIdByWorkspace?: Record<string, string>;
   /** Last selected chat per Minnow app id (e.g. `{ chat: '…' }` for the Chat app). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -672,6 +672,12 @@ export interface OrchestrateBoardState {
     recordedVerdict?: 'pass' | 'fail';
     failingTaskIds?: string[];
     summary?: string;
+    /**
+     * Commands the final tester **actually ran and verified**, reported via
+     * `board_report`. The finish report prints these instead of guessing; when
+     * absent it falls back to manifest detection and labels it unverified.
+     */
+    runInstructions?: BoardRunInstructions;
   };
   /** Chronological diagnostic log, capped ring buffer (oldest dropped). */
   log?: BoardLogEvent[];
@@ -681,6 +687,14 @@ export interface OrchestrateBoardState {
   provisionedSignatures?: string[];
   /** Structured per-task unresolved issues — data source for the MIN-208 finish dashboard. */
   unresolvedIssues?: UnresolvedIssue[];
+}
+
+/** Verified project commands reported by the final integration tester. */
+export interface BoardRunInstructions {
+  install?: string;
+  start?: string;
+  test?: string;
+  notes?: string;
 }
 
 export type BoardLogLevel = 'info' | 'warn' | 'error';
@@ -763,6 +777,10 @@ export interface BoardLogDetail {
   error?: string;
   summary?: string;
   failingTaskIds?: string[];
+  /** Wave a `board_add_tasks` append landed in. */
+  waveId?: string;
+  /** Task ids appended to a running board. */
+  taskIds?: string[];
   /** Durable correlation id for one phase invocation. */
   phaseId?: string;
   phase?: BoardExecutionPhase;

--- a/src/ui/board-timeline-drawer.ts
+++ b/src/ui/board-timeline-drawer.ts
@@ -17,6 +17,7 @@ const MILESTONE_TYPES = new Set<BoardLogEventType>([
   'test_verdict',
   'merge_result',
   'worktree_allocated',
+  'worktree_released',
   'task_retry',
   'task_error',
   'final_test_started',

--- a/src/ui/main-column-overlay.ts
+++ b/src/ui/main-column-overlay.ts
@@ -213,7 +213,9 @@ export async function showCodeStageSection(section: CodeSectionId): Promise<void
   }
   if (section === 'orchestrate') {
     const hub = await import('./orchestrate-hub');
-    hub.renderOrchestrateHub();
+    // Resume the board the user was last inside; the hub is the fallback, not
+    // the unconditional destination.
+    hub.openOrchestrateLanding();
     return;
   }
   if (section === 'map') {

--- a/src/ui/orchestrate-board-dnd.ts
+++ b/src/ui/orchestrate-board-dnd.ts
@@ -1,0 +1,243 @@
+/**
+ * Drag-and-drop for orchestrate kanban cards (Phase 3.1).
+ *
+ * Columns are derived from task status, so a drop is a status transition — the
+ * same transitions the deleted per-card status buttons used to fire. The drag
+ * idiom (module-level active-drag descriptor, because `dragover` cannot read
+ * `getData`) is lifted from `issues-page.ts`, and matches `sidebar-chat-dnd.ts`
+ * and `file-tree-dnd.ts`.
+ */
+
+import { hasPipelineHold } from '../state/orchestrate-pipeline-holds.ts';
+import {
+  moveTaskStatus,
+  requeueBoardTask,
+  startTask,
+  startTaskTesting,
+} from '../state/orchestrate-board-actions.ts';
+import { isChatStreaming } from '../chat/streaming-state.ts';
+import { appConfirm } from './app-dialog.ts';
+import type { BoardTask, Chat, ChatGroup } from '../types.ts';
+
+const TASK_DRAG_MIME = 'application/x-minnow-board-task-id';
+
+/** `dragover` cannot read `getData`, so the payload lives here for the drag's life. */
+let activeTaskDrag: { taskId: string; fromColumn: string } | null = null;
+
+/** Kanban column ids that accept a drop (mirrors `getKanbanColumnDefs`). */
+export type KanbanColumnId = 'planned' | 'in_progress' | 'testing' | 'complete';
+
+function asColumnId(value: string | null | undefined): KanbanColumnId | null {
+  return value === 'planned' || value === 'in_progress' || value === 'testing' || value === 'complete'
+    ? value
+    : null;
+}
+
+/**
+ * A `merging` task is mid-git-merge with a fixer possibly attached; yanking its
+ * status out from under that corrupts the merge queue. Reconcile merge is the
+ * supported way out.
+ */
+export function isBoardTaskDraggable(task: BoardTask): boolean {
+  return task.status !== 'merging';
+}
+
+/** True when moving this task would interrupt work that is currently running. */
+export function boardTaskDragDisrupts(task: BoardTask, group: ChatGroup): boolean {
+  const streaming = [task.chatId, task.testChatId, task.fixerChatId].some((id) => {
+    const trimmed = id?.trim();
+    return Boolean(trimmed && isChatStreaming(trimmed));
+  });
+  if (streaming) return true;
+  return hasPipelineHold(group.orchestrateBoard, task.id);
+}
+
+/**
+ * What a drop into `column` means for a task currently in `task.status`.
+ * `null` when the drop is a no-op (same lane) or not a supported transition.
+ */
+export function resolveBoardDropAction(
+  task: BoardTask,
+  column: KanbanColumnId,
+): 'start' | 'test' | 'complete' | 'requeue' | 'plan' | null {
+  const status = task.status;
+  switch (column) {
+    case 'in_progress':
+      return status === 'in_progress' || status === 'merging' ? null : 'start';
+    case 'testing':
+      return status === 'testing' ? null : 'test';
+    case 'complete':
+      return status === 'complete' ? null : 'complete';
+    case 'planned':
+      if (status === 'planned') return null;
+      // Coming back from a terminal lane is a real requeue: attempt counters and
+      // quarantine payload have to clear or the task re-fails immediately.
+      if (status === 'complete' || status === 'failed' || status === 'quarantined') {
+        return 'requeue';
+      }
+      return 'plan';
+    default:
+      return null;
+  }
+}
+
+function describeDropAction(action: NonNullable<ReturnType<typeof resolveBoardDropAction>>): string {
+  if (action === 'start') return 'start it';
+  if (action === 'test') return 'move it to testing';
+  if (action === 'complete') return 'mark it complete';
+  if (action === 'requeue') return 'requeue it';
+  return 'move it back to planned';
+}
+
+/**
+ * Apply a column drop. Shared by drag-and-drop and the keyboard bindings so both
+ * routes take exactly the same path (including the disruption confirm).
+ */
+export async function applyBoardTaskDrop(
+  group: ChatGroup,
+  taskId: string,
+  column: KanbanColumnId,
+  plannerChat: Chat,
+): Promise<boolean> {
+  const board = group.orchestrateBoard;
+  const task = board?.tasks.find((t) => t.id === taskId);
+  if (!board || !task || !isBoardTaskDraggable(task)) return false;
+
+  const action = resolveBoardDropAction(task, column);
+  if (!action) return false;
+
+  if (boardTaskDragDisrupts(task, group)) {
+    const ok = await appConfirm(
+      `${task.id} is running. Moving it will stop the run and ${describeDropAction(action)}.`,
+      { title: 'Move running task?', confirmLabel: 'Move it', danger: true },
+    );
+    if (!ok) return false;
+  }
+
+  switch (action) {
+    case 'start':
+      await startTask(group, taskId, plannerChat);
+      return true;
+    case 'test':
+      // startTaskTesting refuses anything not already in `testing`.
+      moveTaskStatus(group, taskId, 'testing', plannerChat);
+      await startTaskTesting(group, taskId, plannerChat);
+      return true;
+    case 'complete':
+      moveTaskStatus(group, taskId, 'complete', plannerChat);
+      return true;
+    case 'requeue':
+      await requeueBoardTask(group, taskId, plannerChat);
+      return true;
+    case 'plan':
+      moveTaskStatus(group, taskId, 'planned', plannerChat);
+      return true;
+    default:
+      return false;
+  }
+}
+
+function dropIndexFromY(cards: Element[], clientY: number): number {
+  for (let i = 0; i < cards.length; i += 1) {
+    const rect = cards[i].getBoundingClientRect();
+    if (clientY < rect.top + rect.height / 2) return i;
+  }
+  return cards.length;
+}
+
+function placeDropIndicator(host: HTMLElement, clientY: number): void {
+  host.querySelector('.board-drop-indicator')?.remove();
+  const cards = [...host.querySelectorAll('.board-task-card')];
+  const indicator = document.createElement('div');
+  indicator.className = 'board-drop-indicator';
+  indicator.setAttribute('aria-hidden', 'true');
+  const index = dropIndexFromY(cards, clientY);
+  if (index >= cards.length) host.appendChild(indicator);
+  else host.insertBefore(indicator, cards[index]);
+}
+
+function asElement(value: EventTarget | null): Element | null {
+  if (!value || typeof value !== 'object') return null;
+  return typeof (value as { closest?: unknown }).closest === 'function'
+    ? (value as Element)
+    : null;
+}
+
+/** Make one task card draggable between lanes. */
+export function bindBoardCardDrag(card: HTMLElement, task: BoardTask): void {
+  // Set the attribute, not just the IDL property: the attribute is what the
+  // rendered DOM (and anything inspecting it) actually reports.
+  if (!isBoardTaskDraggable(task)) {
+    card.setAttribute('draggable', 'false');
+    return;
+  }
+  card.setAttribute('draggable', 'true');
+  card.addEventListener('dragstart', (event) => {
+    const column = card.closest('.kanban-column');
+    activeTaskDrag = {
+      taskId: task.id,
+      fromColumn: column?.getAttribute('data-kanban-column') ?? '',
+    };
+    card.classList.add('board-task-card--dragging');
+    const transfer = event.dataTransfer;
+    if (!transfer) return;
+    transfer.setData(TASK_DRAG_MIME, task.id);
+    transfer.setData('text/plain', task.id);
+    transfer.effectAllowed = 'move';
+  });
+  card.addEventListener('dragend', () => {
+    activeTaskDrag = null;
+    card.classList.remove('board-task-card--dragging');
+  });
+}
+
+/** Accept card drops on one kanban column and apply the status transition. */
+export function bindBoardColumnDrop(
+  columnEl: HTMLElement,
+  columnId: string,
+  group: ChatGroup,
+  plannerChat: Chat,
+  onApplied: () => void,
+): void {
+  const target = asColumnId(columnId);
+  if (!target) return;
+  const list = columnEl.querySelector('.kanban-column__list') ?? columnEl;
+
+  const clearHighlight = (): void => {
+    columnEl.classList.remove('is-drag-over');
+    list.querySelector('.board-drop-indicator')?.remove();
+  };
+
+  columnEl.addEventListener('dragover', (event) => {
+    const drag = activeTaskDrag;
+    if (!drag || drag.fromColumn === columnId) return;
+    const task = group.orchestrateBoard?.tasks.find((t) => t.id === drag.taskId);
+    if (!task || !resolveBoardDropAction(task, target)) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+    columnEl.classList.add('is-drag-over');
+    placeDropIndicator(list as HTMLElement, event.clientY);
+  });
+
+  columnEl.addEventListener('dragleave', (event) => {
+    const related = asElement(event.relatedTarget as EventTarget | null);
+    if (related && columnEl.contains(related)) return;
+    clearHighlight();
+  });
+
+  columnEl.addEventListener('drop', (event) => {
+    const drag = activeTaskDrag;
+    if (!drag) return;
+    event.preventDefault();
+    clearHighlight();
+    activeTaskDrag = null;
+    void applyBoardTaskDrop(group, drag.taskId, target, plannerChat).then((applied) => {
+      if (applied) onApplied();
+    });
+  });
+}
+
+/** Test-only: clear the module-level drag descriptor between cases. */
+export function resetBoardDragStateForTests(): void {
+  activeTaskDrag = null;
+}

--- a/src/ui/orchestrate-board-keyboard.ts
+++ b/src/ui/orchestrate-board-keyboard.ts
@@ -1,6 +1,20 @@
 /**
  * Keyboard grid navigation for orchestrate kanban task cards.
+ *
+ * Arrows move focus between cards; Ctrl/Cmd+Arrow moves the *card* between lanes,
+ * so every drag-and-drop transition (orchestrate-board-dnd.ts) has a keyboard
+ * equivalent rather than being mouse-only.
  */
+
+import { applyBoardTaskDrop, type KanbanColumnId } from './orchestrate-board-dnd.ts';
+import type { Chat, ChatGroup } from '../types.ts';
+
+/** Board context needed to apply a lane move; omitted on read-only surfaces. */
+export interface BoardCardKeyboardContext {
+  group: ChatGroup;
+  plannerChat: Chat;
+  onApplied?: () => void;
+}
 
 const FOCUSABLE_CARD_SELECTOR =
   '.board-task-card--clickable[tabindex="0"], .board-task-card--clickable';
@@ -33,8 +47,26 @@ function focusCard(card: HTMLElement | undefined): void {
   card.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 }
 
+/** Column id of the lane `offset` columns away from this card's, if it exists. */
+function adjacentColumnId(
+  root: HTMLElement,
+  columnIndex: number,
+  offset: number,
+): KanbanColumnId | null {
+  const columns = root.querySelectorAll('.kanban-column');
+  const target = columns[columnIndex + offset];
+  const id = target?.getAttribute('data-kanban-column');
+  return id === 'planned' || id === 'in_progress' || id === 'testing' || id === 'complete'
+    ? id
+    : null;
+}
+
 /** Arrow-key navigation between kanban cards when a card holds focus. */
-export function handleBoardCardKeydown(event: KeyboardEvent, card: HTMLElement): void {
+export function handleBoardCardKeydown(
+  event: KeyboardEvent,
+  card: HTMLElement,
+  context?: BoardCardKeyboardContext,
+): void {
   const root = card.closest('.board-kanban-waves') ?? card.closest('.board-main');
   if (!root || !(root instanceof HTMLElement)) return;
 
@@ -44,6 +76,27 @@ export function handleBoardCardKeydown(event: KeyboardEvent, card: HTMLElement):
 
   const col = cardColumnIndex(card);
   const colCards = cardsInColumn(root, col);
+
+  // Ctrl/Cmd + horizontal arrow moves the card itself, matching a lane drag.
+  if (context && (event.ctrlKey || event.metaKey)) {
+    const offset = event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
+    if (offset !== 0) {
+      const taskId = card.getAttribute('data-board-task-id');
+      const targetColumn = adjacentColumnId(root, col, offset);
+      if (taskId && targetColumn) {
+        event.preventDefault();
+        void applyBoardTaskDrop(
+          context.group,
+          taskId,
+          targetColumn,
+          context.plannerChat,
+        ).then((applied) => {
+          if (applied) context.onApplied?.();
+        });
+      }
+      return;
+    }
+  }
 
   if (event.key === 'ArrowDown') {
     const colIndex = colCards.indexOf(card);

--- a/src/ui/orchestrate-board.ts
+++ b/src/ui/orchestrate-board.ts
@@ -62,7 +62,6 @@ import {
   continueBoardTask,
   countRunningTaskChats,
   recoverMergingBoardTask,
-  getBoardExecutionMode,
   isBoardRunning,
   isBoardSkipPerTaskTestingLocked,
   isTaskChatActive,
@@ -73,7 +72,7 @@ import {
   requeueBoardTask,
   resolveEffectiveMaxConcurrent,
   restartBoardTask,
-  setBoardExecutionMode,
+  setBoardHandsOff,
   setBoardIsolationMode,
   setBoardSkipPerTaskTesting,
   setBoardMaxConcurrent,
@@ -600,7 +599,7 @@ export function buildKanbanRefreshKey(
   const running = countRunningTaskChats(board);
   const parts: string[] = [
     `run:${running}/${cap}`,
-    `mode:${getBoardExecutionMode(board)}`,
+    `handsOff:${board.handsOff ? 1 : 0}`,
     `skip:${board.skipPerTaskTesting ? 1 : 0}`,
     `stream:${isChatStreaming(plannerChat.id) ? 1 : 0}`,
   ];
@@ -992,43 +991,8 @@ function createBoardHeaderIconButton(
   return btn;
 }
 
-/** Autonomy stops (least → most autonomous). */
-const BOARD_EXECUTION_MODES = ['manual', 'sequential', 'auto', 'afk'] as const;
-
-const BOARD_EXECUTION_MODE_META: ReadonlyArray<{
-  id: (typeof BOARD_EXECUTION_MODES)[number];
-  label: string;
-  title: string;
-}> = [
-  {
-    id: 'manual',
-    label: 'Manual',
-    title: 'You start each task from the board',
-  },
-  {
-    id: 'sequential',
-    label: 'Sequential',
-    title: 'Orchestrator runs one task at a time',
-  },
-  {
-    id: 'auto',
-    label: 'Auto',
-    title: 'Orchestrator runs tasks concurrently',
-  },
-  {
-    id: 'afk',
-    label: 'AFK',
-    title: 'Fully autonomous until Stop or the board finishes',
-  },
-] as const;
-
-function boardExecutionModeToIndex(mode: string): number {
-  const idx = BOARD_EXECUTION_MODES.indexOf(mode as (typeof BOARD_EXECUTION_MODES)[number]);
-  return idx >= 0 ? idx : 0;
-}
-
-const BOARD_AFK_CONFIRM_MESSAGE =
-  'Enable AFK mode? The orchestrator will run fully hands-off and will not prompt you until you press Stop or the board finishes.';
+const BOARD_HANDS_OFF_CONFIRM_MESSAGE =
+  'Enable hands-off mode? The orchestrator will run fully autonomously and will not prompt you until you press Stop or the board finishes.';
 
 /**
  * Blur a focused header control so native `<select>` menus (isolation mode, etc.)
@@ -1050,160 +1014,20 @@ function releaseBoardHeaderFocus(): void {
   }
 }
 
-/** User-selected execution mode — AFK goes through the shared confirm + activate path. */
-async function selectBoardExecutionModeFromUi(
+/** User toggled hands-off — enabling always goes through the shared confirm path. */
+async function selectBoardHandsOffFromUi(
   group: ChatGroup,
-  mode: (typeof BOARD_EXECUTION_MODES)[number],
+  on: boolean,
   plannerChat: Chat,
-): Promise<void> {
-  if (mode === 'afk') {
-    if (!await appConfirm(BOARD_AFK_CONFIRM_MESSAGE)) return;
-    activateAfk(group, plannerChat);
-    return;
+): Promise<boolean> {
+  if (!on) {
+    setBoardHandsOff(group, false, plannerChat);
+    return false;
   }
-  setBoardExecutionMode(group, mode, plannerChat);
-}
-
-const BOARD_AFK_HINT_VISIBLE_MS = 2500;
-/** Must match `.board-header__exec-mode-hint` opacity transition duration. */
-const BOARD_AFK_HINT_FADE_MS = 400;
-
-let boardAfkHintDismissTimer: ReturnType<typeof setTimeout> | null = null;
-let boardAfkHintFadeTimer: ReturnType<typeof setTimeout> | null = null;
-let lastSyncedExecMode: string | null = null;
-let boardAfkHintShownForSession = false;
-
-function clearBoardAfkHintTimers(): void {
-  if (boardAfkHintDismissTimer !== null) {
-    clearTimeout(boardAfkHintDismissTimer);
-    boardAfkHintDismissTimer = null;
-  }
-  if (boardAfkHintFadeTimer !== null) {
-    clearTimeout(boardAfkHintFadeTimer);
-    boardAfkHintFadeTimer = null;
-  }
-}
-
-function hideBoardAfkHint(hint: HTMLElement, instant = true): void {
-  clearBoardAfkHintTimers();
-  hint.classList.remove('is-visible');
-  if (instant) {
-    hint.hidden = true;
-    hint.setAttribute('aria-hidden', 'true');
-  }
-}
-
-function finishBoardAfkHintFade(hint: HTMLElement): void {
-  boardAfkHintFadeTimer = null;
-  hint.hidden = true;
-  hint.setAttribute('aria-hidden', 'true');
-}
-
-/** Fade out, then remove from layout once the opacity transition completes. */
-function dismissBoardAfkHint(hint: HTMLElement): void {
-  if (boardAfkHintFadeTimer !== null) return;
-  hint.classList.remove('is-visible');
-
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (reducedMotion) {
-    finishBoardAfkHintFade(hint);
-    return;
-  }
-
-  const onTransitionEnd = (event: TransitionEvent): void => {
-    if (event.target !== hint || event.propertyName !== 'opacity') return;
-    hint.removeEventListener('transitionend', onTransitionEnd);
-    finishBoardAfkHintFade(hint);
-  };
-  hint.addEventListener('transitionend', onTransitionEnd);
-  boardAfkHintFadeTimer = setTimeout(() => {
-    hint.removeEventListener('transitionend', onTransitionEnd);
-    finishBoardAfkHintFade(hint);
-  }, BOARD_AFK_HINT_FADE_MS + 80);
-}
-
-/** Brief AFK callout: visible ~2.5s, then fades out without shifting toolbar layout. */
-function showBoardAfkHint(hint: HTMLElement): void {
-  clearBoardAfkHintTimers();
-  hint.hidden = false;
-  hint.setAttribute('aria-hidden', 'false');
-  hint.classList.remove('is-visible');
-  // Two frames so the browser paints opacity 0 before transitioning to 1.
-  const revealHint = (): void => {
-    hint.classList.add('is-visible');
-  };
-  if (typeof requestAnimationFrame === 'function') {
-    requestAnimationFrame(() => requestAnimationFrame(revealHint));
-  } else {
-    setTimeout(revealHint, 0);
-  }
-
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const visibleMs = reducedMotion ? 1200 : BOARD_AFK_HINT_VISIBLE_MS;
-
-  boardAfkHintDismissTimer = setTimeout(() => {
-    boardAfkHintDismissTimer = null;
-    dismissBoardAfkHint(hint);
-  }, visibleMs);
-}
-
-function syncBoardExecModeUi(root: ParentNode, currentMode: string): void {
-  const idx = boardExecutionModeToIndex(currentMode);
-  const segments = root.querySelectorAll<HTMLButtonElement>(
-    '.board-header__exec-mode-segment',
-  );
-  segments.forEach((btn, i) => {
-    btn.setAttribute('aria-checked', i === idx ? 'true' : 'false');
-  });
-  const hint = root.querySelector('.board-header__exec-mode-hint') as HTMLElement | null;
-  if (!hint) return;
-
-  if (currentMode !== 'afk') {
-    hideBoardAfkHint(hint);
-    lastSyncedExecMode = currentMode;
-    boardAfkHintShownForSession = false;
-    return;
-  }
-
-  const enteredAfk = lastSyncedExecMode !== 'afk';
-  lastSyncedExecMode = 'afk';
-  if (enteredAfk || !boardAfkHintShownForSession) {
-    boardAfkHintShownForSession = true;
-    showBoardAfkHint(hint);
-    if (enteredAfk) releaseBoardHeaderFocus();
-  }
-}
-
-function onBoardExecModeSegmentKeydown(
-  event: KeyboardEvent,
-  modeId: string,
-  group: ChatGroup,
-  plannerChat: Chat,
-): void {
-  const segments = BOARD_EXECUTION_MODES;
-  const currentIndex = segments.indexOf(modeId as (typeof BOARD_EXECUTION_MODES)[number]);
-  if (currentIndex < 0) return;
-
-  let nextIndex = currentIndex;
-  if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-    nextIndex = Math.min(currentIndex + 1, segments.length - 1);
-    event.preventDefault();
-  } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
-    nextIndex = Math.max(currentIndex - 1, 0);
-    event.preventDefault();
-  } else {
-    return;
-  }
-
-  const nextMode = segments[nextIndex] ?? 'manual';
-  void selectBoardExecutionModeFromUi(group, nextMode, plannerChat);
-  refreshActiveBoardIfMounted();
+  if (!(await appConfirm(BOARD_HANDS_OFF_CONFIRM_MESSAGE))) return false;
+  activateAfk(group, plannerChat);
   releaseBoardHeaderFocus();
-  const root = document.querySelector('.board-root');
-  const nextBtn = root?.querySelector<HTMLButtonElement>(
-    `.board-header__exec-mode-segment[data-exec-mode="${nextMode}"]`,
-  );
-  nextBtn?.focus();
+  return true;
 }
 
 function wireBoardHeaderControls(
@@ -1214,9 +1038,6 @@ function wireBoardHeaderControls(
   plannerChat: Chat,
 ): void {
   controls.replaceChildren();
-  clearBoardAfkHintTimers();
-  lastSyncedExecMode = null;
-  boardAfkHintShownForSession = false;
 
   void wireBoardHeaderModelSelect(controls, group, board, plannerChat, () => {
     refreshActiveBoardIfMounted();
@@ -1224,53 +1045,6 @@ function wireBoardHeaderControls(
   wireBoardHeaderReasoning(controls, group, board, plannerChat, () => {
     refreshActiveBoardIfMounted();
   });
-  // Execution mode segments (Manual → Sequential → Auto → AFK)
-  const currentMode = getBoardExecutionMode(board);
-  const modeWrapper = document.createElement('div');
-  modeWrapper.className = 'board-header__exec-mode';
-
-  const modeGroup = document.createElement('div');
-  modeGroup.className = 'board-header__exec-mode-segments';
-  modeGroup.dataset.boardAction = 'auto-pilot';
-  modeGroup.setAttribute('role', 'radiogroup');
-  modeGroup.setAttribute('aria-label', 'Execution autonomy');
-
-  for (const meta of BOARD_EXECUTION_MODE_META) {
-    const segment = document.createElement('button');
-    segment.type = 'button';
-    segment.className = 'board-header__exec-mode-segment';
-    segment.dataset.execMode = meta.id;
-    segment.setAttribute('role', 'radio');
-    segment.setAttribute(
-      'aria-checked',
-      meta.id === currentMode ? 'true' : 'false',
-    );
-    segment.textContent = meta.label;
-    segment.title = meta.title;
-
-    segment.addEventListener('click', () => {
-      void selectBoardExecutionModeFromUi(group, meta.id, plannerChat);
-      refreshActiveBoardIfMounted();
-      releaseBoardHeaderFocus();
-    });
-    segment.addEventListener('keydown', (event) => {
-      onBoardExecModeSegmentKeydown(event, meta.id, group, plannerChat);
-    });
-
-    modeGroup.appendChild(segment);
-  }
-
-  const afkHint = document.createElement('p');
-  afkHint.className = 'board-header__exec-mode-hint';
-  afkHint.setAttribute('role', 'status');
-  afkHint.textContent =
-    'Hands-off. Press Start; the orchestrator will not prompt you until Stop or the board finishes.';
-  afkHint.hidden = true;
-  afkHint.setAttribute('aria-hidden', 'true');
-
-  modeWrapper.appendChild(modeGroup);
-  modeWrapper.appendChild(afkHint);
-  controls.appendChild(modeWrapper);
 
   // Run settings cluster: concurrency, isolation, per-task testing. Grouped so
   // the strip reads as two clusters (autonomy | settings) instead of a control wall.
@@ -1279,15 +1053,16 @@ function wireBoardHeaderControls(
   settings.setAttribute('role', 'group');
   settings.setAttribute('aria-label', 'Run settings');
 
-  // Max concurrent stepper (editable in Auto and AFK modes)
+  // How many at once. Always editable — concurrency is the run model now, not a
+  // setting some other mode switches off.
   const concWrapper = document.createElement('label');
   concWrapper.className = 'board-header__concurrency';
   concWrapper.title = isOomPauseActive()
-    ? `Max concurrent tasks (throttled to ${resolveEffectiveMaxConcurrent(board)} after OOM crash)`
-    : 'Max concurrent tasks (Auto and AFK modes)';
+    ? `Tasks running at once (throttled to ${resolveEffectiveMaxConcurrent(board)} after OOM crash)`
+    : 'Tasks running at once — 1 runs them one at a time';
   const concLabel = document.createElement('span');
   concLabel.className = 'board-header__field-label';
-  concLabel.textContent = 'max';
+  concLabel.textContent = 'run';
   concWrapper.appendChild(concLabel);
   const concInput = document.createElement('input');
   concInput.type = 'number';
@@ -1297,8 +1072,7 @@ function wireBoardHeaderControls(
   concInput.value = String(
     board.maxConcurrentTasks ?? getAutopilotMetaSync().maxConcurrentTasks ?? 3,
   );
-  concInput.disabled = currentMode !== 'auto' && currentMode !== 'afk';
-  concInput.setAttribute('aria-label', 'Max concurrent tasks');
+  concInput.setAttribute('aria-label', 'Tasks running at once');
   concInput.addEventListener('change', () => {
     const val = Number(concInput.value);
     if (Number.isFinite(val)) {
@@ -1317,11 +1091,44 @@ function wireBoardHeaderControls(
   }
   settings.appendChild(concWrapper);
 
-  // Isolation mode override (Auto = global default or derive from execution mode)
+  // May it interrupt me. Available at any concurrency, including 1.
+  const handsOffWrapper = document.createElement('label');
+  handsOffWrapper.className = 'board-header__hands-off';
+  handsOffWrapper.title =
+    'Run fully autonomously — the orchestrator never prompts you until Stop or the board finishes.';
+  const handsOffInput = document.createElement('input');
+  handsOffInput.type = 'checkbox';
+  handsOffInput.className = 'board-header__hands-off-input';
+  handsOffInput.checked = board.handsOff === true;
+  handsOffInput.setAttribute('aria-label', 'Hands-off');
+  handsOffInput.addEventListener('change', () => {
+    const requested = handsOffInput.checked;
+    void selectBoardHandsOffFromUi(group, requested, plannerChat).then((applied) => {
+      // Enabling is confirm-gated; snap the box back when the user declines.
+      handsOffInput.checked = applied;
+      refreshActiveBoardIfMounted();
+    });
+  });
+  const handsOffText = document.createElement('span');
+  handsOffText.className = 'board-header__hands-off-label';
+  handsOffText.setAttribute('aria-hidden', 'true');
+  const handsOffFull = document.createElement('span');
+  handsOffFull.className = 'board-header__label-full';
+  handsOffFull.textContent = 'Hands-off';
+  const handsOffShort = document.createElement('span');
+  handsOffShort.className = 'board-header__label-short';
+  handsOffShort.textContent = 'AFK';
+  handsOffText.appendChild(handsOffFull);
+  handsOffText.appendChild(handsOffShort);
+  handsOffWrapper.appendChild(handsOffInput);
+  handsOffWrapper.appendChild(handsOffText);
+  settings.appendChild(handsOffWrapper);
+
+  // Isolation mode override (Auto = global default or derived from concurrency)
   const isoWrapper = document.createElement('label');
   isoWrapper.className = 'board-header__isolation';
   isoWrapper.title =
-    'Git worktree isolation (Auto uses Settings default or execution mode). Isolates checkouts between tasks — not OS host containment.';
+    'Git worktree isolation (Auto uses the Settings default, else derives from concurrency). Isolates checkouts between tasks — not OS host containment.';
   const isoLabel = document.createElement('span');
   isoLabel.className = 'board-header__field-label';
   isoLabel.textContent = 'isolate';
@@ -1332,6 +1139,7 @@ function wireBoardHeaderControls(
   for (const opt of [
     { value: 'auto', label: 'Auto' },
     { value: 'off', label: 'Off' },
+    { value: 'per-board', label: 'Per-board' },
     { value: 'per-task', label: 'Per-task' },
     { value: 'per-wave', label: 'Per-wave' },
   ]) {
@@ -1342,7 +1150,7 @@ function wireBoardHeaderControls(
   }
   isoSelect.value = board.isolationMode ?? 'auto';
   isoSelect.addEventListener('change', () => {
-    const val = isoSelect.value as 'auto' | 'off' | 'per-task' | 'per-wave';
+    const val = isoSelect.value as 'auto' | 'off' | 'per-board' | 'per-task' | 'per-wave';
     setBoardIsolationMode(group, val, plannerChat);
     refreshActiveBoardIfMounted();
   });
@@ -1382,25 +1190,24 @@ function wireBoardHeaderControls(
 
   controls.appendChild(settings);
 
-  // Start / Stop button (shown in sequential, auto, and afk modes)
-  if (currentMode !== 'manual') {
-    const running = isBoardRunning(group);
-    const runBtn = document.createElement('button');
-    runBtn.type = 'button';
-    runBtn.className = `board-header__run-btn${running ? ' board-header__run-btn--stop' : ''}`;
-    runBtn.setAttribute('aria-label', running ? 'Stop orchestrator' : 'Start orchestrator');
-    runBtn.title = running ? 'Stop all tasks and chats' : 'Start auto execution';
-    runBtn.textContent = running ? 'Stop' : 'Start';
-    runBtn.addEventListener('click', () => {
-      if (isBoardRunning(group)) {
-        stopBoardAutoRun(group, plannerChat);
-      } else {
-        startBoardAutoRun(group, plannerChat);
-      }
-      refreshActiveBoardIfMounted();
-    });
-    controls.appendChild(runBtn);
-  }
+  // Start / Stop. A board that has not been started is the "manual" case — there is
+  // no mode that hides this button any more.
+  const running = isBoardRunning(group);
+  const runBtn = document.createElement('button');
+  runBtn.type = 'button';
+  runBtn.className = `board-header__run-btn${running ? ' board-header__run-btn--stop' : ''}`;
+  runBtn.setAttribute('aria-label', running ? 'Stop orchestrator' : 'Start orchestrator');
+  runBtn.title = running ? 'Stop all tasks and chats' : 'Start auto execution';
+  runBtn.textContent = running ? 'Stop' : 'Start';
+  runBtn.addEventListener('click', () => {
+    if (isBoardRunning(group)) {
+      stopBoardAutoRun(group, plannerChat);
+    } else {
+      startBoardAutoRun(group, plannerChat);
+    }
+    refreshActiveBoardIfMounted();
+  });
+  controls.appendChild(runBtn);
 
   const openPlan = createBoardHeaderIconButton(
     'open-plan',
@@ -1466,7 +1273,7 @@ function wireBoardHeaderControls(
   }
 }
 
-/** Banner when the orchestrator requested AFK and awaits user confirmation. */
+/** Banner when the orchestrator requested hands-off and awaits user confirmation. */
 function buildPendingAfkBanner(
   group: ChatGroup,
   board: BoardState,
@@ -1481,13 +1288,13 @@ function buildPendingAfkBanner(
   const label = document.createElement('span');
   label.className = 'board-header__pending-afk-label';
   label.textContent =
-    'The orchestrator requested AFK mode — fully hands-off execution with no prompts until Stop or board finish.';
+    'The orchestrator requested hands-off mode — fully autonomous execution with no prompts until Stop or board finish.';
   wrap.appendChild(label);
 
   const enableBtn = document.createElement('button');
   enableBtn.type = 'button';
   enableBtn.className = 'board-btn board-btn--compact board-btn--primary';
-  enableBtn.textContent = 'Enable AFK';
+  enableBtn.textContent = 'Enable hands-off';
   enableBtn.addEventListener('click', () => {
     activateAfk(group, plannerChat);
     refreshActiveBoardIfMounted();
@@ -2961,8 +2768,6 @@ function refreshBoardDom(
     openPlanBtn.title = planTitle;
   }
 
-  const currentMode = getBoardExecutionMode(board);
-  syncBoardExecModeUi(root, currentMode);
   const concurrencyInput = root.querySelector(
     '.board-header__concurrency-input',
   ) as HTMLInputElement | null;
@@ -2970,7 +2775,13 @@ function refreshBoardDom(
     concurrencyInput.value = String(
       board.maxConcurrentTasks ?? getAutopilotMetaSync().maxConcurrentTasks ?? 3,
     );
-    concurrencyInput.disabled = currentMode !== 'auto' && currentMode !== 'afk';
+  }
+
+  const handsOffInput = root.querySelector(
+    '.board-header__hands-off-input',
+  ) as HTMLInputElement | null;
+  if (handsOffInput) {
+    handsOffInput.checked = board.handsOff === true;
   }
 
   const isolationSelect = root.querySelector(
@@ -2992,41 +2803,37 @@ function refreshBoardDom(
   syncBoardHeaderModelSelect(root, group, board, plannerChat);
   syncBoardHeaderReasoning(group, board, plannerChat);
 
-  // Sync Start/Stop button: add if needed, remove when mode switches to manual
+  // Sync Start/Stop button. It is always present now — there is no mode that hides it.
   const controls = root.querySelector('.board-header__controls') as HTMLElement | null;
   if (controls) {
     let runBtn = controls.querySelector('.board-header__run-btn') as HTMLButtonElement | null;
-    if (currentMode !== 'manual') {
-      const running = isBoardRunning(group);
-      if (!runBtn) {
-        runBtn = document.createElement('button');
-        runBtn.type = 'button';
-        // Keep build order (… settings, Start, Timeline, plan): anchor on the
-        // first trailing action that is a direct child of the controls row.
-        const anchor =
-          controls.querySelector(':scope > .board-timeline-btn') ??
-          controls.querySelector(':scope > [data-board-action="open-plan"]');
-        if (anchor) {
-          controls.insertBefore(runBtn, anchor);
-        } else {
-          controls.appendChild(runBtn);
-        }
-        runBtn.addEventListener('click', () => {
-          if (isBoardRunning(group)) {
-            stopBoardAutoRun(group, plannerChat);
-          } else {
-            startBoardAutoRun(group, plannerChat);
-          }
-          refreshActiveBoardIfMounted();
-        });
+    const running = isBoardRunning(group);
+    if (!runBtn) {
+      runBtn = document.createElement('button');
+      runBtn.type = 'button';
+      // Keep build order (… settings, Start, Timeline, plan): anchor on the
+      // first trailing action that is a direct child of the controls row.
+      const anchor =
+        controls.querySelector(':scope > .board-timeline-btn') ??
+        controls.querySelector(':scope > [data-board-action="open-plan"]');
+      if (anchor) {
+        controls.insertBefore(runBtn, anchor);
+      } else {
+        controls.appendChild(runBtn);
       }
-      runBtn.className = `board-header__run-btn${running ? ' board-header__run-btn--stop' : ''}`;
-      runBtn.setAttribute('aria-label', running ? 'Stop orchestrator' : 'Start orchestrator');
-      runBtn.title = running ? 'Stop all tasks and chats' : 'Start auto execution';
-      runBtn.textContent = running ? 'Stop' : 'Start';
-    } else if (runBtn) {
-      runBtn.remove();
+      runBtn.addEventListener('click', () => {
+        if (isBoardRunning(group)) {
+          stopBoardAutoRun(group, plannerChat);
+        } else {
+          startBoardAutoRun(group, plannerChat);
+        }
+        refreshActiveBoardIfMounted();
+      });
     }
+    runBtn.className = `board-header__run-btn${running ? ' board-header__run-btn--stop' : ''}`;
+    runBtn.setAttribute('aria-label', running ? 'Stop orchestrator' : 'Start orchestrator');
+    runBtn.title = running ? 'Stop all tasks and chats' : 'Start auto execution';
+    runBtn.textContent = running ? 'Stop' : 'Start';
   }
 
   const send = root.querySelector(

--- a/src/ui/orchestrate-board.ts
+++ b/src/ui/orchestrate-board.ts
@@ -21,7 +21,9 @@ import {
   subscribeMainTurnActivity,
 } from '../chat/main-turn-activity';
 import {
+  boardHasRecoverableTasks,
   canAccessOrchestrateFinishDashboard,
+  isBoardTaskRecoverableStatus,
   isOrchestratePlanComplete,
   shouldShowOrchestrateFinishDashboard,
 } from '../chat/orchestrate/plan-complete';
@@ -29,7 +31,12 @@ import {
   getKanbanColumnDefs,
   getWaveCompactLaneDefs,
 } from '../chat/orchestrate/board-kanban-columns.ts';
+import { reportBackgroundError } from '../boot/report-background-error.ts';
 import { isUserStoppedChat } from '../chat/orchestrate/user-stopped.ts';
+import {
+  bindBoardCardDrag,
+  bindBoardColumnDrop,
+} from './orchestrate-board-dnd.ts';
 import { sumUsageSegments } from '../chat/orchestrate/stats-math';
 import {
   isActiveChatStreaming,
@@ -69,8 +76,12 @@ import {
   listRunningBoardTaskSlots,
   moveTaskStatus,
   moveTaskToNewChat,
+  listRecoverableBoardTaskRootIds,
+  requeueAllFailedBoardTasks,
   requeueBoardTask,
+  resetAllFailedBoardTasks,
   resolveEffectiveMaxConcurrent,
+  resetBoardTask,
   restartBoardTask,
   setBoardHandsOff,
   setBoardIsolationMode,
@@ -1188,6 +1199,20 @@ function wireBoardHeaderControls(
   skipWrapper.appendChild(skipText);
   settings.appendChild(skipWrapper);
 
+  // The three controls above constrain each other in ways the strip cannot show
+  // (isolation derives from concurrency, per-board skips merging entirely).
+  const helpBtn = createBoardHeaderIconButton('run-help', 'help', {
+    ariaLabel: 'About run settings',
+    title: 'What concurrency, hands-off, and isolation do',
+  });
+  helpBtn.classList.add('board-header__run-help');
+  helpBtn.addEventListener('click', () => {
+    void import('./orchestrate-run-help-lightbox.ts').then((m) =>
+      m.openBoardRunHelpLightbox(),
+    );
+  });
+  settings.appendChild(helpBtn);
+
   controls.appendChild(settings);
 
   // Start / Stop. A board that has not been started is the "manual" case — there is
@@ -1241,6 +1266,9 @@ function wireBoardHeaderControls(
     openBoardTimelineDrawer(group.id);
   });
 
+  const bulkRequeue = buildBulkRequeueSplitButton(group, board, plannerChat);
+  if (bulkRequeue) controls.appendChild(bulkRequeue);
+
   controls.appendChild(timelineBtn);
   controls.appendChild(openPlan);
 
@@ -1271,6 +1299,112 @@ function wireBoardHeaderControls(
     });
     controls.appendChild(dashToggle);
   }
+}
+
+/**
+ * Bulk recovery split-button: **Requeue N** primary, **Reset N** behind the caret.
+ * Same two verbs as the per-card row — requeue keeps each worktree, reset does not.
+ * Mirrors the finish dashboard's commit split-button.
+ */
+function buildBulkRequeueSplitButton(
+  group: ChatGroup,
+  board: BoardState,
+  plannerChat: Chat,
+): HTMLElement | null {
+  if (!boardHasRecoverableTasks(board)) return null;
+  const count = listRecoverableBoardTaskRootIds(board).length;
+  if (count === 0) return null;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'board-header__bulk-requeue';
+  wrap.dataset.boardAction = 'bulk-requeue';
+
+  let openMenu: HTMLElement | null = null;
+  let busy = false;
+
+  const run = (action: 'requeue' | 'reset'): void => {
+    if (busy) return;
+    busy = true;
+    primary.disabled = true;
+    caret.disabled = true;
+    const work =
+      action === 'requeue'
+        ? requeueAllFailedBoardTasks(group, plannerChat)
+        : resetAllFailedBoardTasks(group, plannerChat);
+    void work
+      .catch((err) => reportBackgroundError('board-bulk-requeue', err))
+      .then(() => {
+        busy = false;
+        refreshActiveBoardIfMounted();
+      });
+  };
+
+  const closeMenu = (): void => {
+    openMenu?.remove();
+    openMenu = null;
+    caret.setAttribute('aria-expanded', 'false');
+  };
+
+  const primary = document.createElement('button');
+  primary.type = 'button';
+  primary.className = 'board-btn board-btn--compact board-header__bulk-requeue-primary';
+  primary.textContent = `Requeue ${count} failed`;
+  primary.title = 'Run every failed task again in its existing worktree';
+  primary.addEventListener('click', () => run('requeue'));
+
+  const caret = document.createElement('button');
+  caret.type = 'button';
+  caret.className = 'board-btn board-btn--compact board-header__bulk-requeue-caret';
+  caret.setAttribute('aria-haspopup', 'menu');
+  caret.setAttribute('aria-expanded', 'false');
+  caret.setAttribute('aria-label', 'More recovery options');
+  caret.textContent = '▾';
+  caret.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    if (openMenu) {
+      closeMenu();
+      return;
+    }
+    const menu = document.createElement('div');
+    menu.className = 'board-header__bulk-requeue-menu';
+    menu.setAttribute('role', 'menu');
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'board-header__bulk-requeue-menuitem';
+    item.setAttribute('role', 'menuitem');
+    item.textContent = `Reset ${count} failed`;
+    item.title = 'Discard each worktree and run again from the integration tip';
+    item.addEventListener('click', (itemEv) => {
+      itemEv.stopPropagation();
+      closeMenu();
+      run('reset');
+    });
+    menu.appendChild(item);
+    wrap.appendChild(menu);
+    openMenu = menu;
+    caret.setAttribute('aria-expanded', 'true');
+
+    const onDoc = (docEv: MouseEvent): void => {
+      const target = docEv.target as Node;
+      if (menu.contains(target) || caret.contains(target)) return;
+      closeMenu();
+      document.removeEventListener('click', onDoc, true);
+    };
+    const onKey = (keyEv: KeyboardEvent): void => {
+      if (keyEv.key !== 'Escape') return;
+      closeMenu();
+      caret.focus();
+      document.removeEventListener('keydown', onKey);
+    };
+    requestAnimationFrame(() => {
+      document.addEventListener('click', onDoc, true);
+      document.addEventListener('keydown', onKey);
+    });
+  });
+
+  wrap.appendChild(primary);
+  wrap.appendChild(caret);
+  return wrap;
 }
 
 /** Banner when the orchestrator requested hands-off and awaits user confirmation. */
@@ -1936,65 +2070,45 @@ function createBoardAdvanceIcon(kind: BoardAdvanceIconKind): HTMLElement {
   });
 }
 
-function buildStatusActionButtons(
+/**
+ * Requeue / Reset for a recoverable card. Status *moves* are drag-and-drop now
+ * (see orchestrate-board-dnd.ts) — these two are the actions drag cannot express,
+ * because they differ only in whether the task keeps its worktree.
+ *
+ * `failed` and `blocked` get the same real requeue as `quarantined`: the old
+ * "Reopen" was a bare status move that left attempt counters maxed out.
+ */
+function buildTaskRequeueActions(
   task: BoardTask,
   group: ChatGroup,
   plannerChat: Chat,
   row: HTMLElement,
 ): void {
-  const skipPerTaskTests = group.orchestrateBoard
-    ? boardSkipsPerTaskTesting(group.orchestrateBoard)
-    : false;
-  const addBtn = (
-    label: string,
-    status: BoardTaskStatus,
-    icon: BoardAdvanceIconKind,
-  ): void => {
+  if (!isBoardTaskRecoverableStatus(task.status)) return;
+
+  const addBtn = (label: string, title: string, run: () => Promise<void>): void => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'board-task-card__advance-btn';
-    btn.appendChild(createBoardAdvanceIcon(icon));
+    btn.title = title;
+    btn.appendChild(createBoardAdvanceIcon('recycle'));
     const text = document.createElement('span');
     text.className = 'board-task-card__advance-label';
     text.textContent = label;
     btn.appendChild(text);
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      moveTaskStatus(group, task.id, status, plannerChat);
-      refreshActiveBoardIfMounted();
+      void run().then(() => refreshActiveBoardIfMounted());
     });
     row.appendChild(btn);
   };
-  if (task.status === 'planned' || task.status === 'blocked') {
-    addBtn('In progress', 'in_progress', 'forward');
-  }
-  if (task.status === 'in_progress' && !skipPerTaskTests) {
-    addBtn('Testing', 'testing', 'forward');
-  }
-  if (task.status === 'testing') {
-    addBtn('Complete', 'complete', 'check');
-    addBtn('Failed', 'failed', 'forward');
-  }
-  if (task.status === 'complete' || task.status === 'failed') {
-    addBtn('Reopen', 'planned', 'recycle');
-  }
-  if (task.status === 'quarantined') {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'board-task-card__advance-btn';
-    btn.appendChild(createBoardAdvanceIcon('recycle'));
-    const text = document.createElement('span');
-    text.className = 'board-task-card__advance-label';
-    text.textContent = 'Requeue';
-    btn.appendChild(text);
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      void requeueBoardTask(group, task.id, plannerChat).then(() => {
-        refreshActiveBoardIfMounted();
-      });
-    });
-    row.appendChild(btn);
-  }
+
+  addBtn('Requeue', 'Run again in the existing worktree', () =>
+    requeueBoardTask(group, task.id, plannerChat),
+  );
+  addBtn('Reset', 'Discard the worktree and run again from the integration tip', () =>
+    resetBoardTask(group, task.id, plannerChat),
+  );
 }
 
 /** True when a stopped/failed/blocked task can use recovery controls. */
@@ -2207,6 +2321,8 @@ function buildTaskCard(
   }
 
   card.setAttribute('data-board-task-id', task.id);
+  card.setAttribute('data-board-task-status', task.status);
+  bindBoardCardDrag(card, task);
 
   const opensPlan = taskCardOpensPlanPanel(task.status);
   const opensChat = !opensPlan;
@@ -2250,7 +2366,11 @@ function buildTaskCard(
         return;
       }
       void import('./orchestrate-board-keyboard').then((mod) => {
-        mod.handleBoardCardKeydown(e, card);
+        mod.handleBoardCardKeydown(e, card, {
+          group,
+          plannerChat,
+          onApplied: () => refreshActiveBoardIfMounted(),
+        });
       });
     });
   }
@@ -2390,7 +2510,7 @@ function buildTaskCard(
 
   const advanceRow = document.createElement('div');
   advanceRow.className = 'board-task-card__advance';
-  buildStatusActionButtons(task, group, plannerChat, advanceRow);
+  buildTaskRequeueActions(task, group, plannerChat, advanceRow);
   if (advanceRow.childElementCount) {
     footer.appendChild(advanceRow);
   }
@@ -2594,6 +2714,9 @@ function renderKanbanColumns(
       list.appendChild(card);
     }
     column.appendChild(list);
+    bindBoardColumnDrop(column, col.id, group, plannerChat, () =>
+      refreshActiveBoardIfMounted(),
+    );
     grid.appendChild(column);
   }
   return grid;

--- a/src/ui/orchestrate-finish-dashboard.ts
+++ b/src/ui/orchestrate-finish-dashboard.ts
@@ -13,15 +13,18 @@ import {
   isOrchestrateBoardFinished,
   isOrchestrateFinalTestFailedWithAllTasksComplete,
 } from '../chat/orchestrate/plan-complete.ts';
-import { enrichFinishReportWithRecommendations } from '../chat/orchestrate/finish-recommendations.ts';
+import {
+  enrichFinishReportWithRecommendations,
+  enrichFinishReportWithRunInstructions,
+} from '../chat/orchestrate/finish-recommendations.ts';
 import { setAssistantBubbleContent } from '../markdown/renderer.ts';
 import { emitBoardChange } from '../state/orchestrate-board-events.ts';
 import {
+  appendFinalTestFixTask,
   clearBoardWorktreesAfterLanding,
   markBoardIntegrationLanded,
   restartBoardAfterRequeueFailures,
 } from '../state/orchestrate-board-actions.ts';
-import { getBoardExecutionMode } from '../state/orchestrate-board-store.ts';
 import {
   mergeIntegrationIntoWorkspace,
   openWorkspacePr,
@@ -81,6 +84,7 @@ function ensureFinishReport(
     scheduleSaveSessions();
   }
   void enrichFinishReportWithRecommendations(groupId, plannerChat, board);
+  void enrichFinishReportWithRunInstructions(groupId, plannerChat, board);
   return board.finishReport!.trim();
 }
 
@@ -816,13 +820,40 @@ export function renderFinishDashboard(
   subtitle.textContent = passedFinal
     ? 'All tasks passed the final integration test. Review the summary below, merge into your branch, or start a follow-up chat.'
     : finalFailed
-      ? 'Tasks merged, but the final integration test failed. Rerun failed tasks to reopen work, or use the board header to re-run the final test.'
+      ? 'Tasks merged, but the final integration test failed. Use Fix integration failures to add a fix task seeded from the tester report, or rerun failed tasks.'
       : 'Some tasks are quarantined or blocked. Rerun failed tasks to put them back on the board and resume auto run.';
   heroCopy.appendChild(title);
   heroCopy.appendChild(subtitle);
   hero.appendChild(badge);
   hero.appendChild(heroCopy);
   panel.appendChild(hero);
+
+  // What the tester actually said, rather than only the generic subtitle.
+  if (finalFailed) {
+    const detail = document.createElement('div');
+    detail.className = 'board-finish-dashboard__final-test';
+    detail.dataset.boardSection = 'final-test-failure';
+
+    const heading = document.createElement('h4');
+    heading.className = 'board-finish-dashboard__section-title';
+    heading.textContent = 'Final integration test';
+    detail.appendChild(heading);
+
+    const summary = document.createElement('p');
+    summary.className = 'board-finish-dashboard__final-test-summary';
+    summary.textContent =
+      board.finalTest?.summary?.trim() || 'The tester reported a failure without a summary.';
+    detail.appendChild(summary);
+
+    const failingIds = board.finalTest?.failingTaskIds ?? [];
+    if (failingIds.length) {
+      const blamed = document.createElement('p');
+      blamed.className = 'board-finish-dashboard__final-test-tasks';
+      blamed.textContent = `Tasks held responsible: ${failingIds.join(', ')}`;
+      detail.appendChild(blamed);
+    }
+    panel.appendChild(detail);
+  }
 
   const statsGrid = document.createElement('div');
   statsGrid.className = 'board-finish-dashboard__stats';
@@ -904,10 +935,8 @@ export function renderFinishDashboard(
     emitBoardChange(group.id);
   });
 
-  const execMode = getBoardExecutionMode(board);
-  const showRerunFailed =
-    (execMode === 'auto' || execMode === 'sequential') &&
-    (boardHasRecoverableTasks(board) || finalFailed);
+  // No mode gate: an AFK board's failures are exactly as rerunnable as any other's.
+  const showRerunFailed = boardHasRecoverableTasks(board) || finalFailed;
   let rerunBtn: HTMLButtonElement | null = null;
   if (showRerunFailed) {
     rerunBtn = document.createElement('button');
@@ -921,6 +950,27 @@ export function renderFinishDashboard(
         .then(() => emitBoardChange(group.id))
         .finally(() => {
           rerunBtn!.disabled = false;
+        });
+    });
+  }
+
+  // The final test failing is a gap *between* tasks that each passed their own
+  // tests, so reopening those tasks is the wrong shape — append a real fix task.
+  let fixBtn: HTMLButtonElement | null = null;
+  if (finalFailed) {
+    fixBtn = document.createElement('button');
+    fixBtn.type = 'button';
+    fixBtn.className = 'board-btn board-btn--compact board-btn--primary';
+    fixBtn.dataset.boardAction = 'fix-final-test';
+    fixBtn.textContent = 'Fix integration failures';
+    fixBtn.title =
+      'Add a fix task in a new wave seeded from the tester report, then re-run the final test';
+    fixBtn.addEventListener('click', () => {
+      fixBtn!.disabled = true;
+      void appendFinalTestFixTask(group, plannerChat)
+        .then(() => emitBoardChange(group.id))
+        .finally(() => {
+          fixBtn!.disabled = false;
         });
     });
   }
@@ -955,6 +1005,7 @@ export function renderFinishDashboard(
   const commitWrap = buildFinishGitAction(group, board, plannerChat, null, gitStatus);
 
   actions.appendChild(backBtn);
+  if (fixBtn) actions.appendChild(fixBtn);
   if (rerunBtn) actions.appendChild(rerunBtn);
   actions.appendChild(followUpBtn);
   actions.appendChild(commitWrap);

--- a/src/ui/orchestrate-finish-dashboard.ts
+++ b/src/ui/orchestrate-finish-dashboard.ts
@@ -34,6 +34,7 @@ import {
 } from '../state/sessions.ts';
 import type { BoardTask, Chat, ChatGroup, OrchestrateBoardState } from '../types.ts';
 import { createChatWithMode } from './sidebar.ts';
+import { openSourceControlCenterLazy } from './source-control-center-entry.ts';
 
 type CommitAction = 'commit-only' | 'commit-push' | 'commit-push-pr';
 
@@ -164,9 +165,25 @@ function closeSplitMenu(menu: HTMLElement | null): void {
   menu?.remove();
 }
 
-type FinishGitActionKind = 'commit' | 'clear' | 'cleared';
+type FinishGitActionKind =
+  | 'commit'
+  | 'clear'
+  | 'cleared'
+  /** No integration branch: commit the live workspace the agents wrote into. */
+  | 'workspace-commit'
+  | 'committed';
+
+/** True when this board has an integration branch to merge from. */
+function boardHasIntegration(board: OrchestrateBoardState): boolean {
+  return Boolean(board.integrationBranch?.trim());
+}
 
 function resolveFinishGitActionKind(board: OrchestrateBoardState): FinishGitActionKind {
+  // Isolation off — the work is already in the user's checkout, so there is
+  // nothing to merge and no worktree to clear afterwards.
+  if (!boardHasIntegration(board)) {
+    return board.integrationLandedAt ? 'committed' : 'workspace-commit';
+  }
   if (board.worktreesClearedAt) return 'cleared';
   if (board.integrationLandedAt) return 'clear';
   return 'commit';
@@ -179,11 +196,20 @@ function tagFinishGitAction(el: HTMLElement, kind: FinishGitActionKind): HTMLEle
   return el;
 }
 
+const FINISH_GIT_ACTION_KINDS: readonly FinishGitActionKind[] = [
+  'commit',
+  'clear',
+  'cleared',
+  'workspace-commit',
+  'committed',
+];
+
 function readFinishGitActionKind(actions: HTMLElement): FinishGitActionKind | null {
   const el = actions.querySelector('[data-board-git-action]');
   const kind = el?.getAttribute('data-board-git-action');
-  if (kind === 'commit' || kind === 'clear' || kind === 'cleared') return kind;
-  return null;
+  return FINISH_GIT_ACTION_KINDS.includes(kind as FinishGitActionKind)
+    ? (kind as FinishGitActionKind)
+    : null;
 }
 
 /** Mark integration landed and swap the primary git action to "Clear worktrees". */
@@ -252,6 +278,14 @@ function buildWorktreesClearedLabel(): HTMLElement {
   return tagFinishGitAction(el, 'cleared');
 }
 
+/** Terminal state for the no-worktree path — nothing left to clear. */
+function buildWorkspaceCommittedLabel(): HTMLElement {
+  const el = document.createElement('span');
+  el.className = 'board-finish-dashboard__worktrees-cleared';
+  el.textContent = 'Committed';
+  return tagFinishGitAction(el, 'committed');
+}
+
 /** Primary git action on the finish dashboard: commit, clear worktrees, or cleared label. */
 function buildFinishGitAction(
   group: ChatGroup,
@@ -260,10 +294,10 @@ function buildFinishGitAction(
   git: FinishBoardStats | null,
   statusEl: HTMLElement,
 ): HTMLElement {
-  if (board.worktreesClearedAt) {
-    return buildWorktreesClearedLabel();
-  }
-  if (board.integrationLandedAt) {
+  const kind = resolveFinishGitActionKind(board);
+  if (kind === 'committed') return buildWorkspaceCommittedLabel();
+  if (kind === 'cleared') return buildWorktreesClearedLabel();
+  if (kind === 'clear') {
     return buildClearWorktreesButton(group, board, plannerChat, statusEl);
   }
   return buildCommitSplitButton(group, board, plannerChat, git, statusEl);
@@ -276,9 +310,15 @@ function buildCommitSplitButton(
   git: FinishBoardStats | null,
   statusEl: HTMLElement,
 ): HTMLElement {
+  // No integration branch: the agents wrote into the live checkout, so there is
+  // nothing to merge — commit the workspace itself instead of dead-ending.
+  const isWorkspaceMode = !boardHasIntegration(board);
+
   const wrap = document.createElement('div');
-  wrap.className = 'board-finish-dashboard__commit-split';
-  tagFinishGitAction(wrap, 'commit');
+  wrap.className = isWorkspaceMode
+    ? 'board-finish-dashboard__commit-split board-finish-dashboard__commit-split--workspace'
+    : 'board-finish-dashboard__commit-split';
+  tagFinishGitAction(wrap, isWorkspaceMode ? 'workspace-commit' : 'commit');
 
   const hasRemote = git?.hasRemote === true;
   const hasGh = git?.hasGh === true;
@@ -292,15 +332,21 @@ function buildCommitSplitButton(
     statusEl.hidden = !text;
   };
 
-  /** After merge + commit succeeds, persist landed state and show clear-worktrees action. */
+  /** After commit succeeds, persist landed state and swap to the follow-on action. */
   const finishLanding = (): void => {
+    if (isWorkspaceMode) {
+      // Nothing was ever checked out elsewhere, so there are no worktrees to clear.
+      markBoardIntegrationLanded(group, plannerChat);
+      wrap.replaceWith(buildWorkspaceCommittedLabel());
+      return;
+    }
     swapToClearWorktreesButton(wrap, group, board, plannerChat, statusEl);
   };
 
   const runChain = async (action: CommitAction): Promise<void> => {
     if (busy) return;
     const branch = board.integrationBranch?.trim();
-    if (!branch) {
+    if (!branch && !isWorkspaceMode) {
       setStatus('No integration branch on this board.', 'err');
       return;
     }
@@ -311,30 +357,34 @@ function buildCommitSplitButton(
     const planName =
       board.planPath?.split('/').pop()?.replace(/\.md$/i, '') || 'Orchestrate board';
     const commitMsg = `feat: ${planName} (orchestrate board ${group.id})`;
-    const mergeMsg = `Merge ${branch}`;
 
-    setStatus('Merging integration branch into workspace…', 'info');
-    const mergeRes = await mergeIntegrationIntoWorkspace({
-      branch,
-      message: mergeMsg,
-    });
-    if (!mergeRes.ok) {
-      const detail = mergeRes.output || mergeRes.error || 'Merge failed';
-      if (mergeRes.error === 'merge_conflict' || mergeRes.conflict) {
-        setStatus(
-          `Merge conflict — resolve in your workspace, then try again. ${detail}`,
-          'err',
-        );
-      } else {
-        setStatus(detail, 'err');
+    /** Did the run actually move work onto the current branch? */
+    let merged = false;
+    if (!isWorkspaceMode && branch) {
+      setStatus('Merging integration branch into workspace…', 'info');
+      const mergeRes = await mergeIntegrationIntoWorkspace({
+        branch,
+        message: `Merge ${branch}`,
+      });
+      if (!mergeRes.ok) {
+        const detail = mergeRes.output || mergeRes.error || 'Merge failed';
+        if (mergeRes.error === 'merge_conflict' || mergeRes.conflict) {
+          setStatus(
+            `Merge conflict — resolve in your workspace, then try again. ${detail}`,
+            'err',
+          );
+        } else {
+          setStatus(detail, 'err');
+        }
+        busy = false;
+        primary.disabled = false;
+        caret.disabled = false;
+        return;
       }
-      busy = false;
-      primary.disabled = false;
-      caret.disabled = false;
-      return;
+      merged = mergeRes.merged === true;
     }
 
-    setStatus('Committing…', 'info');
+    setStatus(isWorkspaceMode ? 'Committing workspace changes…' : 'Committing…', 'info');
     const commitRes = await gitCommit({ message: commitMsg });
     const commitClean =
       !commitRes.ok &&
@@ -352,11 +402,21 @@ function buildCommitSplitButton(
 
     if (action === 'commit-only') {
       if (hadNewCommit) {
-        setStatus('Merged and committed to your current branch.', 'ok');
-      } else if (mergeRes.merged) {
+        setStatus(
+          isWorkspaceMode
+            ? 'Committed workspace changes to your current branch.'
+            : 'Merged and committed to your current branch.',
+          'ok',
+        );
+      } else if (merged) {
         setStatus('Merged integration branch into your current branch.', 'ok');
       } else {
-        setStatus('Integration branch already merged; workspace is clean.', 'info');
+        setStatus(
+          isWorkspaceMode
+            ? 'Nothing to commit; workspace is clean.'
+            : 'Integration branch already merged; workspace is clean.',
+          'info',
+        );
       }
       finishLanding();
       busy = false;
@@ -365,8 +425,8 @@ function buildCommitSplitButton(
 
     if (!hasRemote) {
       setStatus(
-        hadNewCommit || mergeRes.merged
-          ? 'Merged locally. No origin remote — push skipped.'
+        hadNewCommit || merged
+          ? 'Committed locally. No origin remote — push skipped.'
           : 'No origin remote — push skipped.',
         'ok',
       );
@@ -385,14 +445,19 @@ function buildCommitSplitButton(
     }
 
     if (action === 'commit-push') {
-      setStatus('Merged and pushed your current branch.', 'ok');
+      setStatus(
+        isWorkspaceMode
+          ? 'Committed and pushed your current branch.'
+          : 'Merged and pushed your current branch.',
+        'ok',
+      );
       finishLanding();
       busy = false;
       return;
     }
 
     if (!hasGh) {
-      setStatus('Merged and pushed. GitHub CLI not available — PR skipped.', 'ok');
+      setStatus('Committed and pushed. GitHub CLI not available — PR skipped.', 'ok');
       finishLanding();
       busy = false;
       return;
@@ -405,12 +470,12 @@ function buildCommitSplitButton(
     });
     if (!prRes.ok) {
       setStatus(
-        `Merged and pushed. PR failed: ${prRes.output || prRes.error || 'unknown'}`,
+        `Committed and pushed. PR failed: ${prRes.output || prRes.error || 'unknown'}`,
         'err',
       );
     } else {
       const url = prRes.url ? ` ${prRes.url}` : '';
-      setStatus(`Merged, pushed, and opened PR.${url}`, 'ok');
+      setStatus(`Committed, pushed, and opened PR.${url}`, 'ok');
     }
     finishLanding();
     busy = false;
@@ -419,8 +484,19 @@ function buildCommitSplitButton(
   const primary = document.createElement('button');
   primary.type = 'button';
   primary.className = 'board-btn board-btn--primary board-finish-dashboard__commit-primary';
-  primary.textContent = 'Commit & push';
-  if (!hasRemote) {
+  primary.textContent = isWorkspaceMode ? 'Review & commit' : 'Commit & push';
+  if (isWorkspaceMode) {
+    const dirty = git?.filesTouched;
+    const fileNote =
+      typeof dirty === 'number' && dirty > 0
+        ? ` (${dirty} changed file${dirty === 1 ? '' : 's'})`
+        : '';
+    primary.title = !hasRemote
+      ? `Commit the workspace changes locally${fileNote} (no origin remote for push)`
+      : !hasGh
+        ? `Commit the workspace changes and push${fileNote}`
+        : `Commit the workspace changes, push, and open a pull request${fileNote}`;
+  } else if (!hasRemote) {
     primary.title = 'Merge into current branch and commit locally (no origin remote for push)';
   } else if (!hasGh) {
     primary.title = 'Merge into current branch, commit, and push';
@@ -519,6 +595,20 @@ function buildCommitSplitButton(
 
   wrap.appendChild(primary);
   wrap.appendChild(caret);
+
+  // Committing the live checkout is unreviewed by definition — offer the diff first.
+  if (isWorkspaceMode) {
+    const review = document.createElement('button');
+    review.type = 'button';
+    review.className = 'board-finish-dashboard__review-link';
+    review.textContent = 'Open in Source Control';
+    review.title = 'Review the uncommitted workspace changes before committing';
+    review.addEventListener('click', () => {
+      void openSourceControlCenterLazy({ section: 'changes' });
+    });
+    wrap.appendChild(review);
+  }
+
   return wrap;
 }
 

--- a/src/ui/orchestrate-hub.ts
+++ b/src/ui/orchestrate-hub.ts
@@ -16,8 +16,10 @@ import { notifyAskQuestionDisplayContextChanged } from '../chat/ask-question-dis
 import { normalizeModeId } from '../chat/modes/types';
 import {
   getGroupsForWorkspace,
+  getLastBoardGroup,
   openBoardGroup,
 } from '../state/chat-groups';
+import { isBoardRunning } from '../state/orchestrate-board-store';
 import { getActiveChat, sessionState } from '../state/sessions';
 import type { Chat, ChatGroup } from '../types';
 import { getWorkspaceLabel, getWorkspacePath } from '../state/workspace';
@@ -421,6 +423,52 @@ function buildOrchestrateHubDom(): HTMLElement {
 }
 
 /** Paint orchestrate hub into #chatArea (replaces current main view). */
+/**
+ * Where entering Orchestrator should land: the board you were last inside, else
+ * the most recently active running board, else the hub itself.
+ *
+ * Modelled on `resolveSuperPlanTarget` — Super Plan already resumes rather than
+ * always showing its own front door, and `lastBoardGroupId` has been persisted
+ * end-to-end all along; nothing read it.
+ */
+export function resolveOrchestrateLandingTarget(): ChatGroup | null {
+  if (!sessionState) return null;
+
+  const last = getLastBoardGroup();
+  if (last?.orchestrateBoard) return last;
+
+  const workspace = getWorkspacePath();
+  const running = listWorkspaceOrchestrateBoardGroups(workspace).filter(
+    (group) => Boolean(group.orchestrateBoard) && isBoardRunning(group),
+  );
+  // The list is already newest-first by board activity.
+  return running[0] ?? null;
+}
+
+export interface RenderOrchestrateHubOptions {
+  /**
+   * Skip the resume and show the hub itself. Used by explicit "new board"
+   * entry points, mirroring Super Plan's `preferNew`.
+   */
+  preferNew?: boolean;
+}
+
+/**
+ * Enter Orchestrator, resuming the last board when there is one.
+ * Falls through to the hub when nothing is resumable.
+ */
+export function openOrchestrateLanding(options?: RenderOrchestrateHubOptions): void {
+  if (!options?.preferNew) {
+    const target = resolveOrchestrateLandingTarget();
+    if (target) {
+      teardownOrchestrateHub();
+      openBoardGroup(target.id);
+      return;
+    }
+  }
+  renderOrchestrateHub();
+}
+
 export function renderOrchestrateHub(): void {
   void import('./main-column-overlay').then((m) => {
     void m.closeOtherCodeStageViews('orchestrate');

--- a/src/ui/orchestrate-page-shell.ts
+++ b/src/ui/orchestrate-page-shell.ts
@@ -5,7 +5,7 @@
 
 import { boardSetupStatusLabel } from '../chat/orchestrate/board-setup';
 import { getGroupsForWorkspace } from '../state/chat-groups';
-import { getBoardProgressPercent } from '../state/orchestrate-board-store';
+import { getBoardProgressPercent, isBoardRunning } from '../state/orchestrate-board-store';
 import { sessionState } from '../state/sessions';
 import type { BoardTask, Chat, ChatGroup } from '../types';
 import { getWorkspacePath } from '../state/workspace';
@@ -16,7 +16,11 @@ import {
 } from './chat-item-dot';
 import { shortPlanLabel } from './orchestrate-plan-picker';
 
-/** Boards/plans linked to this workspace (shared with hub list helpers). */
+/**
+ * Boards/plans linked to this workspace (shared with hub list helpers).
+ * Running boards pin to the top — a board doing work is the one you came back
+ * for — then most recently active first within each half.
+ */
 function listWorkspaceBoards(workspacePath: string): ChatGroup[] {
   if (!sessionState) return [];
   return getGroupsForWorkspace(workspacePath)
@@ -24,7 +28,25 @@ function listWorkspaceBoards(workspacePath: string): ChatGroup[] {
       (group) =>
         Boolean(group.orchestrateBoard) || Boolean(group.orchestratePlanPath?.trim()),
     )
-    .sort((a, b) => boardGroupSortKey(b) - boardGroupSortKey(a));
+    .sort((a, b) => {
+      const runningDelta = Number(isBoardGroupRunning(b)) - Number(isBoardGroupRunning(a));
+      if (runningDelta !== 0) return runningDelta;
+      return boardGroupSortKey(b) - boardGroupSortKey(a);
+    });
+}
+
+/** True when the group has a board that is actively running. */
+function isBoardGroupRunning(group: ChatGroup): boolean {
+  return Boolean(group.orchestrateBoard) && isBoardRunning(group);
+}
+
+/** Terminal / total task counts for the rail's `done/total` readout. */
+function boardTaskCounts(group: ChatGroup): { done: number; total: number } {
+  const tasks = group.orchestrateBoard?.tasks ?? [];
+  const done = tasks.filter(
+    (t) => t.status === 'complete' || t.status === 'quarantined',
+  ).length;
+  return { done, total: tasks.length };
 }
 
 /** Root class for the Orchestrate library-first page. */
@@ -318,13 +340,17 @@ export function paintOrchestrateBoardRail(
       const board = g.orchestrateBoard;
       const status = board ? 'Board' : boardSetupStatusLabel(g);
       const pct = board ? getBoardProgressPercent(board) : 0;
+      const counts = boardTaskCounts(g);
       return [
         g.id,
         boardTileTitle(g),
         status,
         formatRelativeTime(boardGroupSortKey(g)),
-        board ? board.tasks.length : 0,
+        counts.total,
+        counts.done,
         pct,
+        // Without this the live dot never appears or clears on its own.
+        isBoardGroupRunning(g) ? 'running' : 'idle',
       ].join('|');
     }),
   ].join(' | ');
@@ -368,29 +394,38 @@ export function paintOrchestrateBoardRail(
       : boardSetupStatusLabel(group);
     const board = group.orchestrateBoard;
     const progressPct = board ? getBoardProgressPercent(board) : 0;
-    const taskCount = board?.tasks.length ?? 0;
+    const { done, total } = boardTaskCounts(group);
+    const running = isBoardGroupRunning(group);
 
     const wrap = el('div', 'ob-row-wrap');
     const row = el('button', 'ob-row orchestrate-hub__board-row') as HTMLButtonElement;
     row.type = 'button';
     row.setAttribute('role', 'listitem');
+    if (running) row.classList.add('is-running');
     if (options.activeGroupId && group.id === options.activeGroupId) {
       row.classList.add('is-active');
       row.setAttribute('aria-current', 'true');
     }
 
     const titleEl = el('span', 'ob-row__title orchestrate-hub__board-row-title', title);
+    if (running) {
+      const dot = el('span', 'ob-row__running-dot');
+      dot.setAttribute('aria-hidden', 'true');
+      titleEl.prepend(dot);
+    }
     const meta = el('span', 'ob-row__meta orchestrate-hub__board-row-meta');
     const chip = el('span', 'ob-state orchestrate-hub__board-row-chip', statusLabel);
     meta.appendChild(chip);
     const bits = [when];
-    if (board && taskCount > 0) bits.push(`${progressPct}%`);
+    if (board && total > 0) bits.push(`${done}/${total}`, `${progressPct}%`);
     meta.appendChild(document.createTextNode(` · ${bits.join(' · ')}`));
 
     row.append(titleEl, meta);
     row.setAttribute(
       'aria-label',
-      `${title}, ${statusLabel}, updated ${when}`,
+      `${title}, ${statusLabel}${running ? ', running' : ''}${
+        total > 0 ? `, ${done} of ${total} tasks done` : ''
+      }, updated ${when}`,
     );
     row.addEventListener('click', () => {
       // Collapse overlay rail on narrow layouts after pick (SP pattern).

--- a/src/ui/orchestrate-run-help-lightbox.ts
+++ b/src/ui/orchestrate-run-help-lightbox.ts
@@ -1,0 +1,274 @@
+/**
+ * Run-settings help lightbox: what concurrency, hands-off, and the four isolation
+ * modes actually do. Modelled on `git-help-lightbox.ts` — same focus trap, Escape
+ * handling, and `registerChromePopover` call for Electron visibility.
+ */
+
+import {
+  registerChromePopover,
+  unregisterChromePopover,
+} from './preview-electron-visibility';
+import { createGitWorktreeIcon, type GitWorktreeIconKind } from './git-worktree-icons';
+import { createIcon } from './icon';
+
+const OVERLAY_ID = 'boardRunHelpOverlay';
+const DIALOG_ID = 'boardRunHelpLightbox';
+const FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+let overlayEl: HTMLDivElement | null = null;
+let dialogEl: HTMLDivElement | null = null;
+let isOpen = false;
+let previousFocus: HTMLElement | null = null;
+let escapeHandler: ((e: KeyboardEvent) => void) | null = null;
+let chromePopoverRegistered = false;
+
+/** Whether the run-settings help lightbox is open. */
+export function isBoardRunHelpLightboxOpen(): boolean {
+  return isOpen;
+}
+
+function trapFocus(e: KeyboardEvent): void {
+  if (!dialogEl || e.key !== 'Tab') return;
+  const nodes = [...dialogEl.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
+    (el) => !el.hidden && el.getAttribute('aria-hidden') !== 'true',
+  );
+  if (nodes.length === 0) return;
+  const first = nodes[0];
+  const last = nodes[nodes.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+
+function detachListeners(): void {
+  if (escapeHandler) {
+    document.removeEventListener('keydown', escapeHandler, true);
+    escapeHandler = null;
+  }
+  document.removeEventListener('keydown', trapFocus, true);
+}
+
+function createSetting(title: string, body: string, bullets: string[]): HTMLElement {
+  const card = document.createElement('article');
+  card.className = 'board-run-help-setting';
+
+  const heading = document.createElement('h3');
+  heading.className = 'board-run-help-setting__title';
+  heading.textContent = title;
+
+  const text = document.createElement('p');
+  text.className = 'board-run-help-setting__body';
+  text.textContent = body;
+
+  const list = document.createElement('ul');
+  list.className = 'board-run-help-setting__list';
+  for (const item of bullets) {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  }
+
+  card.append(heading, text, list);
+  return card;
+}
+
+function createIsolationRow(
+  icon: GitWorktreeIconKind,
+  name: string,
+  when: string,
+  merges: string,
+): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'board-run-help-mode';
+
+  const glyph = createGitWorktreeIcon(icon, 'board-run-help-mode__icon');
+  glyph.setAttribute('aria-hidden', 'true');
+
+  const label = document.createElement('span');
+  label.className = 'board-run-help-mode__name';
+  label.textContent = name;
+
+  const detail = document.createElement('div');
+  detail.className = 'board-run-help-mode__detail';
+  const whenEl = document.createElement('p');
+  whenEl.className = 'board-run-help-mode__line';
+  whenEl.textContent = when;
+  const mergeEl = document.createElement('p');
+  mergeEl.className = 'board-run-help-mode__line board-run-help-mode__line--merge';
+  mergeEl.textContent = merges;
+  detail.append(whenEl, mergeEl);
+
+  row.append(glyph, label, detail);
+  return row;
+}
+
+function buildBody(): HTMLElement {
+  const body = document.createElement('div');
+  body.className = 'board-run-help-body';
+
+  const intro = document.createElement('p');
+  intro.className = 'board-run-help-intro';
+  intro.textContent =
+    'A board run is described by two things: how many tasks may run at once, and whether the orchestrator may interrupt you. Isolation decides where each task does its work on disk.';
+
+  const settings = document.createElement('div');
+  settings.className = 'board-run-help-settings';
+  settings.append(
+    createSetting(
+      'Run (concurrency)',
+      'How many tasks may be in flight at the same time.',
+      [
+        'Set to 1 to run tasks strictly one after another.',
+        'Higher values finish sooner but cost more tokens and memory at once.',
+        'After a renderer out-of-memory crash the effective cap is throttled until you press Start again.',
+      ],
+    ),
+    createSetting(
+      'Hands-off',
+      'The orchestrator runs to the end without asking you anything.',
+      [
+        'Available at any concurrency, including 1.',
+        'Permission prompts are answered automatically, so only turn it on for work you would have approved anyway.',
+        'Stop always takes control back.',
+      ],
+    ),
+  );
+
+  const modesTitle = document.createElement('h3');
+  modesTitle.className = 'board-run-help-modes__title';
+  modesTitle.id = 'boardRunHelpModesTitle';
+  modesTitle.textContent = 'Isolation';
+
+  const modesIntro = document.createElement('p');
+  modesIntro.className = 'board-run-help-modes__intro';
+  modesIntro.textContent =
+    'Isolation gives tasks separate git checkouts so they cannot overwrite each other. Auto picks per-board at concurrency 1 and per-task above it.';
+
+  const modes = document.createElement('section');
+  modes.className = 'board-run-help-modes';
+  modes.setAttribute('aria-labelledby', 'boardRunHelpModesTitle');
+  modes.append(
+    modesTitle,
+    modesIntro,
+    createIsolationRow(
+      'local',
+      'Off',
+      'Every task edits your live workspace directly.',
+      'No integration branch — the finish dashboard offers Review & commit instead of a merge.',
+    ),
+    createIsolationRow(
+      'worktree',
+      'Per-board',
+      'One worktree for the whole board; tasks take turns in it.',
+      'The board branch is the integration branch, so tasks commit in sequence and there is no merge step at all.',
+    ),
+    createIsolationRow(
+      'branch',
+      'Per-task',
+      'Each task gets its own worktree and branch.',
+      'Each task merges into integration when it passes; its worktree is then removed and the branch kept.',
+    ),
+    createIsolationRow(
+      'branch',
+      'Per-wave',
+      'Tasks in the same wave share one worktree and branch.',
+      'The wave branch merges into integration once, after the wave finishes.',
+    ),
+  );
+
+  body.append(intro, settings, modes);
+  return body;
+}
+
+function ensureShell(): void {
+  if (overlayEl && dialogEl) return;
+
+  overlayEl = document.createElement('div');
+  overlayEl.id = OVERLAY_ID;
+  overlayEl.className = 'board-run-help-overlay hidden';
+  overlayEl.hidden = true;
+
+  dialogEl = document.createElement('div');
+  dialogEl.id = DIALOG_ID;
+  dialogEl.className = 'board-run-help-lightbox';
+  dialogEl.setAttribute('role', 'dialog');
+  dialogEl.setAttribute('aria-modal', 'true');
+  dialogEl.setAttribute('aria-labelledby', 'boardRunHelpTitle');
+  dialogEl.tabIndex = -1;
+
+  const header = document.createElement('header');
+  header.className = 'board-run-help-header';
+  const title = document.createElement('h2');
+  title.id = 'boardRunHelpTitle';
+  title.className = 'board-run-help-header__title';
+  title.textContent = 'Run settings';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'icon-btn board-run-help-close';
+  closeBtn.setAttribute('aria-label', 'Close');
+  closeBtn.appendChild(createIcon('close'));
+  closeBtn.addEventListener('click', () => closeBoardRunHelpLightbox());
+
+  header.append(title, closeBtn);
+  dialogEl.append(header, buildBody());
+  overlayEl.appendChild(dialogEl);
+  document.body.appendChild(overlayEl);
+
+  overlayEl.addEventListener('click', (e) => {
+    if (e.target === overlayEl) closeBoardRunHelpLightbox();
+  });
+}
+
+/** Open the run-settings explainer. */
+export function openBoardRunHelpLightbox(): void {
+  ensureShell();
+  if (isOpen) return;
+
+  previousFocus =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  isOpen = true;
+  overlayEl!.hidden = false;
+  overlayEl!.classList.remove('hidden');
+  registerChromePopover();
+  chromePopoverRegistered = true;
+  dialogEl!.focus();
+
+  escapeHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeBoardRunHelpLightbox();
+    }
+  };
+  document.addEventListener('keydown', escapeHandler, true);
+  document.addEventListener('keydown', trapFocus, true);
+}
+
+/** Close the explainer and restore focus. */
+export function closeBoardRunHelpLightbox(): void {
+  if (!isOpen) return;
+  isOpen = false;
+  detachListeners();
+  overlayEl!.hidden = true;
+  overlayEl!.classList.add('hidden');
+  if (chromePopoverRegistered) {
+    unregisterChromePopover();
+    chromePopoverRegistered = false;
+  }
+  previousFocus?.focus();
+  previousFocus = null;
+}
+
+/** Reset module state (tests). */
+export function resetBoardRunHelpLightboxForTests(): void {
+  closeBoardRunHelpLightbox();
+  overlayEl?.remove();
+  overlayEl = null;
+  dialogEl = null;
+}

--- a/src/ui/settings-autopilot.ts
+++ b/src/ui/settings-autopilot.ts
@@ -8,7 +8,6 @@ import {
   loadAutopilotMeta,
   saveAutopilotMeta,
   type AutopilotContinueSmartRoute,
-  type AutopilotExecutionMode,
   type AutopilotIsolationMode,
   type AutopilotMeta,
 } from '../config/autopilot-meta';
@@ -98,7 +97,7 @@ export async function renderAutopilotSettingsSection(mount: HTMLElement): Promis
 
   const lead = el('p', 'settings-section-lead');
   lead.append(
-    'Global defaults for orchestrate boards: execution mode, concurrency, git worktree isolation (not host containment), test retries, and planner model fallback. Per-board overrides stay on the board header. Stall and heartbeat thresholds live under ',
+    'Global defaults for orchestrate boards: concurrency, hands-off autonomy, git worktree isolation (not host containment), test retries, and planner model fallback. Per-board overrides stay on the board header. Stall and heartbeat thresholds live under ',
     linkToSettingsSection('Watchdog', 'watchdog'),
     '; work agents under ',
     linkToSettingsSection('Agents', 'agent-center'),
@@ -128,34 +127,25 @@ export async function renderAutopilotSettingsSection(mount: HTMLElement): Promis
     { emphasis: true },
   );
 
-  const modeSelect = document.createElement('select');
-  modeSelect.id = 'settingsAutopilotExecMode';
-  modeSelect.className = 'settings-select';
-  for (const opt of [
-    { value: 'manual', label: 'Manual' },
-    { value: 'sequential', label: 'Sequential' },
-    { value: 'auto', label: 'Auto' },
-    { value: 'afk', label: 'AFK' },
-  ]) {
-    const option = document.createElement('option');
-    option.value = opt.value;
-    option.textContent = opt.label;
-    modeSelect.appendChild(option);
-  }
-  modeSelect.value = meta.defaultExecutionMode;
-  defaultsBody.appendChild(
-    createSettingsSelectRow('Default execution mode', {
-      select: modeSelect,
-      searchKey: 'agents.autopilot.executionMode',
-    }).row,
+  const { row: handsOffRow, input: handsOffToggle } = createSettingsToggleRow(
+    'Hands-off by default',
+    {
+      id: 'settingsAutopilotHandsOff',
+      checked: meta.defaultHandsOff,
+      searchKey: 'agents.autopilot.handsOff',
+      description:
+        'New boards run fully autonomously — the orchestrator never prompts you until Stop or board finish. Available at any concurrency.',
+    },
   );
+  defaultsBody.appendChild(handsOffRow);
 
   const isoSelect = document.createElement('select');
   isoSelect.id = 'settingsAutopilotIsolation';
   isoSelect.className = 'settings-select';
   for (const opt of [
-    { value: 'auto', label: 'Auto (derive from execution mode)' },
+    { value: 'auto', label: 'Auto (derive from concurrency)' },
     { value: 'off', label: 'Off' },
+    { value: 'per-board', label: 'Per-board' },
     { value: 'per-task', label: 'Per-task' },
     { value: 'per-wave', label: 'Per-wave' },
   ]) {
@@ -358,10 +348,8 @@ export async function renderAutopilotSettingsSection(mount: HTMLElement): Promis
     { label: 'Configure providers', sectionId: 'providers' },
   ]);
 
-  modeSelect.addEventListener('change', () => {
-    void persist({
-      defaultExecutionMode: modeSelect.value as AutopilotExecutionMode,
-    });
+  handsOffToggle.addEventListener('change', () => {
+    void persist({ defaultHandsOff: handsOffToggle.checked });
   });
   isoSelect.addEventListener('change', () => {
     void persist({

--- a/src/ui/settings-catalog.ts
+++ b/src/ui/settings-catalog.ts
@@ -355,7 +355,9 @@ const SETTINGS_FIELD_CATALOG_ALL: SettingsFieldEntry[] = [
     keywords: ['orchestrate', 'board', 'autopilot', 'concurrency', 'isolation'],
     description: 'Global defaults for orchestrate board execution, testing, and heartbeat.',
   }),
-  field('agents.autopilot.executionMode', 'Default execution mode', 'agents', 'autopilot'),
+  field('agents.autopilot.handsOff', 'Hands-off by default', 'agents', 'autopilot', {
+    keywords: ['afk', 'autonomous', 'unattended', 'hands off'],
+  }),
   field('agents.autopilot.isolation', 'Default isolation mode', 'agents', 'autopilot'),
   field('agents.autopilot.concurrency', 'Max concurrent tasks', 'agents', 'autopilot'),
   field('agents.autopilot.plannerModel', 'Default planner model', 'agents', 'autopilot'),

--- a/test/agents/controller-watchdog.test.mts
+++ b/test/agents/controller-watchdog.test.mts
@@ -82,7 +82,7 @@ function makeAfkSessionState() {
       lastUpdatedAt: 2,
       waves: [{ id: 'W1', status: 'in_progress' }],
       tasks: [],
-      executionMode: 'afk',
+      handsOff: true,
       autoRunning: true,
     },
   };

--- a/test/chat/orchestrate/board-boot-resume-oom.test.mts
+++ b/test/chat/orchestrate/board-boot-resume-oom.test.mts
@@ -43,7 +43,7 @@ describe('orchestrate OOM recovery', () => {
 
   test('resolveEffectiveMaxConcurrent caps concurrency during OOM recovery', () => {
     const board = {
-      executionMode: 'auto',
+      maxConcurrentTasks: 3,
       maxConcurrentTasks: 5,
     } as OrchestrateBoardState;
 

--- a/test/chat/orchestrate/board-boot-resume.test.mts
+++ b/test/chat/orchestrate/board-boot-resume.test.mts
@@ -45,7 +45,7 @@ function makeGroup(): ChatGroup {
   };
 }
 
-function seedRunningBoard(executionMode: 'auto' | 'sequential' = 'auto') {
+function seedRunningBoard(concurrency = 3) {
   const planner = makePlanner();
   const group = makeGroup();
   initBoard(group, planner, {
@@ -62,7 +62,7 @@ function seedRunningBoard(executionMode: 'auto' | 'sequential' = 'auto') {
     ],
   });
   const board = group.orchestrateBoard!;
-  board.executionMode = executionMode;
+  board.maxConcurrentTasks = concurrency;
   board.autoRunning = true;
   board.tasks[0]!.status = 'in_progress';
   setSessionStateForTests({
@@ -91,10 +91,10 @@ describe('boot orchestrate board resume', () => {
   });
 
   test('resumeBoardExecutionAfterReload keeps board running for stalled in_progress task', async () => {
-    const { planner, group } = seedRunningBoard('sequential');
+    const { planner, group } = seedRunningBoard(1);
     await resumeBoardExecutionAfterReload(group, planner);
     assert.equal(group.orchestrateBoard?.autoRunning, true);
-    assert.equal(group.orchestrateBoard?.executionMode, 'sequential');
+    assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 1);
   });
 
   test('bootOrchestrateBoardResume skips boards that are not running', async () => {
@@ -159,7 +159,7 @@ describe('boot orchestrate board resume', () => {
       ],
     });
     const board = group.orchestrateBoard!;
-    board.executionMode = 'auto';
+    board.maxConcurrentTasks = 3;
     board.autoRunning = true;
     board.integrationBranch = 'minnow/integration/grp_11111111';
 

--- a/test/file/file-tree-worktree-sync.test.mts
+++ b/test/file/file-tree-worktree-sync.test.mts
@@ -263,7 +263,7 @@ describe('resolvePanelBrowseCwd', () => {
       viewMode: 'board' as const,
       orchestrateBoard: {
         planPath: 'documentation/plans/p.md',
-        executionMode: 'auto' as const,
+        maxConcurrentTasks: 3,
         integrationBranch,
         tasks: [
           {
@@ -318,7 +318,7 @@ describe('resolvePanelBrowseCwd', () => {
       viewMode: 'board' as const,
       orchestrateBoard: {
         planPath: 'documentation/plans/p.md',
-        executionMode: 'auto' as const,
+        maxConcurrentTasks: 3,
         integrationBranch,
         tasks: [
           {

--- a/test/orchestrate/_board-flow-helpers.mts
+++ b/test/orchestrate/_board-flow-helpers.mts
@@ -129,7 +129,7 @@ export function makeGroup(overrides: Partial<ChatGroup> = {}): ChatGroup {
 /** Build planner + group, init board store, register session, start auto-run. */
 export function seedBoard(
   spec: BoardSeedSpec,
-  executionMode: 'auto' | 'sequential' | 'afk' = 'auto',
+  runShape: 'auto' | 'sequential' | 'afk' = 'auto',
 ): { planner: Chat; group: ChatGroup } {
   const planner = makePlanner();
   const group = makeGroup();
@@ -151,9 +151,11 @@ export function seedBoard(
   });
   const board = group.orchestrateBoard!;
   board.integrationBranch = spec.integrationBranch ?? FLOW_INTEGRATION_BRANCH;
-  board.executionMode = executionMode;
+  // Modes are derived now: sequential *is* concurrency 1, afk *is* handsOff.
+  if (runShape === 'sequential') board.maxConcurrentTasks = 1;
+  if (runShape === 'afk') board.handsOff = true;
   board.autoRunning = true;
-  if (spec.maxConcurrentTasks !== undefined) {
+  if (spec.maxConcurrentTasks !== undefined && runShape !== 'sequential') {
     board.maxConcurrentTasks = spec.maxConcurrentTasks;
   }
   const decoyChat: Chat = {

--- a/test/orchestrate/board-append-tasks.test.mts
+++ b/test/orchestrate/board-append-tasks.test.mts
@@ -1,0 +1,358 @@
+/**
+ * Phase 4: the finish report is reachable on a failed final test, tasks can be
+ * appended to a running board, and run instructions round-trip through
+ * board_report into the report.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  appendBoardTasks,
+  initBoard,
+  nextBoardWaveId,
+  updateTask,
+} from '../../src/state/orchestrate-board-store.ts';
+import { validateBoardAddTasksArgs } from '../../src/tools/board-tools.ts';
+import {
+  canAccessOrchestrateFinishDashboard,
+  isOrchestrateFinalTestFailed,
+} from '../../src/chat/orchestrate/plan-complete.ts';
+import { buildDeterministicFinishReport } from '../../src/chat/orchestrate/finish-stats.ts';
+import { setSessionStateForTests } from '../../src/state/sessions.ts';
+import type { Chat, ChatGroup, OrchestrateBoardState } from '../../src/types.ts';
+
+const PLANNER_ID = '62222222-2222-2222-2222-222222222222';
+const GROUP_ID = 'grp_62222222-2222-2222-2222-222222222222';
+
+function makePlanner(): Chat {
+  return {
+    id: PLANNER_ID,
+    name: 'Planner',
+    workspacePath: '/tmp/ws',
+    modeId: 'orchestrate',
+    modelId: 'm1',
+    history: [],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    boardGroupId: GROUP_ID,
+  };
+}
+
+function makeGroup(
+  tasks: Array<{ id: string; wave?: string | number; dependsOn?: string[] }> = [
+    { id: 'W1-A' },
+    { id: 'W1-B' },
+  ],
+  waves: Array<{ id: string | number }> = [{ id: 'W1' }],
+): { group: ChatGroup; planner: Chat } {
+  const group: ChatGroup = {
+    id: GROUP_ID,
+    name: 'Append Board',
+    workspacePath: '/tmp/ws',
+    collapsed: false,
+    order: 0,
+    plannerChatId: PLANNER_ID,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    viewMode: 'board',
+  };
+  const planner = makePlanner();
+  initBoard(group, planner, {
+    planPath: 'documentation/plans/test.md',
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      title: `Task ${t.id}`,
+      wave: t.wave ?? 'W1',
+      category: 'build' as const,
+      ...(t.dependsOn ? { dependsOn: t.dependsOn } : {}),
+    })),
+    waves,
+  });
+  setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+  return { group, planner };
+}
+
+describe('finish dashboard access on a failed final test (Phase 4.1)', () => {
+  afterEach(() => setSessionStateForTests(null));
+
+  test('reachable with a quarantined task present', () => {
+    const { group } = makeGroup();
+    const board = group.orchestrateBoard!;
+    board.tasks[0]!.status = 'complete';
+    board.tasks[1]!.status = 'quarantined';
+    board.finalTest = { status: 'failed', summary: 'integration broke' };
+
+    assert.equal(
+      isOrchestrateFinalTestFailed(board),
+      true,
+      'plan is complete (all terminal) and the final test failed',
+    );
+    assert.equal(
+      canAccessOrchestrateFinishDashboard(board),
+      true,
+      'one quarantined task must not hide the report',
+    );
+  });
+
+  test('not reachable while tasks are still running', () => {
+    const { group } = makeGroup();
+    const board = group.orchestrateBoard!;
+    board.tasks[0]!.status = 'complete';
+    board.tasks[1]!.status = 'in_progress';
+    board.finalTest = { status: 'failed', summary: 'integration broke' };
+
+    assert.equal(canAccessOrchestrateFinishDashboard(board), false);
+  });
+
+  test('reachable without completionShownAt being set first', () => {
+    const { group } = makeGroup();
+    const board = group.orchestrateBoard!;
+    for (const t of board.tasks) t.status = 'complete';
+    board.finalTest = { status: 'failed', summary: 'integration broke' };
+    delete board.completionShownAt;
+
+    assert.equal(canAccessOrchestrateFinishDashboard(board), true);
+  });
+});
+
+describe('appendBoardTasks (Phase 4.2)', () => {
+  afterEach(() => setSessionStateForTests(null));
+
+  test('appends into a new wave after the highest existing one', () => {
+    const { group, planner } = makeGroup(
+      [{ id: 'W1-A' }, { id: 'W2-A', wave: 'W2' }],
+      [{ id: 'W1' }, { id: 'W2' }],
+    );
+    const board = group.orchestrateBoard!;
+    assert.equal(nextBoardWaveId(board), 'W3');
+
+    const added = appendBoardTasks(
+      group,
+      [{ id: 'W3-FIX', title: 'Fix it', wave: 'W3', category: 'fix' }],
+      planner,
+    );
+    assert.equal(added.length, 1);
+    assert.equal(added[0]!.wave, 'W3');
+    assert.equal(added[0]!.status, 'planned');
+    assert.equal(board.tasks.length, 3);
+    assert.ok(board.waves.some((w) => w.id === 'W3'), 'the new wave is registered');
+  });
+
+  test('numeric wave ids stay numeric', () => {
+    const { group } = makeGroup([{ id: 'T1', wave: 1 }], [{ id: 1 }]);
+    assert.equal(nextBoardWaveId(group.orchestrateBoard!), 2);
+  });
+
+  test('existing tasks survive the append', () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    updateTask(group, 'W1-A', { status: 'complete' }, planner);
+
+    appendBoardTasks(
+      group,
+      [{ id: 'W2-FIX', title: 'Fix it', wave: 'W2', category: 'fix' }],
+      planner,
+    );
+
+    assert.equal(
+      board.tasks.find((t) => t.id === 'W1-A')?.status,
+      'complete',
+      'append must not reset the board the way board_init does',
+    );
+  });
+});
+
+describe('validateBoardAddTasksArgs against the merged set (Phase 4.2)', () => {
+  afterEach(() => setSessionStateForTests(null));
+
+  function board(): OrchestrateBoardState {
+    return makeGroup().group.orchestrateBoard!;
+  }
+
+  test('accepts a task depending on an existing task id', () => {
+    const res = validateBoardAddTasksArgs(
+      { tasks: [{ id: 'NEW-1', title: 'Follow up', category: 'fix', dependsOn: ['W1-A'] }] },
+      board(),
+    );
+    assert.equal(res.ok, true);
+    if (res.ok) {
+      assert.equal(res.args.wave, 'W2');
+      assert.deepEqual(res.args.tasks[0]!.dependsOn, ['W1-A']);
+    }
+  });
+
+  test('rejects an id that collides with an existing task', () => {
+    const res = validateBoardAddTasksArgs(
+      { tasks: [{ id: 'W1-A', title: 'Dupe', category: 'fix' }] },
+      board(),
+    );
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.match(res.error, /duplicate task id/);
+  });
+
+  test('rejects a dependency on a task that does not exist anywhere', () => {
+    const res = validateBoardAddTasksArgs(
+      { tasks: [{ id: 'NEW-1', title: 'Follow up', category: 'fix', dependsOn: ['NOPE'] }] },
+      board(),
+    );
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.match(res.error, /unknown task "NOPE"/);
+  });
+
+  test('rejects a cycle closed through the new tasks', () => {
+    const res = validateBoardAddTasksArgs(
+      {
+        tasks: [
+          { id: 'NEW-1', title: 'One', category: 'fix', dependsOn: ['NEW-2'] },
+          { id: 'NEW-2', title: 'Two', category: 'fix', dependsOn: ['NEW-1'] },
+        ],
+      },
+      board(),
+    );
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.match(res.error, /cycle/);
+  });
+
+  test('rejects an empty task list', () => {
+    const res = validateBoardAddTasksArgs({ tasks: [] }, board());
+    assert.equal(res.ok, false);
+  });
+
+  test('rejects when there is no board yet', () => {
+    const res = validateBoardAddTasksArgs(
+      { tasks: [{ id: 'NEW-1', title: 'One', category: 'fix' }] },
+      null,
+    );
+    assert.equal(res.ok, false);
+  });
+});
+
+describe('appendFinalTestFixTask (Phase 4.3)', () => {
+  const prevMinnowTest = process.env.MINNOW_TEST;
+
+  beforeEach(() => {
+    process.env.MINNOW_TEST = '1';
+  });
+
+  afterEach(() => {
+    setSessionStateForTests(null);
+    if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+    else process.env.MINNOW_TEST = prevMinnowTest;
+  });
+
+  test('appends one fix task in a new wave and resets the final-test gate', async () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    for (const t of board.tasks) t.status = 'complete';
+    board.finalTest = {
+      status: 'failed',
+      attempts: 1,
+      chatId: 'tester-chat',
+      summary: 'Login flow 500s after the settings refactor',
+      failingTaskIds: ['W1-A'],
+    };
+    board.completionShownAt = Date.now();
+    board.finishReport = 'stale report';
+
+    const { appendFinalTestFixTask } = await import(
+      '../../src/state/orchestrate-board-actions.ts'
+    );
+    const taskId = await appendFinalTestFixTask(group, planner);
+
+    assert.ok(taskId, 'a fix task id is returned');
+    const fix = board.tasks.find((t) => t.id === taskId)!;
+    assert.equal(fix.category, 'fix');
+    assert.equal(fix.wave, 'W2', 'lands in a brand-new wave');
+    assert.match(
+      fix.buildSpec ?? '',
+      /Login flow 500s/,
+      'seeded from the tester summary',
+    );
+    assert.match(fix.buildSpec ?? '', /W1-A/, 'names the tasks held responsible');
+    assert.match(fix.buildSpec ?? '', /tester-chat/, 'references the tester chat');
+
+    assert.equal(board.finalTest?.status, 'pending', 'final test can fire again');
+    assert.equal(board.finalTest?.summary, undefined, 'stale summary cleared');
+    assert.equal(board.finalTest?.attempts, 1, 'attempt count is preserved');
+    assert.equal(board.completionShownAt, undefined);
+    assert.equal(board.finishReport, undefined, 'stale report dropped');
+    assert.equal(board.dashboardDismissed, true, 'returns to the kanban');
+
+    assert.equal(
+      board.tasks.filter((t) => t.status === 'complete').length,
+      2,
+      'tasks that passed are left alone — the failure is between them',
+    );
+  });
+
+  test('does nothing when the final test has not failed', async () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    board.finalTest = { status: 'passed' };
+
+    const { appendFinalTestFixTask } = await import(
+      '../../src/state/orchestrate-board-actions.ts'
+    );
+    assert.equal(await appendFinalTestFixTask(group, planner), null);
+    assert.equal(board.tasks.length, 2);
+  });
+});
+
+describe('run instructions in the finish report (Phase 4.4)', () => {
+  afterEach(() => setSessionStateForTests(null));
+
+  test('prints the tester-verified commands and marks them verified', () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    for (const t of board.tasks) t.status = 'complete';
+    board.finalTest = {
+      status: 'passed',
+      runInstructions: {
+        install: 'pnpm install',
+        start: 'pnpm dev',
+        test: 'pnpm test',
+        notes: 'Needs Postgres on 5432.',
+      },
+    };
+
+    const report = buildDeterministicFinishReport(planner, board);
+    assert.match(report, /pnpm install/);
+    assert.match(report, /pnpm dev/);
+    assert.match(report, /Needs Postgres on 5432\./);
+    assert.match(report, /Verified by the final integration tester/);
+    assert.equal(
+      /npm start/.test(report),
+      false,
+      'the hardcoded npm block is gone',
+    );
+  });
+
+  test('leaves a detection placeholder when the tester reported nothing', () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    for (const t of board.tasks) t.status = 'complete';
+    board.finalTest = { status: 'passed' };
+
+    const report = buildDeterministicFinishReport(planner, board);
+    assert.match(report, /Detecting run commands/);
+    assert.equal(/npm install/.test(report), false);
+  });
+
+  test('next steps and branch line follow the isolation mode', () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    for (const t of board.tasks) t.status = 'complete';
+
+    board.isolationMode = 'off';
+    const noBranch = buildDeterministicFinishReport(planner, board);
+    assert.match(noBranch, /Isolation off/);
+    assert.match(noBranch, /Review & commit/);
+
+    board.isolationMode = 'per-task';
+    board.integrationBranch = 'minnow/board/b/integration';
+    const withBranch = buildDeterministicFinishReport(planner, board);
+    assert.match(withBranch, /Integration branch/);
+    assert.match(withBranch, /Commit & push/);
+  });
+});

--- a/test/orchestrate/board-display-wake.test.mts
+++ b/test/orchestrate/board-display-wake.test.mts
@@ -89,7 +89,7 @@ function makeGroup(): ChatGroup {
     },
   );
   const board = group.orchestrateBoard!;
-  board.executionMode = 'afk';
+  board.handsOff = true;
   board.autoRunning = true;
   board.tasks[0] = {
     ...board.tasks[0]!,

--- a/test/orchestrate/board-drag-drop.test.mts
+++ b/test/orchestrate/board-drag-drop.test.mts
@@ -1,0 +1,272 @@
+/**
+ * Phase 3.1/3.2: kanban drop → status transition mapping, the running-card
+ * confirm, and Requeue vs Reset.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  boardTaskDragDisrupts,
+  isBoardTaskDraggable,
+  resolveBoardDropAction,
+  type KanbanColumnId,
+} from '../../src/ui/orchestrate-board-dnd.ts';
+import {
+  requeueBoardTask,
+  resetBoardTask,
+} from '../../src/state/orchestrate-board-actions.ts';
+import { initBoard, updateTask } from '../../src/state/orchestrate-board-store.ts';
+import { setSessionStateForTests } from '../../src/state/sessions.ts';
+import { setLocalServerAvailableForTests } from '../../src/tools/config.ts';
+import { acquirePipelineHold } from '../../src/state/orchestrate-pipeline-holds.ts';
+import type { BoardTask, BoardTaskStatus, Chat, ChatGroup } from '../../src/types.ts';
+
+const PLANNER_ID = '42222222-2222-2222-2222-222222222222';
+const GROUP_ID = 'grp_42222222-2222-2222-2222-222222222222';
+
+function makePlanner(): Chat {
+  return {
+    id: PLANNER_ID,
+    name: 'Planner',
+    workspacePath: '/tmp/ws',
+    modeId: 'orchestrate',
+    modelId: 'm1',
+    history: [],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    boardGroupId: GROUP_ID,
+  };
+}
+
+function makeGroup(): { group: ChatGroup; planner: Chat } {
+  const group: ChatGroup = {
+    id: GROUP_ID,
+    name: 'Drag Board',
+    workspacePath: '/tmp/ws',
+    collapsed: false,
+    order: 0,
+    plannerChatId: PLANNER_ID,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    viewMode: 'board',
+  };
+  const planner = makePlanner();
+  initBoard(group, planner, {
+    planPath: 'documentation/plans/test.md',
+    tasks: [
+      { id: 'W1-A', title: 'Feature A', wave: 'W1', category: 'build', build: 'Do A' },
+    ],
+    waves: [{ id: 'W1', status: 'in_progress' }],
+  });
+  return { group, planner };
+}
+
+function taskWithStatus(status: BoardTaskStatus): BoardTask {
+  return { id: 'W1-A', title: 'Feature A', wave: 'W1', category: 'build', status };
+}
+
+describe('kanban drop → status transition (Phase 3.1)', () => {
+  const cases: Array<{
+    from: BoardTaskStatus;
+    column: KanbanColumnId;
+    expected: ReturnType<typeof resolveBoardDropAction>;
+    why: string;
+  }> = [
+    { from: 'planned', column: 'in_progress', expected: 'start', why: 'Planned → In Progress starts the task' },
+    { from: 'blocked', column: 'in_progress', expected: 'start', why: 'a blocked card can be started by hand' },
+    { from: 'in_progress', column: 'testing', expected: 'test', why: 'In Progress → Testing runs the tester' },
+    { from: 'testing', column: 'complete', expected: 'complete', why: 'any → Complete marks it complete' },
+    { from: 'in_progress', column: 'complete', expected: 'complete', why: 'any → Complete, not only from Testing' },
+    { from: 'complete', column: 'planned', expected: 'requeue', why: 'Complete → Planned is a real requeue' },
+    { from: 'failed', column: 'planned', expected: 'requeue', why: 'failed requeues rather than bare status move' },
+    { from: 'quarantined', column: 'planned', expected: 'requeue', why: 'quarantined requeues' },
+    { from: 'blocked', column: 'planned', expected: 'plan', why: 'blocked was never terminal, so plain move' },
+    { from: 'planned', column: 'planned', expected: null, why: 'same lane is a no-op' },
+    { from: 'complete', column: 'complete', expected: null, why: 'same lane is a no-op' },
+  ];
+
+  for (const c of cases) {
+    test(`${c.from} → ${c.column}: ${c.why}`, () => {
+      assert.equal(resolveBoardDropAction(taskWithStatus(c.from), c.column), c.expected);
+    });
+  }
+
+  test('merging cards are not draggable', () => {
+    assert.equal(isBoardTaskDraggable(taskWithStatus('merging')), false);
+    assert.equal(isBoardTaskDraggable(taskWithStatus('in_progress')), true);
+  });
+
+  test('a card holding a pipeline slot counts as disruptive', () => {
+    const { group } = makeGroup();
+    const board = group.orchestrateBoard!;
+    const task = board.tasks[0]!;
+    assert.equal(boardTaskDragDisrupts(task, group), false);
+    acquirePipelineHold(board, task.id, 'merge');
+    assert.equal(
+      boardTaskDragDisrupts(task, group),
+      true,
+      'moving a task mid-merge has to be confirmed first',
+    );
+  });
+});
+
+describe('requeue vs reset (Phase 3.2)', () => {
+  let restoreFetch: (() => void) | undefined;
+  const prevMinnowTest = process.env.MINNOW_TEST;
+
+  beforeEach(() => {
+    process.env.MINNOW_TEST = '1';
+    setLocalServerAvailableForTests(true);
+    setSessionStateForTests(null);
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = undefined;
+    setLocalServerAvailableForTests(false);
+    if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+    else process.env.MINNOW_TEST = prevMinnowTest;
+    setSessionStateForTests(null);
+  });
+
+  function mockWorktree(responses: Record<string, unknown>): {
+    restore: () => void;
+    calls: Array<{ op: string; args: Record<string, unknown> }>;
+  } {
+    const saved = globalThis.fetch;
+    const calls: Array<{ op: string; args: Record<string, unknown> }> = [];
+    // @ts-ignore — test-only replacement
+    globalThis.fetch = async (_url: unknown, opts?: { body?: unknown }) => {
+      let parsed: Record<string, unknown> = {};
+      try {
+        parsed = JSON.parse(opts?.body as string) as Record<string, unknown>;
+      } catch {
+        /* teardown pings are not worktree ops */
+      }
+      const op = typeof parsed.op === 'string' ? parsed.op : '';
+      if (op) calls.push({ op, args: parsed });
+      const payload = op in responses ? responses[op] : { ok: false, error: 'not_mocked' };
+      return { ok: true, json: async () => payload };
+    };
+    return {
+      restore: () => {
+        globalThis.fetch = saved;
+      },
+      calls,
+    };
+  }
+
+  test('requeue on a failed task clears the retry budget and keeps the worktree', async () => {
+    const { group, planner } = makeGroup();
+    updateTask(
+      group,
+      'W1-A',
+      {
+        status: 'failed',
+        buildAttempts: 3,
+        testAttempts: 2,
+        error: 'build blew up',
+        worktreePath: '/tmp/wt/W1-A',
+        worktreeBranch: 'minnow/board/b/W1-A',
+      },
+      planner,
+    );
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    const mock = mockWorktree({});
+    restoreFetch = mock.restore;
+
+    await requeueBoardTask(group, 'W1-A', planner);
+
+    const task = group.orchestrateBoard!.tasks[0]!;
+    assert.equal(task.status, 'planned');
+    assert.equal(task.buildAttempts, undefined, 'buildAttempts reset');
+    assert.equal(task.testAttempts, undefined, 'testAttempts reset');
+    assert.equal(task.error, undefined);
+    assert.equal(task.worktreePath, '/tmp/wt/W1-A', 'requeue keeps the worktree');
+    assert.equal(
+      mock.calls.some((c) => c.op === 'remove'),
+      false,
+    );
+  });
+
+  test('reset removes the worktree and forgets the branch so it is recreated fresh', async () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    board.isolationMode = 'per-task';
+    board.worktreeSlug = 'drag-board';
+    updateTask(
+      group,
+      'W1-A',
+      {
+        status: 'failed',
+        buildAttempts: 3,
+        worktreePath: '/tmp/wt/W1-A-feature-a',
+        worktreeBranch: 'minnow/board/drag-board/W1-A-feature-a',
+        pendingBuildSeed: 'retry this',
+      },
+      planner,
+    );
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    const mock = mockWorktree({ remove: { ok: true } });
+    restoreFetch = mock.restore;
+
+    await resetBoardTask(group, 'W1-A', planner);
+
+    const task = group.orchestrateBoard!.tasks[0]!;
+    assert.equal(task.status, 'planned');
+    assert.equal(task.buildAttempts, undefined);
+    assert.equal(task.worktreePath, undefined, 'worktree dropped');
+    assert.equal(task.worktreeBranch, undefined, 'branch forgotten so a fresh one is minted');
+    assert.equal(task.pendingBuildSeed, undefined, 'no stale seed replayed into the new worktree');
+
+    const removeCall = mock.calls.find((c) => c.op === 'remove');
+    assert.ok(removeCall, 'reset removes the slot');
+    assert.equal(removeCall.args.slotId, 'W1-A-feature-a');
+  });
+
+  test('reset in per-board isolation never removes the shared checkout', async () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    board.isolationMode = 'per-board';
+    board.integrationBranch = 'minnow/board/drag-board/integration';
+    updateTask(
+      group,
+      'W1-A',
+      {
+        status: 'failed',
+        worktreePath: '/tmp/wt/integration',
+        worktreeBranch: board.integrationBranch,
+      },
+      planner,
+    );
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    const mock = mockWorktree({ remove: { ok: true } });
+    restoreFetch = mock.restore;
+
+    await resetBoardTask(group, 'W1-A', planner);
+
+    assert.equal(
+      mock.calls.some((c) => c.op === 'remove'),
+      false,
+      'removing it would take the whole board with it',
+    );
+    assert.equal(group.orchestrateBoard!.tasks[0]!.status, 'planned');
+  });
+
+  test('reset refuses a task that is not recoverable', async () => {
+    const { group, planner } = makeGroup();
+    updateTask(group, 'W1-A', { status: 'in_progress' }, planner);
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    const mock = mockWorktree({ remove: { ok: true } });
+    restoreFetch = mock.restore;
+
+    await resetBoardTask(group, 'W1-A', planner);
+    assert.equal(group.orchestrateBoard!.tasks[0]!.status, 'in_progress');
+    assert.equal(mock.calls.length, 0);
+  });
+});

--- a/test/orchestrate/board-report.test.mts
+++ b/test/orchestrate/board-report.test.mts
@@ -94,7 +94,7 @@ function seedTwoTaskBoard() {
       { id: 'B', title: 'Task B', wave: 'W1', category: 'build', build: 'do b' },
     ],
   });
-  group.orchestrateBoard!.executionMode = 'auto';
+  group.orchestrateBoard!.maxConcurrentTasks = 3;
   group.orchestrateBoard!.autoRunning = true;
   setSessionStateForTests({
     version: 5,

--- a/test/orchestrate/board-store.test.mts
+++ b/test/orchestrate/board-store.test.mts
@@ -90,7 +90,6 @@ const EXPECTED_INIT_BOARD_JSON = `{
   "lastUpdatedAt": 1710000001000,
   "timerAccumulatedMs": 0,
   "maxConcurrentTasks": 3,
-  "executionMode": "manual",
   "modelId": "test-model",
   "log": [
     {
@@ -480,8 +479,8 @@ describe('isTaskReadyForAuto DAG-first scheduling', () => {
   });
 });
 
-describe('execution mode afk', () => {
-  test('getBoardExecutionMode returns afk when set', () => {
+describe('derived execution mode', () => {
+  function seededBoard() {
     const chat = makeChat();
     const group = makeGroup();
     initBoard(group, chat, {
@@ -489,19 +488,46 @@ describe('execution mode afk', () => {
       tasks: [{ id: 'W1-A', title: 'A', wave: 'W1', category: 'build' }],
       waves: [{ id: 'W1' }],
     });
-    group.orchestrateBoard!.executionMode = 'afk';
-    assert.equal(getBoardExecutionMode(group.orchestrateBoard), 'afk');
+    return group;
+  }
+
+  test('mode derives from concurrency and hands-off, never from a stored string', () => {
+    const group = seededBoard();
+    const board = group.orchestrateBoard!;
+
+    board.maxConcurrentTasks = 3;
+    assert.equal(getBoardExecutionMode(board), 'auto');
+
+    board.maxConcurrentTasks = 1;
+    assert.equal(getBoardExecutionMode(board), 'sequential');
+
+    // Hands-off wins at any concurrency, including 1.
+    board.handsOff = true;
+    assert.equal(getBoardExecutionMode(board), 'afk');
+    board.maxConcurrentTasks = 4;
+    assert.equal(getBoardExecutionMode(board), 'afk');
   });
 
-  test('isBoardAutoMode and isBoardRunning recognise afk', () => {
-    const chat = makeChat();
-    const group = makeGroup();
-    initBoard(group, chat, {
-      planPath: PLAN_PATH,
-      tasks: [{ id: 'W1-A', title: 'A', wave: 'W1', category: 'build' }],
-      waves: [{ id: 'W1' }],
-    });
-    group.orchestrateBoard!.executionMode = 'afk';
+  test('manual is no longer producible', () => {
+    const group = seededBoard();
+    const board = group.orchestrateBoard!;
+    for (const concurrency of [1, 2, 3, 20]) {
+      for (const handsOff of [true, false]) {
+        board.maxConcurrentTasks = concurrency;
+        board.handsOff = handsOff;
+        assert.notEqual(getBoardExecutionMode(board), 'manual');
+      }
+    }
+  });
+
+  test('initBoard does not persist an execution mode', () => {
+    const group = seededBoard();
+    assert.equal(group.orchestrateBoard!.executionMode, undefined);
+  });
+
+  test('isBoardAutoMode is true for any board; isBoardRunning needs Start', () => {
+    const group = seededBoard();
+    group.orchestrateBoard!.handsOff = true;
     assert.equal(isBoardAutoMode(group), true);
     assert.equal(isBoardRunning(group), false);
     group.orchestrateBoard!.autoRunning = true;

--- a/test/orchestrate/board-task-chat-stall.test.mts
+++ b/test/orchestrate/board-task-chat-stall.test.mts
@@ -103,9 +103,19 @@ function makeTaskChat(): Chat {
   };
 }
 
+type BoardRunShape = { handsOff?: boolean; maxConcurrentTasks?: number; autoRunning?: boolean };
+
+/** Board run shapes under the concurrency + hands-off model. */
+const RUN_SHAPES = {
+  afk: { handsOff: true, autoRunning: true },
+  sequential: { maxConcurrentTasks: 1, autoRunning: true },
+  auto: { maxConcurrentTasks: 3, autoRunning: true },
+  // "Manual" is simply a board the user never Started.
+  manual: { maxConcurrentTasks: 1, autoRunning: false },
+} satisfies Record<string, BoardRunShape>;
+
 function makeBoard(
-  executionMode: 'manual' | 'sequential' | 'auto' | 'afk' = 'afk',
-  autoRunning = true,
+  shape: keyof typeof RUN_SHAPES = 'afk',
 ): OrchestrateBoardState {
   return {
     planPath: 'plan.md',
@@ -122,12 +132,11 @@ function makeBoard(
         chatId: TASK_CHAT_ID,
       },
     ],
-    executionMode,
-    autoRunning,
+    ...RUN_SHAPES[shape],
   };
 }
 
-function makeGroup(executionMode: 'manual' | 'sequential' | 'auto' | 'afk' = 'afk'): ChatGroup {
+function makeGroup(shape: keyof typeof RUN_SHAPES = 'afk'): ChatGroup {
   const group: ChatGroup = {
     id: GROUP_ID,
     name: 'Board',
@@ -136,7 +145,7 @@ function makeGroup(executionMode: 'manual' | 'sequential' | 'auto' | 'afk' = 'af
     order: 0,
     createdAt: 1,
     plannerChatId: PLANNER_ID,
-    orchestrateBoard: makeBoard(executionMode),
+    orchestrateBoard: makeBoard(shape),
   };
   return group;
 }
@@ -240,7 +249,7 @@ describe('board task-chat stall detection', () => {
     assert.equal(getTaskChatStallRestartCountForTests(TASK_CHAT_ID), 0);
   });
 
-  test('manual mode: stall detection does not restart', () => {
+  test('a never-started board: stall detection does not restart', () => {
     const planner = makePlanner();
     const taskChat = makeTaskChat();
     const group = makeGroup('manual');

--- a/test/orchestrate/build-failure-preserve.test.mts
+++ b/test/orchestrate/build-failure-preserve.test.mts
@@ -100,7 +100,7 @@ function failedRunRecord(): TurnRunRecord {
   };
 }
 
-function makeGroup(executionMode: 'manual' | 'auto' = 'auto'): ChatGroup {
+function makeGroup(started = true): ChatGroup {
   const planner = makePlanner();
   const group: ChatGroup = {
     id: GROUP_ID,
@@ -127,8 +127,8 @@ function makeGroup(executionMode: 'manual' | 'auto' = 'auto'): ChatGroup {
     { status: 'in_progress', chatId: TASK_CHAT_ID, startedAt: 1 },
     planner,
   );
-  group.orchestrateBoard!.executionMode = executionMode;
-  group.orchestrateBoard!.autoRunning = executionMode !== 'manual';
+  group.orchestrateBoard!.maxConcurrentTasks = 3;
+  group.orchestrateBoard!.autoRunning = started;
   setSessionStateForTests({
     chats: [planner, makePartialBoardTaskChat()],
     groups: [group],
@@ -198,7 +198,7 @@ describe('finalizeBoardTaskOnStreamEnd in-place auto retry', () => {
   });
 
   test('auto retry keeps the same chat id and seeds next build with error context', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     const taskChat = makePartialBoardTaskChat();
     taskChat.history = [
@@ -226,7 +226,7 @@ describe('finalizeBoardTaskOnStreamEnd in-place auto retry', () => {
   });
 
   test('context exceeded failed run retries in-place on same chat id', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     const taskChat = makePartialBoardTaskChat();
     taskChat.history = [

--- a/test/orchestrate/delegate-tasks.test.mts
+++ b/test/orchestrate/delegate-tasks.test.mts
@@ -1,5 +1,5 @@
 /**
- * Orchestrate auto-delegation: delegate_tasks tool, executionMode, wave readiness.
+ * Orchestrate auto-delegation: delegate_tasks tool, derived mode, wave readiness.
  */
 
 import assert from 'node:assert/strict';
@@ -27,7 +27,7 @@ import {
 import {
   activateAfk,
   resolveBoardMaxConcurrent,
-  setBoardExecutionMode,
+  setBoardHandsOff,
   setBoardMaxConcurrent,
 } from '../../src/state/orchestrate-board-actions.ts';
 import { setSessionStateForTests } from '../../src/state/sessions.ts';
@@ -72,7 +72,7 @@ function makeGroup(board?: ChatGroup['orchestrateBoard']): ChatGroup {
   };
 }
 
-function seedBoard(executionMode: 'manual' | 'auto' = 'manual') {
+function seedBoard(concurrency = 1) {
   const planner = makePlanner();
   const group = makeGroup();
   initBoard(group, planner, {
@@ -95,7 +95,7 @@ function seedBoard(executionMode: 'manual' | 'auto' = 'manual') {
       },
     ],
   });
-  group.orchestrateBoard!.executionMode = executionMode;
+  group.orchestrateBoard!.maxConcurrentTasks = concurrency;
   setSessionStateForTests({
     version: 5,
     activeId: PLANNER_ID,
@@ -123,11 +123,12 @@ describe('orchestrate delegate_tasks', () => {
     }
   });
 
-  test('initBoard sets executionMode manual', () => {
+  test('mode derives from concurrency; no mode string is persisted', () => {
     const { group } = seedBoard();
-    assert.equal(group.orchestrateBoard?.executionMode, 'manual');
-    assert.equal(getBoardExecutionMode(group.orchestrateBoard), 'manual');
-    assert.equal(getBoardExecutionMode(undefined), 'manual');
+    assert.equal(group.orchestrateBoard?.executionMode, undefined);
+    assert.equal(getBoardExecutionMode(group.orchestrateBoard), 'sequential');
+    // No board at all is treated as the most conservative shape.
+    assert.equal(getBoardExecutionMode(undefined), 'sequential');
   });
 
   test('delegate_tasks omitted from planner tools in manual and auto modes', () => {
@@ -149,7 +150,7 @@ describe('orchestrate delegate_tasks', () => {
   });
 
   test('isTaskReadyForAuto respects prior wave completion', () => {
-    const { group } = seedBoard('auto');
+    const { group } = seedBoard(3);
     const board = group.orchestrateBoard!;
     const w1 = board.tasks.find((t) => t.id === 'W1-A')!;
     const w2 = board.tasks.find((t) => t.id === 'W2-A')!;
@@ -160,35 +161,30 @@ describe('orchestrate delegate_tasks', () => {
     assert.equal(isTaskReadyForAuto(board, w2), true);
   });
 
-  test('executeBoardTool delegate_tasks rejects manual mode', async () => {
-    const { planner } = seedBoard('manual');
+  test('delegate_tasks no longer rejects one-at-a-time boards', async () => {
+    // The old gate required executionMode === 'auto' exactly, which rejected every
+    // sequential and AFK board. Any initialized board is delegable now.
+    const { planner } = seedBoard(1);
     const out = await executeBoardTool(
       'delegate_tasks',
       { taskIds: ['W1-A'] },
       { chatId: planner.id },
     );
-    assert.match(out, /executionMode auto/i);
+    assert.doesNotMatch(out, /requires an initialized orchestrate board/i);
   });
 
-  test('setBoardExecutionMode persists auto on board without starting tasks', () => {
-    const { planner, group } = seedBoard('manual');
-    boardSetExecutionModeOnly(group, 'auto');
-    assert.equal(group.orchestrateBoard?.executionMode, 'auto');
-    assert.equal(getBoardExecutionMode(group.orchestrateBoard), 'auto');
-    void planner;
+  test('delegate_tasks accepts a hands-off board', async () => {
+    const { planner, group } = seedBoard(3);
+    group.orchestrateBoard!.handsOff = true;
+    assert.equal(getBoardExecutionMode(group.orchestrateBoard), 'afk');
+    const out = await executeBoardTool(
+      'delegate_tasks',
+      { taskIds: ['W1-A'] },
+      { chatId: planner.id },
+    );
+    assert.doesNotMatch(out, /requires an initialized orchestrate board/i);
   });
 });
-
-/** Test helper: set mode without auto-delegate side effects. */
-function boardSetExecutionModeOnly(
-  group: ChatGroup,
-  mode: 'manual' | 'auto',
-): void {
-  const board = group.orchestrateBoard;
-  if (!board) return;
-  board.executionMode = mode;
-  board.lastUpdatedAt = Date.now();
-}
 
 describe('orchestrator auto reports', () => {
   beforeEach(() => {
@@ -222,7 +218,7 @@ describe('orchestrator auto reports', () => {
   });
 
   test('deliverOrchestratorTaskReport dedupes by task, kind, and lifecycle run', async () => {
-    const { planner, group } = seedBoard('auto');
+    const { planner, group } = seedBoard(3);
     group.orchestrateBoard!.autoRunning = true;
     const task = group.orchestrateBoard!.tasks[0]!;
     task.status = 'failed';
@@ -241,7 +237,7 @@ describe('orchestrator auto reports', () => {
   });
 
   test('defers failure reports while planner is streaming; flushes on stream end', async () => {
-    const { planner, group } = seedBoard('auto');
+    const { planner, group } = seedBoard(3);
     setSessionStateForTests({ version: 5, activeId: PLANNER_ID, chats: [planner], groups: [group] });
     group.orchestrateBoard!.autoRunning = true;
     const taskA = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
@@ -276,7 +272,7 @@ describe('orchestrator auto reports', () => {
   });
 
   test('silent delivery appends assistant message without starting a planner turn', async () => {
-    const { planner, group } = seedBoard('auto');
+    const { planner, group } = seedBoard(3);
     setSessionStateForTests({ version: 5, activeId: PLANNER_ID, chats: [planner], groups: [group] });
     group.orchestrateBoard!.autoRunning = true;
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -295,80 +291,65 @@ describe('orchestrator auto reports', () => {
   });
 });
 
-// ─── Sequential mode and setBoardExecutionMode widening ──────────────────
+// ─── Derived mode + hands-off ─────────────────────────────────────────────
 
-describe('sequential execution mode', () => {
-  test('getBoardExecutionMode returns sequential when set', () => {
-    const { group } = seedBoard('manual');
-    group.orchestrateBoard!.executionMode = 'sequential';
+describe('derived execution mode', () => {
+  test('concurrency 1 derives sequential', () => {
+    const { group } = seedBoard(1);
     assert.equal(getBoardExecutionMode(group.orchestrateBoard), 'sequential');
   });
 
-  test('isBoardAutoMode true for auto, sequential, and afk', () => {
-    const { group } = seedBoard('manual');
-    group.orchestrateBoard!.executionMode = 'auto';
-    assert.equal(isBoardAutoMode(group), true);
-    group.orchestrateBoard!.executionMode = 'sequential';
-    assert.equal(isBoardAutoMode(group), true);
-    group.orchestrateBoard!.executionMode = 'afk';
-    assert.equal(isBoardAutoMode(group), true);
-    group.orchestrateBoard!.executionMode = 'manual';
-    assert.equal(isBoardAutoMode(group), false);
-  });
-
-  test('delegate_tasks rejects sequential mode (not auto)', async () => {
-    const { planner, group } = seedBoard('manual');
-    group.orchestrateBoard!.executionMode = 'sequential';
-    setSessionStateForTests({ version: 5, activeId: PLANNER_ID, chats: [planner], groups: [group] });
-    const out = await executeBoardTool(
-      'delegate_tasks',
-      { taskIds: ['W1-A'] },
-      { chatId: planner.id },
-    );
-    assert.match(out, /executionMode auto/i);
-  });
-
-  test('getBoardExecutionMode falls back to manual for unknown values', () => {
-    const board = { executionMode: 'unknown' as any };
-    assert.equal(getBoardExecutionMode(board as any), 'manual');
-  });
-
-  test('sequential → afk pins maxConcurrentTasks to 1 when unset', () => {
-    const { planner, group } = seedBoard('manual');
+  test('isBoardAutoMode is true for any board, whatever the derived mode', () => {
+    const { group } = seedBoard(1);
     const board = group.orchestrateBoard!;
-    board.executionMode = 'sequential';
-    delete board.maxConcurrentTasks;
+    for (const [concurrency, handsOff] of [[3, false], [1, false], [3, true], [1, true]] as const) {
+      board.maxConcurrentTasks = concurrency;
+      board.handsOff = handsOff;
+      assert.equal(isBoardAutoMode(group), true);
+    }
+  });
+
+  test('hands-off wins over concurrency in the derivation', () => {
+    const { group } = seedBoard(1);
+    const board = group.orchestrateBoard!;
+    board.handsOff = true;
+    assert.equal(getBoardExecutionMode(board), 'afk');
+  });
+
+  test('a stale persisted mode string is ignored entirely', () => {
+    const { group } = seedBoard(3);
+    const board = group.orchestrateBoard!;
+    board.executionMode = 'manual';
+    assert.equal(getBoardExecutionMode(board), 'auto');
+  });
+
+  test('hands-off at concurrency 1 does not lift the one-at-a-time cap', () => {
+    const { planner, group } = seedBoard(1);
+    const board = group.orchestrateBoard!;
     assert.equal(resolveBoardMaxConcurrent(board), 1);
     activateAfk(group, planner);
-    assert.equal(board.maxConcurrentTasks, 1);
+    assert.equal(board.handsOff, true);
     assert.equal(resolveBoardMaxConcurrent(board), 1);
+    assert.equal(getBoardExecutionMode(board), 'afk');
   });
 
-  test('sequential → afk keeps explicit maxConcurrentTasks', () => {
-    const { planner, group } = seedBoard('manual');
+  test('hands-off keeps an explicit maxConcurrentTasks', () => {
+    const { planner, group } = seedBoard(1);
     const board = group.orchestrateBoard!;
-    board.executionMode = 'sequential';
     board.maxConcurrentTasks = 5;
     activateAfk(group, planner);
     assert.equal(board.maxConcurrentTasks, 5);
     assert.equal(resolveBoardMaxConcurrent(board), 5);
   });
 
-  test('auto → afk does not change maxConcurrentTasks', () => {
-    const { planner, group } = seedBoard('auto');
+  test('setBoardHandsOff toggles both ways', () => {
+    const { planner, group } = seedBoard(3);
     const board = group.orchestrateBoard!;
-    delete board.maxConcurrentTasks;
-    setBoardExecutionMode(group, 'afk', planner);
-    assert.equal(board.maxConcurrentTasks, undefined);
-  });
-
-  test('setBoardExecutionMode afk from sequential pins concurrency', () => {
-    const { planner, group } = seedBoard('manual');
-    const board = group.orchestrateBoard!;
-    board.executionMode = 'sequential';
-    delete board.maxConcurrentTasks;
-    setBoardExecutionMode(group, 'afk', planner);
-    assert.equal(board.maxConcurrentTasks, 1);
+    setBoardHandsOff(group, true, planner);
+    assert.equal(board.handsOff, true);
+    setBoardHandsOff(group, false, planner);
+    assert.equal(board.handsOff, undefined);
+    assert.equal(getBoardExecutionMode(board), 'auto');
   });
 });
 
@@ -376,7 +357,7 @@ describe('sequential execution mode', () => {
 
 describe('setBoardMaxConcurrent', () => {
   test('clamps value to [1, 20]', () => {
-    const { planner, group } = seedBoard('auto');
+    const { planner, group } = seedBoard(3);
     setBoardMaxConcurrent(group, 0, planner);
     assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 1);
     setBoardMaxConcurrent(group, 99, planner);
@@ -386,13 +367,13 @@ describe('setBoardMaxConcurrent', () => {
   });
 
   test('floors fractional values', () => {
-    const { planner, group } = seedBoard('auto');
+    const { planner, group } = seedBoard(3);
     setBoardMaxConcurrent(group, 3.9, planner);
     assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 3);
   });
 
   test('no-op when value unchanged', () => {
-    const { planner, group } = seedBoard('auto');
+    const { planner, group } = seedBoard(3);
     group.orchestrateBoard!.maxConcurrentTasks = 5;
     const before = group.orchestrateBoard!.lastUpdatedAt;
     setBoardMaxConcurrent(group, 5, planner);

--- a/test/orchestrate/env-fixer-stall.test.mts
+++ b/test/orchestrate/env-fixer-stall.test.mts
@@ -135,7 +135,7 @@ function makeEnvFixerChat(options?: {
   return chat;
 }
 
-function makeGroup(executionMode: 'manual' | 'sequential' | 'auto' | 'afk' = 'afk'): ChatGroup {
+function makeGroup(shape: 'stopped' | 'sequential' | 'auto' | 'afk' = 'afk'): ChatGroup {
   const group: ChatGroup = {
     id: GROUP_ID,
     name: 'Board',
@@ -162,7 +162,9 @@ function makeGroup(executionMode: 'manual' | 'sequential' | 'auto' | 'afk' = 'af
     ],
     waves: [{ id: 'W1', status: 'in_progress' }],
   });
-  group.orchestrateBoard!.executionMode = executionMode;
+  group.orchestrateBoard!.maxConcurrentTasks = shape === 'auto' ? 3 : 1;
+  if (shape === 'afk') group.orchestrateBoard!.handsOff = true;
+  if (shape === 'stopped') group.orchestrateBoard!.autoRunning = false;
   group.orchestrateBoard!.autoRunning = true;
   return group;
 }

--- a/test/orchestrate/fixer-recovery.test.mts
+++ b/test/orchestrate/fixer-recovery.test.mts
@@ -173,7 +173,7 @@ function makeMergeGroup(): ChatGroup {
     waves: [{ id: 'W1', status: 'in_progress' }],
   });
   group.orchestrateBoard!.integrationBranch = INTEGRATION_BRANCH;
-  group.orchestrateBoard!.executionMode = 'afk';
+  group.orchestrateBoard!.handsOff = true;
   group.orchestrateBoard!.autoRunning = true;
   return group;
 }
@@ -276,7 +276,7 @@ function makeGroup(): ChatGroup {
     ],
     waves: [{ id: 'W1', status: 'in_progress' }],
   });
-  group.orchestrateBoard!.executionMode = 'afk';
+  group.orchestrateBoard!.handsOff = true;
   group.orchestrateBoard!.autoRunning = true;
   return group;
 }
@@ -706,7 +706,7 @@ describe('Env-fixer pass board_report routing', () => {
       ],
       waves: [{ id: 'W1', status: 'in_progress' }],
     });
-    group.orchestrateBoard!.executionMode = 'afk';
+    group.orchestrateBoard!.handsOff = true;
     group.orchestrateBoard!.autoRunning = true;
     group.orchestrateBoard!.maxConcurrentTasks = 1;
 
@@ -901,7 +901,7 @@ function makeFixDRunningGroup(): { group: ChatGroup; planner: Chat } {
     { status: 'in_progress', chatId: FIX_D_TASK_CHAT_ID, startedAt: 1 },
     planner,
   );
-  group.orchestrateBoard!.executionMode = 'auto';
+  group.orchestrateBoard!.maxConcurrentTasks = 3;
   group.orchestrateBoard!.autoRunning = true;
   setSessionStateForTests({
     chats: [planner, makeFixDStoppedTaskChat()],

--- a/test/orchestrate/merge-fixer-finalize.test.mts
+++ b/test/orchestrate/merge-fixer-finalize.test.mts
@@ -79,7 +79,7 @@ function makeGroup(tasks: BoardTask[]): ChatGroup {
     waves: [{ id: 'W1', status: 'in_progress' }],
   });
   group.orchestrateBoard!.integrationBranch = INTEGRATION_BRANCH;
-  group.orchestrateBoard!.executionMode = 'auto';
+  group.orchestrateBoard!.maxConcurrentTasks = 3;
   group.orchestrateBoard!.autoRunning = true;
   return group;
 }

--- a/test/orchestrate/merge-fixer-llm-quirks.test.mts
+++ b/test/orchestrate/merge-fixer-llm-quirks.test.mts
@@ -73,7 +73,7 @@ function makeGroup(tasks: BoardTask[]): ChatGroup {
     waves: [{ id: 'W1', status: 'in_progress' }],
   });
   group.orchestrateBoard!.integrationBranch = INTEGRATION_BRANCH;
-  group.orchestrateBoard!.executionMode = 'auto';
+  group.orchestrateBoard!.maxConcurrentTasks = 3;
   group.orchestrateBoard!.autoRunning = true;
   return group;
 }

--- a/test/orchestrate/orchestrate-quarantine-completion.test.mts
+++ b/test/orchestrate/orchestrate-quarantine-completion.test.mts
@@ -265,7 +265,7 @@ describe('requeueBoardTask', () => {
         { id: 'SIBLING', title: 'Sibling', wave: 'W1', category: 'build', build: 'do sibling' },
       ],
     });
-    group.orchestrateBoard!.executionMode = 'auto';
+    group.orchestrateBoard!.maxConcurrentTasks = 3;
     group.orchestrateBoard!.autoRunning = true;
     setSessionStateForTests({
       version: 5,
@@ -376,7 +376,7 @@ describe('deliverOrchestratorTaskReport re-drive idempotency', () => {
         { id: 'W1-A', title: 'Task A', wave: 'W1', category: 'build', build: 'do a' },
       ],
     });
-    group.orchestrateBoard!.executionMode = 'auto';
+    group.orchestrateBoard!.maxConcurrentTasks = 3;
     group.orchestrateBoard!.autoRunning = true;
     setSessionStateForTests({
       version: 5,

--- a/test/orchestrate/orchestrate-self-heal.test.mts
+++ b/test/orchestrate/orchestrate-self-heal.test.mts
@@ -54,7 +54,7 @@ function makeSetup(tasks: BoardTask[]): { group: ChatGroup; planner: Chat } {
     lastUpdatedAt: 2,
     waves: [{ id: 'W1', status: 'planned' }],
     tasks,
-    executionMode: 'afk',
+    handsOff: true,
     autoRunning: true,
   };
   const group: ChatGroup = {
@@ -180,10 +180,11 @@ describe('runSelfHeal — board not running', () => {
     assert.equal(fresh.envFixAttempts ?? 0, 0);
   });
 
-  test('manual mode board → same guard applies', async () => {
+  test('a never-started board → same guard applies', async () => {
+    // "Manual" is just a board that has not been Started now.
     const t = task('W1-A');
     const { group, planner } = makeSetup([t]);
-    group.orchestrateBoard!.executionMode = 'manual';
+    delete group.orchestrateBoard!.autoRunning;
 
     const { deps, s } = makeDeps();
     await runSelfHeal(group, t, planner, opts('build', { category: 'code' }), deps);

--- a/test/orchestrate/persisted/persisted-afk.test.mts
+++ b/test/orchestrate/persisted/persisted-afk.test.mts
@@ -206,7 +206,7 @@ describe('persisted AFK harness (real server, provider HTTP, sessions, and git)'
       sessions.saveSessionsNow();
       await sessions.waitForSessionSaveForTests();
 
-      assert.equal(group.orchestrateBoard.executionMode, 'afk');
+      assert.equal(group.orchestrateBoard.handsOff, true);
       assert.ok(turnsStarted >= 6, `expected builder + tester turns, observed ${turnsStarted}`);
       assert.deepEqual(
         group.orchestrateBoard.tasks.map((task) => [task.id, task.status]),
@@ -233,12 +233,12 @@ describe('persisted AFK harness (real server, provider HTTP, sessions, and git)'
       const persisted = await harness.api<{
         groups: Array<{
           id: string;
-          orchestrateBoard?: { executionMode?: string; tasks?: Array<{ status?: string }> };
+          orchestrateBoard?: { handsOff?: boolean; tasks?: Array<{ status?: string }> };
         }>;
       }>('GET', '/api/config/sessions');
       const persistedBoard = persisted.body.groups.find((candidate) => candidate.id === seeded.groupId)
         ?.orchestrateBoard;
-      assert.equal(persistedBoard?.executionMode, 'afk');
+      assert.equal(persistedBoard?.handsOff, true);
       assert.deepEqual(
         persistedBoard?.tasks?.map((task) => task.status),
         ['complete', 'complete', 'complete'],

--- a/test/orchestrate/quarantine-completion-hooks.test.mts
+++ b/test/orchestrate/quarantine-completion-hooks.test.mts
@@ -67,7 +67,7 @@ function seedTwoTaskBoard() {
       { id: 'B', title: 'Task B', wave: 'W1', category: 'build', build: 'do b' },
     ],
   });
-  group.orchestrateBoard!.executionMode = 'auto';
+  group.orchestrateBoard!.maxConcurrentTasks = 3;
   group.orchestrateBoard!.autoRunning = true;
   setSessionStateForTests({
     version: 5,
@@ -123,7 +123,7 @@ describe('quarantine completion hooks', () => {
   test('mixed complete+quarantine triggers final test pending via hook', async () => {
     const { group, planner } = seedTwoTaskBoard();
     const board = group.orchestrateBoard!;
-    board.executionMode = 'manual';
+    board.autoRunning = false;
     updateTask(group, 'A', { status: 'complete' }, planner);
 
     quarantineTaskAndDependents(

--- a/test/orchestrate/task-build-retry.test.mts
+++ b/test/orchestrate/task-build-retry.test.mts
@@ -60,7 +60,7 @@ function makeFailedTaskChat(): Chat {
   };
 }
 
-function makeGroup(executionMode: 'manual' | 'auto' | 'afk' = 'auto'): ChatGroup {
+function makeGroup(shape: 'stopped' | 'auto' | 'afk' = 'auto'): ChatGroup {
   const planner = makePlanner();
   const group: ChatGroup = {
     id: GROUP_ID,
@@ -87,8 +87,9 @@ function makeGroup(executionMode: 'manual' | 'auto' | 'afk' = 'auto'): ChatGroup
     { status: 'in_progress', chatId: TASK_CHAT_ID, startedAt: 1 },
     planner,
   );
-  group.orchestrateBoard!.executionMode = executionMode;
-  group.orchestrateBoard!.autoRunning = executionMode !== 'manual';
+  group.orchestrateBoard!.maxConcurrentTasks = shape === 'stopped' ? 1 : 3;
+  if (shape === 'afk') group.orchestrateBoard!.handsOff = true;
+  group.orchestrateBoard!.autoRunning = shape !== 'stopped';
   setSessionStateForTests({
     chats: [planner, makeFailedTaskChat()],
     groups: [group],
@@ -150,7 +151,7 @@ describe('clearTaskFailureState', () => {
   afterEach(() => setSessionStateForTests(null));
 
   test('resetAttempts clears buildAttempts', () => {
-    const group = makeGroup('manual');
+    const group = makeGroup('stopped');
     const planner = makePlanner();
     updateTask(
       group,
@@ -192,7 +193,7 @@ describe('finalizeBoardTaskOnStreamEnd build retry', () => {
   });
 
   test('manual mode marks failed without retry', () => {
-    const group = makeGroup('manual');
+    const group = makeGroup('stopped');
     const planner = makePlanner();
     const task = group.orchestrateBoard!.tasks[0]!;
     finalizeBoardTaskOnStreamEnd(group, task, planner);

--- a/test/orchestrate/task-stream-end.test.mts
+++ b/test/orchestrate/task-stream-end.test.mts
@@ -102,7 +102,7 @@ function makeTaskChat(stopped = false, runStopReason?: 'user' | 'timeout' | 'sys
   return chat;
 }
 
-function makeGroup(executionMode: 'manual' | 'auto' = 'manual'): ChatGroup {
+function makeGroup(started = false): ChatGroup {
   const planner = makePlanner();
   const group: ChatGroup = {
     id: GROUP_ID,
@@ -136,8 +136,8 @@ function makeGroup(executionMode: 'manual' | 'auto' = 'manual'): ChatGroup {
     { status: 'in_progress', chatId: TASK_CHAT_ID, startedAt: 1 },
     planner,
   );
-  group.orchestrateBoard!.executionMode = executionMode;
-  if (executionMode === 'auto') {
+  group.orchestrateBoard!.maxConcurrentTasks = 3;
+  if (started) {
     group.orchestrateBoard!.autoRunning = true;
   }
   const taskChat = makeTaskChat();
@@ -179,7 +179,7 @@ describe('task stream end finalization', () => {
   });
 
   test('resolveTaskChatStopReason: run stopReason wins; history marker uses userStopped', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const board = group.orchestrateBoard!;
     assert.equal(resolveTaskChatStopReason(makeTaskChat(true, 'timeout'), board), 'timeout');
     assert.equal(resolveTaskChatStopReason(makeTaskChat(true), board), 'system');
@@ -188,7 +188,7 @@ describe('task stream end finalization', () => {
   });
 
   test('auto mode moves successful build to testing (Tester launched separately)', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { boardReport: { outcome: 'pass', summary: 'Build verified' } }, planner);
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -200,7 +200,7 @@ describe('task stream end finalization', () => {
   });
 
   test('second build pass on same task does not bump synthesizedBuildAt', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { boardReport: { outcome: 'pass', summary: 'Build verified' } }, planner);
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -224,7 +224,7 @@ describe('task stream end finalization', () => {
   });
 
   test('manual mode moves successful task to testing', () => {
-    const group = makeGroup('manual');
+    const group = makeGroup(false);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { boardReport: { outcome: 'pass', summary: 'Build verified' } }, planner);
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -235,7 +235,7 @@ describe('task stream end finalization', () => {
   });
 
   test('user stop parks task back to planned without quarantine (MIN-304)', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     group.orchestrateBoard!.userStopped = true;
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -276,7 +276,7 @@ describe('task stream end finalization', () => {
       ],
       waves: [{ id: 'W1', status: 'in_progress' }],
     });
-    group.orchestrateBoard!.executionMode = 'auto';
+    group.orchestrateBoard!.maxConcurrentTasks = 3;
     group.orchestrateBoard!.autoRunning = true;
     group.orchestrateBoard!.userStopped = true;
     updateTask(group, 'W1-A', { status: 'in_progress', chatId: TASK_CHAT_ID, startedAt: 1 }, planner);
@@ -300,7 +300,7 @@ describe('task stream end finalization', () => {
   });
 
   test('system/timeout stop under cap moves task to planned for bounded retry', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     const task = group.orchestrateBoard!.tasks[0]!;
     const taskChat = makeTaskChat(true, 'system');
@@ -318,7 +318,7 @@ describe('task stream end finalization', () => {
   });
 
   test('stopRetries cleared after successful build completion', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { stopRetries: 1, boardReport: { outcome: 'pass', summary: 'Build verified' } }, planner);
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -335,7 +335,7 @@ describe('task stream end finalization', () => {
   });
 
   test('system stop at cap quarantines with repeated-stop note', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { stopRetries: MAX_STOP_RETRY_ATTEMPTS }, planner);
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -354,7 +354,7 @@ describe('task stream end finalization', () => {
   });
 
   test('stopped task does not re-enter finalize once quarantined', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { stopRetries: MAX_STOP_RETRY_ATTEMPTS }, planner);
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -375,7 +375,7 @@ describe('task stream end finalization', () => {
 
   test('failed outcome quarantines task in auto mode at build retry cap (Phase 2)', () => {
     setAutopilotMetaForTests({ maxBuildAttempts: 1 });
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { buildAttempts: 1 }, planner);
     const task = group.orchestrateBoard!.tasks[0]!;
@@ -409,7 +409,7 @@ describe('task stream end finalization', () => {
     process.env.MINNOW_TEST = '1';
     try {
       setAutopilotMetaForTests({ maxBuildAttempts: 2 });
-      const group = makeGroup('auto');
+      const group = makeGroup(true);
       const planner = makePlanner();
       const task = group.orchestrateBoard!.tasks[0]!;
       const failedChat: Chat = {
@@ -455,7 +455,7 @@ describe('task stream end finalization', () => {
     const prevMinnowTest = process.env.MINNOW_TEST;
     process.env.MINNOW_TEST = '1';
     try {
-      const group = makeGroup('auto');
+      const group = makeGroup(true);
       const planner = makePlanner();
       const task = group.orchestrateBoard!.tasks[0]!;
       finalizeBoardTaskOnStreamEnd(group, task, planner);
@@ -482,7 +482,7 @@ describe('task stream end finalization', () => {
       setBoardChatTurnRunner(async (input) => {
         launches.push(input.chat.id);
       });
-      const group = makeGroup('auto');
+      const group = makeGroup(true);
       const planner = makePlanner();
       const task = group.orchestrateBoard!.tasks[0]!;
 
@@ -508,7 +508,7 @@ describe('task stream end finalization', () => {
     const prevMinnowTest = process.env.MINNOW_TEST;
     process.env.MINNOW_TEST = '1';
     try {
-      const group = makeGroup('auto');
+      const group = makeGroup(true);
       const planner = makePlanner();
       finalizeBoardTaskOnStreamEnd(group, group.orchestrateBoard!.tasks[0]!, planner);
       assert.equal(getMissingReportNudgeCountForTests(TASK_CHAT_ID), 1);
@@ -536,7 +536,7 @@ describe('task stream end finalization', () => {
     process.env.MINNOW_TEST = '1';
     try {
       setAutopilotMetaForTests({ maxBuildAttempts: 1 });
-      const group = makeGroup('auto');
+      const group = makeGroup(true);
       const planner = makePlanner();
       updateTask(group, 'W1-A', { buildAttempts: 1 }, planner);
 
@@ -562,7 +562,7 @@ describe('task stream end finalization', () => {
     const prevMinnowTest = process.env.MINNOW_TEST;
     process.env.MINNOW_TEST = '1';
     try {
-      const group = makeGroup('manual');
+      const group = makeGroup(false);
       const planner = makePlanner();
       finalizeBoardTaskOnStreamEnd(group, group.orchestrateBoard!.tasks[0]!, planner);
 
@@ -579,7 +579,7 @@ describe('task stream end finalization', () => {
     const prevMinnowTest = process.env.MINNOW_TEST;
     process.env.MINNOW_TEST = '1';
     try {
-      const group = makeGroup('auto');
+      const group = makeGroup(true);
       const planner = makePlanner();
       updateTask(
         group,
@@ -610,7 +610,7 @@ describe('task stream end finalization', () => {
   });
 
   test('markBoardTaskInProgressFromChat sets in_progress when stream starts', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(group, 'W1-A', { status: 'planned', chatId: TASK_CHAT_ID }, planner);
     const taskChat = makeTaskChat();
@@ -622,7 +622,7 @@ describe('task stream end finalization', () => {
   });
 
   test('markBoardTaskInProgressFromChat leaves testing status for Tester chats', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(
       group,
@@ -642,7 +642,7 @@ describe('task stream end finalization', () => {
   });
 
   test('isTaskStalledForRestart uses testChatId during testing', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(
       group,
@@ -662,7 +662,7 @@ describe('task stream end finalization', () => {
   });
 
   test('isTaskStalledForRestart detects idle in_progress task', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(
       group,
@@ -692,7 +692,7 @@ describe('build→test handoff slot accounting', () => {
   });
 
   test('reservation counts as a concurrency slot', () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     updateTask(
       group,
@@ -709,7 +709,7 @@ describe('build→test handoff slot accounting', () => {
   });
 
   test('handoff reservation keeps board at cap across microtask re-drain', async () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     const board = group.orchestrateBoard!;
     board.maxConcurrentTasks = 2;
@@ -751,7 +751,7 @@ describe('build→test handoff slot accounting', () => {
   });
 
   test('slot release after handoff re-drains stranded tester queue item', async () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     const board = group.orchestrateBoard!;
     board.maxConcurrentTasks = 1;
@@ -783,7 +783,7 @@ describe('build→test handoff slot accounting', () => {
   });
 
   test('drainTaskQueue promotes in-testing tasks ahead of queued builds in auto mode', async () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     const board = group.orchestrateBoard!;
     board.maxConcurrentTasks = 2;
@@ -820,7 +820,7 @@ describe('build→test handoff slot accounting', () => {
   });
 
   test('concurrent drainTaskQueue coalesces and does not double-resume queued tasks', async () => {
-    const group = makeGroup('auto');
+    const group = makeGroup(true);
     const planner = makePlanner();
     const board = group.orchestrateBoard!;
     board.maxConcurrentTasks = 1;
@@ -889,7 +889,7 @@ describe('pipeline merge hold blocks queue drain', () => {
       waves: [{ id: 'W1', status: 'in_progress' }],
     });
     const board = group.orchestrateBoard!;
-    board.executionMode = 'sequential';
+    board.maxConcurrentTasks = 1;
     board.autoRunning = true;
     board.maxConcurrentTasks = 1;
     board.integrationBranch = 'minnow/integration/grp_11111111';

--- a/test/orchestrate/task-testing.test.mts
+++ b/test/orchestrate/task-testing.test.mts
@@ -297,7 +297,7 @@ describe('finalizeTaskTestingOnStreamEnd', () => {
       const group = makeGroup({ 'W1-A': 'testing' });
       const planner = makePlanner();
       // Nudging (like fail-routing) only happens on a running board.
-      group.orchestrateBoard!.executionMode = 'afk';
+      group.orchestrateBoard!.handsOff = true;
       group.orchestrateBoard!.autoRunning = true;
       const testChat = makeNoVerdictTesterChat();
       updateTask(group, 'W1-A', { testChatId: TEST_CHAT_ID }, planner);
@@ -324,7 +324,7 @@ describe('finalizeTaskTestingOnStreamEnd', () => {
     try {
       const group = makeGroup({ 'W1-A': 'testing' });
       const planner = makePlanner();
-      group.orchestrateBoard!.executionMode = 'afk';
+      group.orchestrateBoard!.handsOff = true;
       group.orchestrateBoard!.autoRunning = true;
       const testChat = makeNoVerdictTesterChat();
       updateTask(group, 'W1-A', { testChatId: TEST_CHAT_ID }, planner);
@@ -352,7 +352,7 @@ describe('finalizeTaskTestingOnStreamEnd', () => {
   test('retry persists the failure-aware builder seed on the task', async () => {
     const group = makeGroup({ 'W1-A': 'testing' });
     const planner = makePlanner();
-    group.orchestrateBoard!.executionMode = 'afk';
+    group.orchestrateBoard!.handsOff = true;
     group.orchestrateBoard!.autoRunning = true;
     updateTask(
       group,
@@ -384,7 +384,7 @@ describe('finalizeTaskTestingOnStreamEnd', () => {
       // on for W1-A.
       const group = makeGroup({ 'W1-B': 'testing' });
       const planner = makePlanner();
-      group.orchestrateBoard!.executionMode = 'afk';
+      group.orchestrateBoard!.handsOff = true;
       group.orchestrateBoard!.autoRunning = true;
       updateTask(
         group,
@@ -415,7 +415,7 @@ describe('finalizeTaskTestingOnStreamEnd', () => {
 
     const group = makeGroup({ 'W1-A': 'testing' });
     const planner = makePlanner();
-    group.orchestrateBoard!.executionMode = 'afk';
+    group.orchestrateBoard!.handsOff = true;
     group.orchestrateBoard!.autoRunning = true;
 
     updateTask(
@@ -462,7 +462,7 @@ describe('skip per-task testing', () => {
     const planner = makePlanner();
     group.orchestrateBoard!.skipPerTaskTesting = true;
     group.orchestrateBoard!.autoRunning = true;
-    group.orchestrateBoard!.executionMode = 'auto';
+    group.orchestrateBoard!.maxConcurrentTasks = 3;
     const buildChat: Chat = {
       id: BUILD_CHAT_ID,
       name: 'Build',
@@ -507,7 +507,7 @@ describe('skip per-task testing', () => {
       const planner = makePlanner();
       group.orchestrateBoard!.skipPerTaskTesting = true;
       group.orchestrateBoard!.autoRunning = true;
-      group.orchestrateBoard!.executionMode = 'auto';
+      group.orchestrateBoard!.maxConcurrentTasks = 3;
       updateTask(group, 'W1-A', { testChatId: TEST_CHAT_ID }, planner);
       setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
       await startTaskTesting(group, 'W1-A', planner);
@@ -523,7 +523,7 @@ describe('skip per-task testing', () => {
     const group = makeGroup({ 'W1-A': 'complete', 'W1-B': 'complete' });
     const planner = makePlanner();
     group.orchestrateBoard!.skipPerTaskTesting = true;
-    group.orchestrateBoard!.executionMode = 'manual';
+    group.orchestrateBoard!.autoRunning = false;
     tryTriggerFinalIntegrationTest(group, planner);
     assert.equal(group.orchestrateBoard!.finalTest?.status, 'pending');
   });
@@ -576,10 +576,10 @@ describe('final integration test', () => {
     assert.notEqual(group.orchestrateBoard!.finalTest.status, 'passed');
   });
 
-  test('manual mode sets final test pending when all tasks complete', () => {
+  test('a never-started board sets final test pending when all tasks complete', () => {
     const group = makeGroup({ 'W1-A': 'complete', 'W1-B': 'complete' });
     const planner = makePlanner();
-    group.orchestrateBoard!.executionMode = 'manual';
+    group.orchestrateBoard!.autoRunning = false;
     tryTriggerFinalIntegrationTest(group, planner);
     assert.equal(group.orchestrateBoard!.finalTest?.status, 'pending');
   });
@@ -647,7 +647,7 @@ describe('final integration test', () => {
     try {
       const group = makeGroup({ 'W1-A': 'complete', 'W1-B': 'complete' });
       const planner = makePlanner();
-      group.orchestrateBoard!.executionMode = 'afk';
+      group.orchestrateBoard!.handsOff = true;
       group.orchestrateBoard!.autoRunning = true;
       group.orchestrateBoard!.finalTest = {
         status: 'in_progress',

--- a/test/orchestrate/worktree-isolation.test.mts
+++ b/test/orchestrate/worktree-isolation.test.mts
@@ -18,6 +18,8 @@ import {
   sanitizeRefFragment,
   tasksSharingSlot,
   taskWorktreeBranch,
+  taskWorktreeSlot,
+  deriveBoardWorktreeSlug,
   usedDevPorts,
   waveWorktreeBranch,
   worktreeBranchFor,
@@ -45,43 +47,58 @@ afterEach(() => {
 });
 
 describe('resolveIsolationMode', () => {
-  test('explicit override wins over execution mode', () => {
+  test('explicit override wins over the derived default', () => {
     assert.equal(
-      resolveIsolationMode(board({ isolationMode: 'per-wave', executionMode: 'sequential' })),
+      resolveIsolationMode(board({ isolationMode: 'per-wave', maxConcurrentTasks: 1 })),
       'per-wave',
     );
     assert.equal(
-      resolveIsolationMode(board({ isolationMode: 'off', executionMode: 'auto' })),
+      resolveIsolationMode(board({ isolationMode: 'off', maxConcurrentTasks: 4 })),
       'off',
+    );
+    assert.equal(
+      resolveIsolationMode(board({ isolationMode: 'per-board', maxConcurrentTasks: 4 })),
+      'per-board',
     );
   });
 
-  test('auto defaults to per-task; sequential/manual/unset default to off', () => {
-    assert.equal(resolveIsolationMode(board({ executionMode: 'auto' })), 'per-task');
-    assert.equal(resolveIsolationMode(board({ executionMode: 'afk' })), 'per-task');
-    assert.equal(resolveIsolationMode(board({ executionMode: 'sequential' })), 'off');
-    assert.equal(resolveIsolationMode(board({ executionMode: 'manual' })), 'off');
-    assert.equal(resolveIsolationMode(board({})), 'off');
+  test('concurrency 1 derives per-board; >1 derives per-task', () => {
+    assert.equal(resolveIsolationMode(board({ maxConcurrentTasks: 1 })), 'per-board');
+    assert.equal(
+      resolveIsolationMode(board({ maxConcurrentTasks: 1, handsOff: true })),
+      'per-board',
+    );
+    assert.equal(resolveIsolationMode(board({ maxConcurrentTasks: 3 })), 'per-task');
+    assert.equal(resolveIsolationMode(board({ handsOff: true })), 'per-task');
+  });
+
+  test('no board concurrency falls back to the global default', () => {
+    setAutopilotMetaForTests({ maxConcurrentTasks: 1 });
+    assert.equal(resolveIsolationMode(board({})), 'per-board');
+    setAutopilotMetaForTests({ maxConcurrentTasks: 5 });
+    assert.equal(resolveIsolationMode(board({})), 'per-task');
   });
 
   test('global isolation default applies when board has no override', () => {
     setAutopilotMetaForTests({ isolationMode: 'per-wave' });
-    assert.equal(resolveIsolationMode(board({ executionMode: 'manual' })), 'per-wave');
+    assert.equal(resolveIsolationMode(board({ maxConcurrentTasks: 1 })), 'per-wave');
     setAutopilotMetaForTests({ isolationMode: 'off' });
-    assert.equal(resolveIsolationMode(board({ executionMode: 'auto' })), 'off');
+    assert.equal(resolveIsolationMode(board({ maxConcurrentTasks: 4 })), 'off');
   });
 
-  test('global auto preserves derive-from-execution-mode behavior', () => {
+  test('global auto keeps deriving from concurrency', () => {
     setAutopilotMetaForTests({ isolationMode: 'auto' });
-    assert.equal(resolveIsolationMode(board({ executionMode: 'auto' })), 'per-task');
-    assert.equal(resolveIsolationMode(board({ executionMode: 'manual' })), 'off');
+    assert.equal(resolveIsolationMode(board({ maxConcurrentTasks: 4 })), 'per-task');
+    assert.equal(resolveIsolationMode(board({ maxConcurrentTasks: 1 })), 'per-board');
   });
 
   test('null board is off; isIsolationActive mirrors resolution', () => {
     assert.equal(resolveIsolationMode(null), 'off');
     assert.equal(isIsolationActive(null), false);
-    assert.equal(isIsolationActive(board({ executionMode: 'auto' })), true);
-    assert.equal(isIsolationActive(board({ executionMode: 'sequential' })), false);
+    assert.equal(isIsolationActive(board({ maxConcurrentTasks: 4 })), true);
+    // Sequential boards are isolated now — that is the whole point of per-board.
+    assert.equal(isIsolationActive(board({ maxConcurrentTasks: 1 })), true);
+    assert.equal(isIsolationActive(board({ isolationMode: 'off' })), false);
   });
 });
 
@@ -94,36 +111,69 @@ describe('ref/slot naming', () => {
     assert.equal(sanitizeRefFragment(7), '7');
   });
 
-  test('branch names are stable and namespaced per board', () => {
-    assert.equal(boardIntegrationBranch('grp1'), 'minnow/board/grp1/integration');
-    assert.equal(taskWorktreeBranch('grp1', 'T-2'), 'minnow/board/grp1/task/T-2');
-    assert.equal(waveWorktreeBranch('grp1', 'W1'), 'minnow/board/grp1/wave/W1');
+  test('branch names are readable, stable and namespaced per board', () => {
+    assert.equal(boardIntegrationBranch('checkout-flow'), 'minnow/board/checkout-flow/integration');
+    assert.equal(
+      taskWorktreeBranch('checkout-flow', { id: 'T-2', title: 'Add Login Form' }),
+      'minnow/board/checkout-flow/T-2-add-login-form',
+    );
+    assert.equal(
+      waveWorktreeBranch('checkout-flow', 'W1'),
+      'minnow/board/checkout-flow/wave-W1',
+    );
+  });
+
+  test('every board branch keeps the minnow/board/ prefix git-ops matches on', () => {
+    const t = task({ id: 'T1', wave: 1, title: 'Do the thing' });
+    for (const branch of [
+      boardIntegrationBranch('slug'),
+      taskWorktreeBranch('slug', t),
+      waveWorktreeBranch('slug', 1),
+      worktreeBranchFor('per-board', 'slug', t),
+    ]) {
+      assert.ok(branch?.startsWith('minnow/board/'), branch ?? '(null)');
+    }
+  });
+
+  test('taskWorktreeSlot degrades gracefully on empty and oversized titles', () => {
+    assert.equal(taskWorktreeSlot({ id: 'T1', title: '   ' }), 'T1');
+    const slot = taskWorktreeSlot({ id: 'T1', title: 'x'.repeat(200) });
+    assert.equal(slot.length, 64);
+    assert.ok(slot.startsWith('T1-'));
+    assert.ok(!slot.endsWith('-'));
   });
 
   test('integrationWorktreePathFromSlotPath derives integration slot path', () => {
     const boardDir = 'C:/repo/.minnow/worktrees/minnow-abc/board-1';
-    assert.equal(
-      integrationWorktreePathFromSlotPath(`${boardDir}/task-T1`),
-      `${boardDir}/integration`,
-    );
-    assert.equal(
-      integrationWorktreePathFromSlotPath(`${boardDir}/wave-W1`),
-      `${boardDir}/integration`,
-    );
+    // Survives the new free-form slot names as well as the legacy task-/wave- ones.
+    for (const slot of ['task-T1', 'wave-W1', 'T1-add-login-form', 'W1']) {
+      assert.equal(
+        integrationWorktreePathFromSlotPath(`${boardDir}/${slot}`),
+        `${boardDir}/integration`,
+      );
+    }
     assert.equal(
       integrationWorktreePathFromSlotPath(`${boardDir}/integration`),
       `${boardDir}/integration`,
     );
     assert.equal(integrationWorktreePathFromSlotPath('C:/other/path'), undefined);
+    // Regular-chat worktrees (MIN-276) are not board slots.
+    assert.equal(
+      integrationWorktreePathFromSlotPath('C:/repo/.minnow/worktrees/minnow-abc/chat/c1'),
+      undefined,
+    );
   });
 
   test('worktreeSlotId / worktreeBranchFor follow the mode', () => {
-    const t = task({ id: 'T-2', wave: 'W1' });
-    assert.equal(worktreeSlotId('per-task', t), 'task-T-2');
+    const t = task({ id: 'T-2', wave: 'W1', title: 'Ship it' });
+    assert.equal(worktreeSlotId('per-task', t), 'T-2-ship-it');
     assert.equal(worktreeSlotId('per-wave', t), 'wave-W1');
+    assert.equal(worktreeSlotId('per-board', t), 'integration');
     assert.equal(worktreeSlotId('off', t), null);
-    assert.equal(worktreeBranchFor('per-task', 'g', t), 'minnow/board/g/task/T-2');
-    assert.equal(worktreeBranchFor('per-wave', 'g', t), 'minnow/board/g/wave/W1');
+    assert.equal(worktreeBranchFor('per-task', 'g', t), 'minnow/board/g/T-2-ship-it');
+    assert.equal(worktreeBranchFor('per-wave', 'g', t), 'minnow/board/g/wave-W1');
+    // Per-board: the board branch *is* the integration branch, so there is no merge.
+    assert.equal(worktreeBranchFor('per-board', 'g', t), 'minnow/board/g/integration');
     assert.equal(worktreeBranchFor('off', 'g', t), null);
   });
 });
@@ -140,8 +190,66 @@ describe('tasksSharingSlot', () => {
   test('per-wave shares with all tasks in the same wave', () => {
     assert.deepEqual(tasksSharingSlot('per-wave', a, all).map((t) => t.id), ['A', 'B']);
   });
+  test('per-board shares with every task on the board', () => {
+    assert.deepEqual(tasksSharingSlot('per-board', a, all).map((t) => t.id), ['A', 'B', 'C']);
+  });
   test('off shares with nothing', () => {
     assert.deepEqual(tasksSharingSlot('off', a, all), []);
+  });
+});
+
+describe('deriveBoardWorktreeSlug', () => {
+  function group(patch: Partial<ChatGroup> = {}): ChatGroup {
+    return {
+      id: 'grp-9f3a2b',
+      name: '',
+      workspacePath: 'C:/repo',
+      collapsed: false,
+      order: 0,
+      createdAt: 0,
+      orchestratePlanPath: 'documentation/plans/checkout-flow.md',
+      orchestrateBoard: board({ maxConcurrentTasks: 3 }),
+      ...patch,
+    } as ChatGroup;
+  }
+
+  test('derives a readable slug from the plan file name', () => {
+    assert.equal(deriveBoardWorktreeSlug(group()), 'checkout-flow');
+  });
+
+  test('falls back to the folder name, then to "board"', () => {
+    const named = group({ orchestratePlanPath: undefined, name: 'Payments Rework' });
+    assert.equal(deriveBoardWorktreeSlug(named), 'payments-rework');
+    const bare = group({ orchestratePlanPath: undefined, name: '' });
+    assert.equal(deriveBoardWorktreeSlug(bare), 'board');
+  });
+
+  test('de-dupes against sibling slugs', () => {
+    assert.equal(deriveBoardWorktreeSlug(group(), ['checkout-flow']), 'checkout-flow-2');
+    assert.equal(
+      deriveBoardWorktreeSlug(group(), ['checkout-flow', 'checkout-flow-2']),
+      'checkout-flow-3',
+    );
+  });
+
+  test('a frozen slug survives a board rename', () => {
+    const g = group();
+    g.orchestrateBoard!.worktreeSlug = 'checkout-flow';
+    g.name = 'Something Else Entirely';
+    g.orchestratePlanPath = 'documentation/plans/renamed.md';
+    assert.equal(deriveBoardWorktreeSlug(g), 'checkout-flow');
+  });
+
+  test('boards that already provisioned worktrees keep the opaque group id', () => {
+    const withBranch = group();
+    withBranch.orchestrateBoard!.integrationBranch = 'minnow/board/grp-9f3a2b/integration';
+    assert.equal(deriveBoardWorktreeSlug(withBranch), 'grp-9f3a2b');
+
+    const withPath = group();
+    withPath.orchestrateBoard!.tasks = [
+      task({ id: 'T1', wave: 1, worktreePath: 'C:/w/grp-9f3a2b/task-T1' }),
+    ];
+    assert.equal(deriveBoardWorktreeSlug(withPath), 'grp-9f3a2b');
   });
 });
 
@@ -161,7 +269,7 @@ describe('resolveBoardIntegrationWorktreePath', () => {
       createdAt: 0,
       viewMode: 'board',
       orchestrateBoard: board({
-        executionMode: 'auto',
+        maxConcurrentTasks: 3,
         integrationBranch,
         tasks,
       }),
@@ -184,10 +292,10 @@ describe('resolveBoardIntegrationWorktreePath', () => {
     const group = boardGroup([
       task({ id: 'T1', wave: 1, status: 'planned', worktreePath: taskPath }),
     ]);
-    group.orchestrateBoard!.executionMode = 'manual';
+    group.orchestrateBoard!.isolationMode = 'off';
     assert.equal(resolveBoardIntegrationWorktreePath(group), undefined);
 
-    group.orchestrateBoard!.executionMode = 'auto';
+    delete group.orchestrateBoard!.isolationMode;
     delete group.orchestrateBoard!.integrationBranch;
     assert.equal(resolveBoardIntegrationWorktreePath(group), undefined);
   });

--- a/test/orchestrate/worktree-release.test.mts
+++ b/test/orchestrate/worktree-release.test.mts
@@ -1,0 +1,267 @@
+/**
+ * Phase 2 worktree lifecycle: a task's worktree directory is dropped once its
+ * branch lands in integration, the branch survives, and a later requeue can
+ * recreate the slot from that surviving branch.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  enqueueMergeCompletedTaskWorktreeForTests,
+  ensureTaskWorktreeForTests,
+} from '../../src/state/orchestrate-board-actions.ts';
+import { initBoard, updateTask } from '../../src/state/orchestrate-board-store.ts';
+import { setSessionStateForTests } from '../../src/state/sessions.ts';
+import { setLocalServerAvailableForTests } from '../../src/tools/config.ts';
+import type { Chat, ChatGroup } from '../../src/types.ts';
+
+const PLANNER_ID = '32222222-2222-2222-2222-222222222222';
+const GROUP_ID = 'grp_32222222-2222-2222-2222-222222222222';
+const INTEGRATION_BRANCH = 'minnow/board/test-board/integration';
+const TASK_BRANCH = 'minnow/board/test-board/W1-A-feature-a';
+const TASK_SLOT = 'W1-A-feature-a';
+const SLOT_PATH = '/tmp/worktrees/repo-abc/test-board/W1-A-feature-a';
+const INTEGRATION_PATH = '/tmp/worktrees/repo-abc/test-board/integration';
+
+function makePlanner(): Chat {
+  return {
+    id: PLANNER_ID,
+    name: 'Planner',
+    workspacePath: '/tmp/ws',
+    modeId: 'orchestrate',
+    modelId: 'm1',
+    history: [],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    boardGroupId: GROUP_ID,
+  };
+}
+
+/** Board pinned to per-task isolation (the only mode that releases worktrees). */
+function makeGroup(): { group: ChatGroup; planner: Chat } {
+  const group: ChatGroup = {
+    id: GROUP_ID,
+    name: 'Test Board',
+    workspacePath: '/tmp/ws',
+    collapsed: false,
+    order: 0,
+    plannerChatId: PLANNER_ID,
+    orchestratePlanPath: 'documentation/plans/test.md',
+    viewMode: 'board',
+  };
+  const planner = makePlanner();
+  initBoard(group, planner, {
+    planPath: 'documentation/plans/test.md',
+    tasks: [
+      {
+        id: 'W1-A',
+        title: 'Feature A',
+        wave: 'W1',
+        category: 'build',
+        build: 'Add feature A',
+        test: 'Run tests',
+      },
+    ],
+    waves: [{ id: 'W1', status: 'in_progress' }],
+  });
+  const board = group.orchestrateBoard!;
+  board.integrationBranch = INTEGRATION_BRANCH;
+  board.worktreeSlug = 'test-board';
+  board.maxConcurrentTasks = 2;
+  board.isolationMode = 'per-task';
+  return { group, planner };
+}
+
+/** Route /api/worktree by `op`, recording every call for assertions. */
+function mockWorktreeOps(responses: Record<string, unknown>): {
+  restore: () => void;
+  calls: Array<{ op: string; args: Record<string, unknown> }>;
+} {
+  const saved = globalThis.fetch;
+  const calls: Array<{ op: string; args: Record<string, unknown> }> = [];
+  // @ts-ignore — test-only replacement
+  globalThis.fetch = async (_url: unknown, opts?: { body?: unknown }) => {
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = JSON.parse(opts?.body as string) as Record<string, unknown>;
+    } catch {
+      /* non-JSON bodies are teardown pings, not worktree ops */
+    }
+    const op = typeof parsed.op === 'string' ? parsed.op : '';
+    if (op) calls.push({ op, args: parsed });
+    const payload = op in responses ? responses[op] : { ok: false, error: 'not_mocked' };
+    return { ok: true, json: async () => payload };
+  };
+  return {
+    restore: () => {
+      globalThis.fetch = saved;
+    },
+    calls,
+  };
+}
+
+describe('board worktree release on merge (Phase 2)', () => {
+  let restoreFetch: (() => void) | undefined;
+  const prevMinnowTest = process.env.MINNOW_TEST;
+
+  beforeEach(() => {
+    process.env.MINNOW_TEST = '1';
+    setLocalServerAvailableForTests(true);
+    setSessionStateForTests(null);
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = undefined;
+    setLocalServerAvailableForTests(false);
+    if (prevMinnowTest === undefined) delete process.env.MINNOW_TEST;
+    else process.env.MINNOW_TEST = prevMinnowTest;
+    setSessionStateForTests(null);
+  });
+
+  test('verified merge removes the worktree directory and keeps the branch', async () => {
+    const { group, planner } = makeGroup();
+    updateTask(
+      group,
+      'W1-A',
+      {
+        status: 'testing',
+        worktreeBranch: TASK_BRANCH,
+        worktreePath: SLOT_PATH,
+        devPort: 5200,
+        apiPort: 5300,
+      },
+      planner,
+    );
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    const mock = mockWorktreeOps({
+      commit: { ok: true },
+      merge: { ok: true, integrationSha: 'abc123' },
+      verify_integration: { ok: true, verified: true },
+      refresh_integration_deps: { ok: true },
+      remove: { ok: true, path: SLOT_PATH },
+    });
+    restoreFetch = mock.restore;
+
+    const task = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+    const res = await enqueueMergeCompletedTaskWorktreeForTests(group, task, planner);
+    assert.equal(res.outcome, 'merged');
+
+    const removeCall = mock.calls.find((c) => c.op === 'remove');
+    assert.ok(removeCall, 'the merged task worktree should be removed');
+    assert.equal(removeCall.args.slotId, TASK_SLOT);
+
+    const after = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+    assert.equal(after.worktreePath, undefined, 'worktreePath is cleared');
+    assert.equal(
+      after.worktreeBranch,
+      TASK_BRANCH,
+      'the branch is kept so the work stays inspectable',
+    );
+    assert.equal(after.devPort, undefined, 'dev port released');
+    assert.equal(after.apiPort, undefined, 'api port released');
+
+    const log = group.orchestrateBoard!.log ?? [];
+    assert.ok(
+      log.some((e) => e.type === 'worktree_released' && e.taskId === 'W1-A'),
+      'a worktree_released event balances the earlier allocation',
+    );
+  });
+
+  test('a failed removal keeps worktreePath pointing at the surviving directory', async () => {
+    const { group, planner } = makeGroup();
+    updateTask(
+      group,
+      'W1-A',
+      { status: 'testing', worktreeBranch: TASK_BRANCH, worktreePath: SLOT_PATH },
+      planner,
+    );
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    restoreFetch = mockWorktreeOps({
+      commit: { ok: true },
+      merge: { ok: true, integrationSha: 'abc123' },
+      verify_integration: { ok: true, verified: true },
+      refresh_integration_deps: { ok: true },
+      remove: { ok: false, error: 'worktree directory survived removal' },
+    }).restore;
+
+    const task = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+    const res = await enqueueMergeCompletedTaskWorktreeForTests(group, task, planner);
+    assert.equal(res.outcome, 'merged', 'a failed cleanup must not fail the merge');
+
+    const after = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+    assert.equal(
+      after.worktreePath,
+      SLOT_PATH,
+      'an orphan directory must stay referenced, not be forgotten',
+    );
+  });
+
+  test('per-board isolation never removes the shared integration checkout', async () => {
+    const { group, planner } = makeGroup();
+    const board = group.orchestrateBoard!;
+    board.isolationMode = 'per-board';
+    board.maxConcurrentTasks = 1;
+    updateTask(
+      group,
+      'W1-A',
+      {
+        status: 'testing',
+        worktreeBranch: INTEGRATION_BRANCH,
+        worktreePath: INTEGRATION_PATH,
+      },
+      planner,
+    );
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    const mock = mockWorktreeOps({ commit: { ok: true } });
+    restoreFetch = mock.restore;
+
+    const task = board.tasks.find((t) => t.id === 'W1-A')!;
+    const res = await enqueueMergeCompletedTaskWorktreeForTests(group, task, planner);
+    assert.equal(res.outcome, 'merged');
+    assert.equal(
+      mock.calls.some((c) => c.op === 'remove'),
+      false,
+      'the integration checkout is where the next task works',
+    );
+  });
+
+  test('requeue after cleanup recreates the slot from the surviving branch', async () => {
+    const { group, planner } = makeGroup();
+    // Post-cleanup shape: branch remembered, directory gone.
+    updateTask(
+      group,
+      'W1-A',
+      { status: 'planned', worktreeBranch: TASK_BRANCH, worktreePath: undefined },
+      planner,
+    );
+    setSessionStateForTests({ chats: [planner], groups: [group], activeChatId: PLANNER_ID });
+
+    const mock = mockWorktreeOps({
+      ensure_integration: { ok: true, path: INTEGRATION_PATH },
+      create: { ok: true, path: SLOT_PATH },
+    });
+    restoreFetch = mock.restore;
+
+    const task = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+    const path = await ensureTaskWorktreeForTests(group, task, planner);
+    assert.equal(path, SLOT_PATH);
+
+    const createCall = mock.calls.find((c) => c.op === 'create');
+    assert.ok(createCall, 'the slot is recreated');
+    assert.equal(createCall.args.slotId, TASK_SLOT);
+    assert.equal(
+      createCall.args.branch,
+      TASK_BRANCH,
+      'it checks out the surviving branch rather than minting a new one',
+    );
+
+    const after = group.orchestrateBoard!.tasks.find((t) => t.id === 'W1-A')!;
+    assert.equal(after.worktreePath, SLOT_PATH);
+  });
+});

--- a/test/prompts/compose-context.test.mts
+++ b/test/prompts/compose-context.test.mts
@@ -115,7 +115,7 @@ describe('buildComposeContext cwd', () => {
           createdAt: 1,
           orchestrateBoard: {
             planPath: 'plan.md',
-            executionMode: 'auto',
+            maxConcurrentTasks: 3,
             tasks: [
               {
                 id: TASK_ID,
@@ -211,7 +211,7 @@ describe('buildComposeContext cwd', () => {
           plannerChatId: plannerId,
           orchestrateBoard: {
             planPath: 'plan.md',
-            executionMode: 'auto',
+            maxConcurrentTasks: 3,
             tasks: [
               {
                 id: TASK_ID,

--- a/test/server/validate-orchestrate-board.test.mjs
+++ b/test/server/validate-orchestrate-board.test.mjs
@@ -12,7 +12,7 @@ const PLANNER_ID = '11111111-1111-1111-1111-111111111111';
 const PLAN_PATH = 'documentation/plans/reload-persist.md';
 
 describe('validateSessionState orchestrate board', () => {
-  it('preserves autoRunning, sequential mode, and task chat links on save', () => {
+  it('migrates legacy sequential to concurrency 1 and keeps task chat links', () => {
     const out = validateSessionState({
       version: 5,
       activeId: PLANNER_ID,
@@ -64,14 +64,15 @@ describe('validateSessionState orchestrate board', () => {
     });
 
     const board = out.groups[0].orchestrateBoard;
-    assert.equal(board.executionMode, 'sequential');
+    assert.equal(board.executionMode, undefined);
+    assert.equal(board.maxConcurrentTasks, 1);
     assert.equal(board.autoRunning, true);
     assert.equal(board.tasks[0].chatId, '22222222-2222-2222-2222-222222222222');
     assert.equal(board.tasks[0].testChatId, '33333333-3333-3333-3333-333333333333');
     assert.equal(board.finalTest?.status, 'pending');
   });
 
-  it('preserves afk executionMode on save', () => {
+  it('migrates legacy afk to handsOff on save', () => {
     const out = validateSessionState({
       version: 5,
       activeId: PLANNER_ID,
@@ -120,11 +121,12 @@ describe('validateSessionState orchestrate board', () => {
     });
 
     const board = out.groups[0].orchestrateBoard;
-    assert.equal(board.executionMode, 'afk');
+    assert.equal(board.executionMode, undefined);
+    assert.equal(board.handsOff, true);
     assert.equal(board.autoRunning, true);
   });
 
-  it('coerces junk executionMode to manual', () => {
+  it('drops junk executionMode without inventing a concurrency', () => {
     const out = validateSessionState({
       version: 5,
       activeId: PLANNER_ID,
@@ -169,7 +171,10 @@ describe('validateSessionState orchestrate board', () => {
       ],
     });
 
-    assert.equal(out.groups[0].orchestrateBoard.executionMode, 'manual');
+    const junkBoard = out.groups[0].orchestrateBoard;
+    assert.equal(junkBoard.executionMode, undefined);
+    assert.equal(junkBoard.handsOff, undefined);
+    assert.equal(junkBoard.maxConcurrentTasks, undefined);
   });
 
   it('preserves pendingAfk on save', () => {
@@ -221,7 +226,9 @@ describe('validateSessionState orchestrate board', () => {
     });
 
     const board = out.groups[0].orchestrateBoard;
-    assert.equal(board.executionMode, 'manual');
+    assert.equal(board.executionMode, undefined);
+    assert.equal(board.maxConcurrentTasks, 1);
+    assert.equal(board.autoRunning, undefined);
     assert.equal(board.pendingAfk, true);
   });
 
@@ -406,7 +413,7 @@ describe('validateSessionState orchestrate board', () => {
 describe('mergeConfigMeta autopilot', () => {
   it('defaults autopilot block when patch provides empty object', () => {
     const merged = mergeConfigMeta({}, { autopilot: {} });
-    assert.equal(merged.autopilot.defaultExecutionMode, 'manual');
+    assert.equal(merged.autopilot.defaultHandsOff, false);
     assert.equal(merged.autopilot.maxConcurrentTasks, 3);
     assert.equal(merged.autopilot.isolationMode, 'auto');
     assert.equal(merged.autopilot.maxTestAttempts, 3);
@@ -440,15 +447,15 @@ describe('mergeConfigMeta autopilot', () => {
 
   it('validates execution and isolation mode enums', () => {
     const merged = mergeConfigMeta(
-      { autopilot: { defaultExecutionMode: 'auto', isolationMode: 'per-task' } },
+      { autopilot: { defaultHandsOff: true, isolationMode: 'per-task' } },
       {
         autopilot: {
-          defaultExecutionMode: 'not-a-mode',
+          defaultHandsOff: 'not-a-boolean',
           isolationMode: 'invalid',
         },
       },
     );
-    assert.equal(merged.autopilot.defaultExecutionMode, 'auto');
+    assert.equal(merged.autopilot.defaultHandsOff, true);
     assert.equal(merged.autopilot.isolationMode, 'per-task');
   });
 
@@ -456,7 +463,7 @@ describe('mergeConfigMeta autopilot', () => {
     const merged = mergeConfigMeta(
       {
         autopilot: {
-          defaultExecutionMode: 'manual',
+          defaultHandsOff: false,
           maxConcurrentTasks: 3,
           isolationMode: 'auto',
           maxTestAttempts: 3,
@@ -473,7 +480,7 @@ describe('mergeConfigMeta autopilot', () => {
     assert.equal(merged.autopilot.maxConcurrentTasks, 7);
     assert.equal(merged.autopilot.plannerProviderId, 'p1');
     assert.equal(merged.autopilot.plannerModelId, 'm2');
-    assert.equal(merged.autopilot.defaultExecutionMode, 'manual');
+    assert.equal(merged.autopilot.defaultHandsOff, false);
   });
 });
 

--- a/test/state/chat-groups.test.mts
+++ b/test/state/chat-groups.test.mts
@@ -293,7 +293,7 @@ describe('chat groups', () => {
         lastUpdatedAt: 1,
         timerAccumulatedMs: 0,
         maxConcurrentTasks: 3,
-        executionMode: 'manual' as const,
+        maxConcurrentTasks: 1,
       },
     };
     const planner = createEmptyChatObject('', WS);

--- a/test/state/orchestrate-board-hydrate.test.mts
+++ b/test/state/orchestrate-board-hydrate.test.mts
@@ -1,5 +1,5 @@
 /**
- * Orchestrate board session hydration: autoRunning, executionMode, finalTest.
+ * Orchestrate board session hydration: autoRunning, hands-off, concurrency, finalTest.
  */
 
 import assert from 'node:assert/strict';
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, test } from 'node:test';
 import { STORAGE_KEY } from '../../src/constants.ts';
 import {
   stopBoardAutoRun,
-  setBoardExecutionMode,
+  setBoardHandsOff,
 } from '../../src/state/orchestrate-board-actions.ts';
 import { initBoard, isBoardRunning } from '../../src/state/orchestrate-board-store.ts';
 import {
@@ -50,7 +50,7 @@ function makeGroup(): ChatGroup {
   };
 }
 
-function seedRunningBoard(executionMode: 'auto' | 'sequential' = 'auto') {
+function seedRunningBoard(concurrency = 3) {
   const planner = makePlanner();
   const group = makeGroup();
   initBoard(group, planner, {
@@ -67,7 +67,7 @@ function seedRunningBoard(executionMode: 'auto' | 'sequential' = 'auto') {
     ],
   });
   const board = group.orchestrateBoard!;
-  board.executionMode = executionMode;
+  board.maxConcurrentTasks = concurrency;
   board.autoRunning = true;
   setSessionStateForTests({
     version: 5,
@@ -122,12 +122,14 @@ const PERSISTED_GROUP = {
 };
 
 describe('orchestrate board hydration', () => {
-  test('restores autoRunning, sequential executionMode, and finalTest', () => {
+  test('migrates legacy sequential to concurrency 1 and restores finalTest', () => {
     const [group] = hydrateSessionGroupsForTests([PERSISTED_GROUP]);
     assert.ok(group);
     const board = group.orchestrateBoard;
     assert.ok(board);
-    assert.equal(board.executionMode, 'sequential');
+    assert.equal(board.executionMode, undefined);
+    assert.equal(board.maxConcurrentTasks, 1);
+    assert.equal(board.handsOff, undefined);
     assert.equal(board.autoRunning, true);
     assert.equal(board.finalTest?.status, 'in_progress');
     assert.equal(board.finalTest?.chatId, '33333333-3333-3333-3333-333333333333');
@@ -144,7 +146,6 @@ describe('orchestrate board hydration', () => {
         orchestrateBoard: {
           ...PERSISTED_GROUP.orchestrateBoard,
           autoRunning: false,
-          executionMode: 'manual',
           tasks: [
             {
               id: 'W1-A',
@@ -189,50 +190,56 @@ describe('orchestrate board hydration', () => {
     assert.equal(dependent?.quarantine?.summary, 'blocked by quarantined W1-A');
   });
 
-  test('restores afk executionMode and autoRunning', () => {
+  function hydrateWithBoard(patch: Record<string, unknown>) {
     const [group] = hydrateSessionGroupsForTests([
       {
         ...PERSISTED_GROUP,
-        orchestrateBoard: {
-          ...PERSISTED_GROUP.orchestrateBoard,
-          executionMode: 'afk',
-          autoRunning: true,
-        },
+        orchestrateBoard: { ...PERSISTED_GROUP.orchestrateBoard, ...patch },
       },
     ]);
-    assert.equal(group.orchestrateBoard?.executionMode, 'afk');
+    return group;
+  }
+
+  test('legacy afk migrates to handsOff and keeps autoRunning', () => {
+    const group = hydrateWithBoard({ executionMode: 'afk', autoRunning: true });
+    assert.equal(group.orchestrateBoard?.executionMode, undefined);
+    assert.equal(group.orchestrateBoard?.handsOff, true);
     assert.equal(group.orchestrateBoard?.autoRunning, true);
     assert.equal(isBoardRunning(group), true);
   });
 
-  test('drops autoRunning when false and coerces unknown executionMode to manual', () => {
-    const [group] = hydrateSessionGroupsForTests([
-      {
-        ...PERSISTED_GROUP,
-        orchestrateBoard: {
-          ...PERSISTED_GROUP.orchestrateBoard,
-          executionMode: 'turbo',
-          autoRunning: false,
-        },
-      },
-    ]);
-    assert.equal(group.orchestrateBoard?.executionMode, 'manual');
+  test('legacy auto keeps its concurrency and stays interactive', () => {
+    const group = hydrateWithBoard({
+      executionMode: 'auto',
+      maxConcurrentTasks: 5,
+      autoRunning: true,
+    });
+    assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 5);
+    assert.equal(group.orchestrateBoard?.handsOff, undefined);
+  });
+
+  test('legacy manual migrates to concurrency 1, stopped', () => {
+    const group = hydrateWithBoard({ executionMode: 'manual', autoRunning: true });
+    assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 1);
     assert.equal(group.orchestrateBoard?.autoRunning, undefined);
     assert.equal(isBoardRunning(group), false);
   });
 
-  test('manual mode with autoRunning true does not count as running', () => {
-    const [group] = hydrateSessionGroupsForTests([
-      {
-        ...PERSISTED_GROUP,
-        orchestrateBoard: {
-          ...PERSISTED_GROUP.orchestrateBoard,
-          executionMode: 'manual',
-          autoRunning: true,
-        },
-      },
-    ]);
+  test('junk executionMode is dropped and leaves the board untouched', () => {
+    const group = hydrateWithBoard({
+      executionMode: 'turbo',
+      maxConcurrentTasks: 4,
+      autoRunning: false,
+    });
+    assert.equal(group.orchestrateBoard?.executionMode, undefined);
+    assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 4);
+    assert.equal(group.orchestrateBoard?.autoRunning, undefined);
     assert.equal(isBoardRunning(group), false);
+  });
+
+  test('worktreeSlug survives a round trip', () => {
+    const group = hydrateWithBoard({ worktreeSlug: 'checkout-flow' });
+    assert.equal(group.orchestrateBoard?.worktreeSlug, 'checkout-flow');
   });
 
   test('restores board diagnostic log events on reload', () => {
@@ -284,7 +291,7 @@ describe('orchestrate board stop persistence', () => {
   });
 
   test('stopBoardAutoRun persists stopped state without debounced flush', () => {
-    const { planner, group } = seedRunningBoard('auto');
+    const { planner, group } = seedRunningBoard(3);
     saveSessionsNow();
     assert.equal(
       readPersistedGroupsFromLocalStorage()[0]?.orchestrateBoard?.autoRunning,
@@ -299,20 +306,29 @@ describe('orchestrate board stop persistence', () => {
     assert.equal(isBoardRunning(persisted), false);
   });
 
-  test('setBoardExecutionMode manual persists stopped state without debounced flush', () => {
-    const { planner, group } = seedRunningBoard('sequential');
+  test('setBoardHandsOff persists hands-off without a stored mode string', () => {
+    const { planner, group } = seedRunningBoard(1);
     saveSessionsNow();
     assert.equal(
       readPersistedGroupsFromLocalStorage()[0]?.orchestrateBoard?.autoRunning,
       true,
     );
 
-    setBoardExecutionMode(group, 'manual', planner);
+    setBoardHandsOff(group, true, planner);
+    saveSessionsNow();
 
     const [persisted] = readPersistedGroupsFromLocalStorage();
     assert.ok(persisted);
-    assert.equal(persisted.orchestrateBoard?.executionMode, 'manual');
-    assert.equal(persisted.orchestrateBoard?.autoRunning, undefined);
-    assert.equal(isBoardRunning(persisted), false);
+    assert.equal(persisted.orchestrateBoard?.handsOff, true);
+    assert.equal(persisted.orchestrateBoard?.executionMode, undefined);
+    // Hands-off is available at concurrency 1 — it does not lift the cap.
+    assert.equal(persisted.orchestrateBoard?.maxConcurrentTasks, 1);
+
+    setBoardHandsOff(group, false, planner);
+    saveSessionsNow();
+    assert.equal(
+      readPersistedGroupsFromLocalStorage()[0]?.orchestrateBoard?.handsOff,
+      undefined,
+    );
   });
 });

--- a/test/tools/board-tools.test.mts
+++ b/test/tools/board-tools.test.mts
@@ -77,7 +77,8 @@ type BoardStateJson = {
   lastUpdatedAt: number;
   timerAccumulatedMs: number;
   maxConcurrentTasks: number;
-  executionMode: string;
+  executionMode?: string;
+  handsOff?: boolean;
   log?: Array<{ type: string; level: string; message: string }>;
 };
 
@@ -91,7 +92,9 @@ function assertPlannedBoardInit(parsed: BoardStateJson): void {
   assert.equal(parsed.lastUpdatedAt, FIXED_NOW);
   assert.equal(parsed.timerAccumulatedMs, 0);
   assert.equal(parsed.maxConcurrentTasks, 3);
-  assert.equal(parsed.executionMode, 'manual');
+  // Mode is derived now, never persisted onto the board.
+  assert.equal(parsed.executionMode, undefined);
+  assert.equal(parsed.handsOff, undefined);
   assert.deepEqual(parsed.tasks, [
     {
       id: 'W1-A',
@@ -119,7 +122,9 @@ function assertInProgressBoardState(parsed: BoardStateJson): void {
   assert.equal(parsed.lastUpdatedAt, FIXED_NOW);
   assert.equal(parsed.timerAccumulatedMs, 0);
   assert.equal(parsed.maxConcurrentTasks, 3);
-  assert.equal(parsed.executionMode, 'manual');
+  // Mode is derived now, never persisted onto the board.
+  assert.equal(parsed.executionMode, undefined);
+  assert.equal(parsed.handsOff, undefined);
   assert.deepEqual(parsed.tasks, [
     {
       id: 'W1-A',
@@ -970,35 +975,60 @@ async function seedInitializedBoard() {
 }
 
 describe('validateBoardSetAutonomyArgs', () => {
-  for (const level of ['manual', 'sequential', 'auto', 'afk'] as const) {
-    test(`accepts level ${level}`, () => {
-      const r = validateBoardSetAutonomyArgs({ level });
-      assert.equal(r.ok, true);
-      if (r.ok) assert.equal(r.args.level, level);
-    });
-  }
+  test('accepts concurrency, handsOff, or both', () => {
+    const conc = validateBoardSetAutonomyArgs({ concurrency: 4 });
+    assert.equal(conc.ok, true);
+    if (conc.ok) assert.deepEqual(conc.args, { concurrency: 4 });
 
-  test('accepts mode alias', () => {
-    const r = validateBoardSetAutonomyArgs({ mode: 'Auto' });
+    const hands = validateBoardSetAutonomyArgs({ handsOff: true });
+    assert.equal(hands.ok, true);
+    if (hands.ok) assert.deepEqual(hands.args, { handsOff: true });
+
+    const both = validateBoardSetAutonomyArgs({ concurrency: 2, handsOff: false });
+    assert.equal(both.ok, true);
+    if (both.ok) assert.deepEqual(both.args, { concurrency: 2, handsOff: false });
+  });
+
+  test('accepts snake_case aliases', () => {
+    const r = validateBoardSetAutonomyArgs({ max_concurrent_tasks: 6, hands_off: true });
     assert.equal(r.ok, true);
-    if (r.ok) assert.equal(r.args.level, 'auto');
+    if (r.ok) assert.deepEqual(r.args, { concurrency: 6, handsOff: true });
   });
 
-  test('rejects missing level', () => {
+  test('folds legacy level strings onto the two fields', () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ['afk', { handsOff: true }],
+      ['sequential', { concurrency: 1 }],
+      ['manual', { concurrency: 1 }],
+    ];
+    for (const [level, expected] of cases) {
+      const r = validateBoardSetAutonomyArgs({ level });
+      assert.equal(r.ok, true, level);
+      if (r.ok) assert.deepEqual(r.args, expected, level);
+    }
+  });
+
+  test('rejects an empty call', () => {
     const r = validateBoardSetAutonomyArgs({});
-    assert.equal(r.ok, false);
-    if (!r.ok) assert.equal(r.error, 'Error: board_set_autonomy requires "level"');
-  });
-
-  test('rejects invalid level', () => {
-    const r = validateBoardSetAutonomyArgs({ level: 'turbo' });
     assert.equal(r.ok, false);
     if (!r.ok) {
       assert.equal(
         r.error,
-        'Error: board_set_autonomy requires level manual, sequential, auto, or afk',
+        'Error: board_set_autonomy requires "concurrency" and/or "handsOff"',
       );
     }
+  });
+
+  test('rejects out-of-range concurrency and non-boolean handsOff', () => {
+    const tooHigh = validateBoardSetAutonomyArgs({ concurrency: 99 });
+    assert.equal(tooHigh.ok, false);
+    const notBool = validateBoardSetAutonomyArgs({ handsOff: 'yes' });
+    assert.equal(notBool.ok, false);
+  });
+
+  test('rejects an unknown legacy level', () => {
+    const r = validateBoardSetAutonomyArgs({ level: 'turbo' });
+    assert.equal(r.ok, false);
   });
 });
 
@@ -1009,51 +1039,48 @@ describe('executeBoardSetAutonomy', () => {
     setBoardExecutorContext(null);
   });
 
-  test('auto sets executionMode and autoRunning', async () => {
+  test('concurrency >1 sets the cap, starts the run, and derives auto', async () => {
     await seedInitializedBoard();
-    const out = await executeBoardTool('board_set_autonomy', { level: 'auto' });
-    assert.equal(
-      out,
-      '{"level":"auto","executionMode":"auto","autoRunning":true,"pendingAfk":false}',
-    );
-    const chat = findChatById(CHAT_ID)!;
-    const group = getOrCreateBoardGroup(chat);
-    assert.equal(group.orchestrateBoard?.executionMode, 'auto');
-    assert.equal(group.orchestrateBoard?.autoRunning, true);
-  });
-
-  test('sequential sets executionMode and autoRunning', async () => {
-    await seedInitializedBoard();
-    const out = await executeBoardTool('board_set_autonomy', { level: 'sequential' });
-    assert.equal(
-      out,
-      '{"level":"sequential","executionMode":"sequential","autoRunning":true,"pendingAfk":false}',
-    );
-    const chat = findChatById(CHAT_ID)!;
-    const group = getOrCreateBoardGroup(chat);
-    assert.equal(group.orchestrateBoard?.executionMode, 'sequential');
-    assert.equal(group.orchestrateBoard?.autoRunning, true);
-  });
-
-  test('afk sets pendingAfk without changing executionMode', async () => {
-    await seedInitializedBoard();
-    const out = await executeBoardTool('board_set_autonomy', { level: 'afk' });
+    const out = await executeBoardTool('board_set_autonomy', { concurrency: 4 });
     const parsed = JSON.parse(out);
-    assert.equal(parsed.level, 'afk');
-    assert.equal(parsed.executionMode, 'manual');
+    assert.equal(parsed.concurrency, 4);
+    assert.equal(parsed.handsOff, false);
+    assert.equal(parsed.executionMode, 'auto');
+    assert.equal(parsed.autoRunning, true);
+    assert.equal(parsed.pendingHandsOff, false);
+    const chat = findChatById(CHAT_ID)!;
+    const group = getOrCreateBoardGroup(chat);
+    assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 4);
+    assert.equal(group.orchestrateBoard?.autoRunning, true);
+  });
+
+  test('concurrency 1 derives sequential', async () => {
+    await seedInitializedBoard();
+    const out = await executeBoardTool('board_set_autonomy', { concurrency: 1 });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.concurrency, 1);
+    assert.equal(parsed.executionMode, 'sequential');
+    assert.equal(parsed.autoRunning, true);
+  });
+
+  test('handsOff only requests — the user confirms on the board', async () => {
+    await seedInitializedBoard();
+    const out = await executeBoardTool('board_set_autonomy', { handsOff: true });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.handsOff, false);
+    assert.equal(parsed.pendingHandsOff, true);
     assert.equal(parsed.autoRunning, false);
-    assert.equal(parsed.pendingAfk, true);
     assert.match(parsed.message, /pending user confirmation/i);
     const chat = findChatById(CHAT_ID)!;
     const group = getOrCreateBoardGroup(chat);
-    assert.equal(group.orchestrateBoard?.executionMode, 'manual');
+    assert.equal(group.orchestrateBoard?.handsOff, undefined);
     assert.equal(group.orchestrateBoard?.pendingAfk, true);
   });
 
   test('rejects non-planner caller', async () => {
     seedOrchestrateChat({ modeId: 'build' });
     withBoardContext();
-    const out = await executeBoardTool('board_set_autonomy', { level: 'auto' });
+    const out = await executeBoardTool('board_set_autonomy', { concurrency: 3 });
     assert.equal(out, 'Error: board tools require an active Orchestrate chat');
   });
 });
@@ -1071,13 +1098,14 @@ describe('autopilot resolution', () => {
       waves: [],
       startedAt: 1,
       lastUpdatedAt: 1,
-      executionMode: 'auto' as const,
     };
     assert.equal(resolveBoardMaxConcurrent(board), 8);
     assert.equal(resolveBoardMaxConcurrent({ ...board, maxConcurrentTasks: 5 }), 5);
     resetAutopilotMetaCache();
     assert.equal(resolveBoardMaxConcurrent(board), 3);
-    assert.equal(resolveBoardMaxConcurrent({ ...board, executionMode: 'sequential' }), 1);
+    // Concurrency is the input to the mode derivation, so it must not read back
+    // from the mode — that would be circular.
+    assert.equal(resolveBoardMaxConcurrent({ ...board, maxConcurrentTasks: 1 }), 1);
   });
 
   test('test thresholds read global meta only', () => {
@@ -1089,8 +1117,8 @@ describe('autopilot resolution', () => {
     assert.equal(resolveMaxFinalTestAttempts(), 3);
   });
 
-  test('initBoard inherits global default execution mode', () => {
-    setAutopilotMetaForTests({ defaultExecutionMode: 'auto', maxConcurrentTasks: 6 });
+  test('initBoard inherits global concurrency and hands-off defaults', () => {
+    setAutopilotMetaForTests({ defaultHandsOff: true, maxConcurrentTasks: 6 });
     seedOrchestrateChat();
     const chat = findChatById(CHAT_ID)!;
     const group = getOrCreateBoardGroup(chat);
@@ -1099,7 +1127,21 @@ describe('autopilot resolution', () => {
       tasks: [{ id: 'W1-A', title: 'T', wave: 'W1', category: 'build' }],
       waves: [{ id: 'W1' }],
     });
-    assert.equal(group.orchestrateBoard?.executionMode, 'auto');
+    assert.equal(group.orchestrateBoard?.executionMode, undefined);
+    assert.equal(group.orchestrateBoard?.handsOff, true);
     assert.equal(group.orchestrateBoard?.maxConcurrentTasks, 6);
+  });
+
+  test('initBoard leaves hands-off unset when the global default is off', () => {
+    setAutopilotMetaForTests({ defaultHandsOff: false, maxConcurrentTasks: 2 });
+    seedOrchestrateChat();
+    const chat = findChatById(CHAT_ID)!;
+    const group = getOrCreateBoardGroup(chat);
+    initBoard(group, chat, {
+      planPath: PLAN_PATH,
+      tasks: [{ id: 'W1-A', title: 'T', wave: 'W1', category: 'build' }],
+      waves: [{ id: 'W1' }],
+    });
+    assert.equal(group.orchestrateBoard?.handsOff, undefined);
   });
 });

--- a/test/tools/permission-gate.test.mts
+++ b/test/tools/permission-gate.test.mts
@@ -125,7 +125,7 @@ describe('AFK interaction execution guard', () => {
       tasks: [{ id: 'W1-A', title: 'Task', wave: 'W1', category: 'build' }],
       waves: [{ id: 'W1' }],
     });
-    group.orchestrateBoard!.executionMode = 'afk';
+    group.orchestrateBoard!.handsOff = true;
     const config = defaultToolConfig();
     config.enabled.ask_question = true;
     config.permissions.default.ask_question = 'full';

--- a/test/ui/orchestrate-board-dnd-dom.test.mjs
+++ b/test/ui/orchestrate-board-dnd-dom.test.mjs
@@ -1,0 +1,241 @@
+/**
+ * Phase 3 board DOM: cards are draggable, columns are drop targets, status-move
+ * buttons are gone, and the header carries the run-help and bulk-recovery controls.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+import { installHappyDomGlobals, teardownHappyDomAsync } from '../os/dom-helpers.mts';
+
+const FIXED_CHAT_ID = '51111111-1111-1111-1111-111111111111';
+const FIXED_GROUP_ID = 'grp_51111111-1111-1111-1111-111111111111';
+const PLAN_PATH = 'documentation/plans/fixture-plan.md';
+
+const { setSessionStateForTests, createEmptyChatObject } = await import(
+  '../../src/state/sessions.ts'
+);
+const { initBoard, updateTask, setBoardNowForTests } = await import(
+  '../../src/state/orchestrate-board-store.ts'
+);
+const { renderBoardView, disposeBoardViewForTests } = await import(
+  '../../src/ui/orchestrate-board.ts'
+);
+const { clearBoardListenersForTests } = await import(
+  '../../src/state/orchestrate-board-events.ts'
+);
+const { loadSubAgentConfig, resetSubAgentConfigCache, setRuntimeSubAgentOverrides } =
+  await import('../../src/agents/sub-agent-config.ts');
+
+/** @type {import('happy-dom').Window | undefined} */
+let win;
+let savedFetch;
+
+function installTestFetch() {
+  savedFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (url.includes('/api/config/meta')) {
+      return Response.json({ terminal: { open: false, tabs: [], activeTabId: null } });
+    }
+    return Response.json({ ok: true });
+  };
+}
+
+function setupDom() {
+  win = new Window();
+  installTestFetch();
+  installHappyDomGlobals(win, { fetch: globalThis.fetch });
+  globalThis.HTMLSelectElement = win.HTMLSelectElement;
+  for (const id of ['chatArea', 'mainColumn', 'msgInput']) {
+    const el = document.createElement('div');
+    el.id = id;
+    document.body.appendChild(el);
+  }
+  const modelSelect = document.createElement('select');
+  modelSelect.id = 'modelSelect';
+  document.body.appendChild(modelSelect);
+}
+
+async function primeSubAgentConfig() {
+  resetSubAgentConfigCache();
+  setRuntimeSubAgentOverrides({
+    globalMaxConcurrent: 4,
+    types: { builder: { enabled: true, maxConcurrent: 2 } },
+  });
+  await loadSubAgentConfig();
+}
+
+async function waitForKanban() {
+  const deadline = Date.now() + 8000;
+  while (Date.now() < deadline) {
+    if (document.querySelector('.kanban-grid')) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('kanban grid not rendered');
+}
+
+function makeBoard(tasks) {
+  const chat = createEmptyChatObject('');
+  chat.id = FIXED_CHAT_ID;
+  chat.modeId = 'orchestrate';
+  chat.viewMode = 'board';
+  chat.orchestratePlanPath = PLAN_PATH;
+
+  const group = {
+    id: FIXED_GROUP_ID,
+    name: 'Fixture Board',
+    workspacePath: '',
+    collapsed: false,
+    order: 0,
+    createdAt: 1,
+    plannerChatId: chat.id,
+    orchestratePlanPath: PLAN_PATH,
+    viewMode: 'board',
+  };
+  initBoard(group, chat, {
+    planPath: PLAN_PATH,
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      title: t.title,
+      wave: 'W1',
+      category: 'build',
+    })),
+    waves: [{ id: 'W1' }],
+  });
+  chat.boardGroupId = group.id;
+  chat.groupId = group.id;
+  for (const t of tasks) {
+    if (t.status) updateTask(group, t.id, { status: t.status });
+  }
+  setSessionStateForTests({
+    version: 2,
+    activeId: chat.id,
+    activeBoardGroupId: group.id,
+    sidebarCollapsed: false,
+    chats: [chat],
+    groups: [group],
+  });
+  return group;
+}
+
+describe('orchestrate board drag affordances (Phase 3)', { concurrency: false }, () => {
+  afterEach(async () => {
+    disposeBoardViewForTests();
+    clearBoardListenersForTests();
+    setSessionStateForTests(null);
+    setBoardNowForTests(null);
+    resetSubAgentConfigCache();
+    if (savedFetch) globalThis.fetch = savedFetch;
+    await teardownHappyDomAsync(win);
+    win = undefined;
+  });
+
+  test('cards are draggable and carry their status; merging cards are not', async () => {
+    setupDom();
+    await primeSubAgentConfig();
+    setBoardNowForTests(() => 1_700_000_000_000);
+    const group = makeBoard([
+      { id: 'W1-A', title: 'Task A', status: 'planned' },
+      { id: 'W1-B', title: 'Task B', status: 'merging' },
+    ]);
+
+    renderBoardView(group);
+    await waitForKanban();
+
+    const planned = document.querySelector('[data-board-task-id="W1-A"]');
+    assert.ok(planned, 'planned card rendered');
+    assert.equal(planned.getAttribute('draggable'), 'true');
+    assert.equal(planned.getAttribute('data-board-task-status'), 'planned');
+
+    const merging = document.querySelector('[data-board-task-id="W1-B"]');
+    assert.ok(merging, 'merging card rendered');
+    assert.notEqual(
+      merging.getAttribute('draggable'),
+      'true',
+      'a mid-merge card must not be draggable',
+    );
+  });
+
+  test('status-move buttons are gone; recoverable cards keep Requeue and Reset', async () => {
+    setupDom();
+    await primeSubAgentConfig();
+    setBoardNowForTests(() => 1_700_000_000_000);
+    const group = makeBoard([
+      { id: 'W1-A', title: 'Task A', status: 'planned' },
+      { id: 'W1-B', title: 'Task B', status: 'failed' },
+    ]);
+
+    renderBoardView(group);
+    await waitForKanban();
+
+    const plannedActions = [
+      ...document
+        .querySelector('[data-board-task-id="W1-A"]')
+        .querySelectorAll('.board-task-card__advance-label'),
+    ].map((el) => el.textContent);
+    assert.deepEqual(
+      plannedActions,
+      [],
+      'a planned card has no status-move button — that is a drag now',
+    );
+
+    const failedActions = [
+      ...document
+        .querySelector('[data-board-task-id="W1-B"]')
+        .querySelectorAll('.board-task-card__advance-label'),
+    ].map((el) => el.textContent);
+    assert.ok(failedActions.includes('Requeue'), 'failed cards get a real Requeue');
+    assert.ok(failedActions.includes('Reset'), 'and a Reset for a fresh worktree');
+    assert.equal(
+      failedActions.includes('Reopen'),
+      false,
+      'the fake Reopen that left buildAttempts maxed is gone',
+    );
+  });
+
+  test('header carries the run-settings help button', async () => {
+    setupDom();
+    await primeSubAgentConfig();
+    setBoardNowForTests(() => 1_700_000_000_000);
+    const group = makeBoard([{ id: 'W1-A', title: 'Task A', status: 'planned' }]);
+
+    renderBoardView(group);
+    await waitForKanban();
+
+    const help = document.querySelector('[data-board-action="run-help"]');
+    assert.ok(help, 'run-settings explainer is reachable from the header');
+    assert.equal(help.getAttribute('aria-label'), 'About run settings');
+  });
+
+  test('bulk recovery control appears only when a task is recoverable', async () => {
+    setupDom();
+    await primeSubAgentConfig();
+    setBoardNowForTests(() => 1_700_000_000_000);
+    const group = makeBoard([{ id: 'W1-A', title: 'Task A', status: 'planned' }]);
+
+    renderBoardView(group);
+    await waitForKanban();
+    assert.equal(
+      document.querySelector('[data-board-action="bulk-requeue"]'),
+      null,
+      'nothing failed yet, so no bulk control',
+    );
+
+    disposeBoardViewForTests();
+    const failedGroup = makeBoard([
+      { id: 'W1-A', title: 'Task A', status: 'failed' },
+      { id: 'W1-B', title: 'Task B', status: 'quarantined' },
+    ]);
+    renderBoardView(failedGroup);
+    await waitForKanban();
+
+    const bulk = document.querySelector('[data-board-action="bulk-requeue"]');
+    assert.ok(bulk, 'bulk control shows once tasks are recoverable');
+    assert.equal(
+      bulk.querySelector('.board-header__bulk-requeue-primary').textContent,
+      'Requeue 2 failed',
+    );
+    assert.ok(group);
+  });
+});

--- a/test/ui/orchestrate-board-live-update.test.mjs
+++ b/test/ui/orchestrate-board-live-update.test.mjs
@@ -231,6 +231,16 @@ async function primeSubAgentConfig() {
   await loadSubAgentConfig();
 }
 
+/** Poll until `check()` is truthy — requeue is async (it awaits a dynamic import). */
+async function waitFor(check, label) {
+  const deadline = Date.now() + 8000;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
 async function waitForKanban() {
   const deadline = Date.now() + 8000;
   while (Date.now() < deadline) {
@@ -414,30 +424,42 @@ describe('orchestrate board live updates', { concurrency: false }, () => {
       tasks: [{ id: 'W1-A', title: 'Task A', wave: 'W1', category: 'build' }],
       waves: [{ id: 'W1' }],
     });
-    updateTask(group, 'W1-A', { status: 'complete' });
+    // `failed` is the recoverable case that keeps a card button; status *moves*
+    // are drag-and-drop now, so there is no Reopen button to click.
+    updateTask(group, 'W1-A', { status: 'failed', buildAttempts: 3 });
     setSessionStateForTests(sessionStateForBoard(chat, group));
 
     renderBoardView(group);
     await waitForKanban();
 
-    const reopenBtn = document.querySelector(
+    const requeueBtn = document.querySelector(
       `${kanbanColumnSelector('complete')} .board-task-card__advance-btn`,
     );
-    assert.ok(reopenBtn, 'complete column shows Reopen');
-    reopenBtn.focus();
-    assert.equal(document.activeElement, reopenBtn);
+    assert.ok(requeueBtn, 'failed card shows Requeue');
+    requeueBtn.focus();
+    assert.equal(document.activeElement, requeueBtn);
 
-    reopenBtn.click();
-    await waitForKanban();
+    requeueBtn.click();
+    await waitFor(
+      () =>
+        document.querySelectorAll(`${kanbanColumnSelector('planned')} .board-task-card`)
+          .length === 1,
+      'requeued card to land in Planned',
+    );
 
     assert.equal(
       document.querySelectorAll(`${kanbanColumnSelector('planned')} .board-task-card`).length,
       1,
-      'reopened task should move to Planned without a second click',
+      'requeued task should move to Planned without a second click',
     );
     assert.equal(
       document.querySelectorAll(`${kanbanColumnSelector('complete')} .board-task-card`).length,
       0,
+    );
+    assert.equal(
+      group.orchestrateBoard.tasks[0].buildAttempts,
+      undefined,
+      'requeue resets the retry budget instead of re-failing immediately',
     );
   });
 

--- a/test/ui/orchestrate-board-live-update.test.mjs
+++ b/test/ui/orchestrate-board-live-update.test.mjs
@@ -780,7 +780,7 @@ describe('orchestrate board live updates', { concurrency: false }, () => {
     assert.equal(document.getElementById('btnViewModeToggleChat'), null);
   });
 
-  test('isolation select still works after switching to AFK', async () => {
+  test('isolation select still works after enabling hands-off', async () => {
     setupDom();
     setBoardNowForTests(() => 1_700_000_000_000);
     const chat = makeOrchestrateChat();
@@ -793,22 +793,23 @@ describe('orchestrate board live updates', { concurrency: false }, () => {
 
     renderBoardView(group);
 
-    const afkBtn = document.querySelector('[data-exec-mode="afk"]');
+    const handsOff = document.querySelector('.board-header__hands-off-input');
     const isoSelect = document.querySelector('.board-header__isolation-select');
-    assert.ok(afkBtn);
-    assert.ok(isoSelect instanceof HTMLSelectElement);
+    assert.ok(handsOff);
+    assert.ok(isoSelect instanceof window.HTMLSelectElement);
 
     const confirmStub = () => true;
     const priorConfirm = globalThis.window.confirm;
     globalThis.window.confirm = confirmStub;
     try {
-      afkBtn.click();
+      handsOff.checked = true;
+      handsOff.dispatchEvent(new window.Event('change', { bubbles: true }));
       await new Promise((resolve) => setTimeout(resolve, 0));
       const confirmBtn = document.querySelector('[data-dialog-action="confirm"]');
-      assert.ok(confirmBtn, 'AFK switch should open appConfirm dialog');
+      assert.ok(confirmBtn, 'hands-off should open appConfirm dialog');
       confirmBtn.click();
       await new Promise((resolve) => setTimeout(resolve, 20));
-      assert.equal(group.orchestrateBoard?.executionMode, 'afk');
+      assert.equal(group.orchestrateBoard?.handsOff, true);
 
       isoSelect.value = 'per-wave';
       isoSelect.dispatchEvent(new window.Event('change', { bubbles: true }));

--- a/test/ui/orchestrate-landing-target.test.mts
+++ b/test/ui/orchestrate-landing-target.test.mts
@@ -1,0 +1,110 @@
+/**
+ * Phase 3.4: entering Orchestrator returns to the board the user was inside,
+ * falling back to a running board and only then to the hub.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { resolveOrchestrateLandingTarget } from '../../src/ui/orchestrate-hub.ts';
+import { initBoard } from '../../src/state/orchestrate-board-store.ts';
+import { getOrCreateBoardGroup } from '../../src/state/chat-groups.ts';
+import {
+  createEmptyChatObject,
+  sessionState,
+  setSessionStateForTests,
+} from '../../src/state/sessions.ts';
+import {
+  resetWorkspaceStateForTests,
+  setWorkspaceFromServer,
+} from '../../src/state/workspace.ts';
+import type { Chat, ChatGroup } from '../../src/types.ts';
+
+const WORKSPACE = '/tmp/orchestrate-landing-test';
+
+function makePlanner(planPath: string): Chat {
+  const chat = createEmptyChatObject('m1');
+  chat.workspacePath = WORKSPACE;
+  chat.modeId = 'orchestrate';
+  chat.orchestratePlanPath = planPath;
+  return chat;
+}
+
+/** Seed a session with N board folders; returns them in creation order. */
+function seedBoards(count: number): ChatGroup[] {
+  const planners = Array.from({ length: count }, (_, i) =>
+    makePlanner(`documentation/plans/plan-${i}.md`),
+  );
+  setSessionStateForTests({
+    version: 5,
+    activeId: planners[0]!.id,
+    sidebarCollapsed: false,
+    groups: [],
+    chats: planners,
+  });
+
+  return planners.map((planner, i) => {
+    const group = getOrCreateBoardGroup(planner);
+    initBoard(group, planner, {
+      planPath: `documentation/plans/plan-${i}.md`,
+      tasks: [{ id: 't1', title: 'One', wave: 1, category: 'code' }],
+      waves: [{ id: 'W1' }],
+    });
+    return group;
+  });
+}
+
+describe('resolveOrchestrateLandingTarget (Phase 3.4)', () => {
+  beforeEach(() => {
+    setWorkspaceFromServer({ path: WORKSPACE, label: 'landing', isDefault: false });
+  });
+
+  afterEach(() => {
+    setSessionStateForTests(null);
+    resetWorkspaceStateForTests();
+  });
+
+  test('returns null with no boards, so the hub stays the destination', () => {
+    setSessionStateForTests({
+      version: 5,
+      activeId: '',
+      sidebarCollapsed: false,
+      groups: [],
+      chats: [],
+    });
+    assert.equal(resolveOrchestrateLandingTarget(), null);
+  });
+
+  test('resumes the last board the user was inside', () => {
+    const [first, second] = seedBoards(2);
+    sessionState!.lastBoardGroupId = second!.id;
+
+    assert.equal(resolveOrchestrateLandingTarget()?.id, second!.id);
+    assert.notEqual(resolveOrchestrateLandingTarget()?.id, first!.id);
+  });
+
+  test('ignores a last-board pointer at a group that no longer exists', () => {
+    seedBoards(1);
+    sessionState!.lastBoardGroupId = 'grp_deleted';
+    // No board is running, so there is nothing else to fall back to.
+    assert.equal(resolveOrchestrateLandingTarget(), null);
+  });
+
+  test('falls back to a running board when there is no last board', () => {
+    const [first, second] = seedBoards(2);
+    delete sessionState!.lastBoardGroupId;
+    second!.orchestrateBoard!.autoRunning = true;
+
+    assert.equal(
+      resolveOrchestrateLandingTarget()?.id,
+      second!.id,
+      'a board still doing work is the one worth returning to',
+    );
+    assert.ok(first);
+  });
+
+  test('a stopped board alone is not a landing target', () => {
+    seedBoards(1);
+    delete sessionState!.lastBoardGroupId;
+    assert.equal(resolveOrchestrateLandingTarget(), null);
+  });
+});

--- a/test/ui/workspace-switch-guard.test.mts
+++ b/test/ui/workspace-switch-guard.test.mts
@@ -71,7 +71,7 @@ function seedRunningBoard(): { planner: Chat; group: ChatGroup } {
     ],
   });
   const board = group.orchestrateBoard!;
-  board.executionMode = 'auto';
+  board.maxConcurrentTasks = 3;
   board.autoRunning = true;
   setSessionStateForTests({
     version: 5,


### PR DESCRIPTION
## Summary

Four-phase cleanup of the Orchestrate board's execution model, worktree lifecycle, kanban UX, and finish report. Each phase landed as its own commit.

- **P1 — Execution model**: replaces the four-value `executionMode` (`manual|sequential|auto|afk`) with two orthogonal controls, `maxConcurrentTasks` (parallelism) and `handsOff` (autonomy), derived rather than stored. Adds `per-board` isolation and stable, readable worktree slugs/names.
- **P2 — Worktree lifecycle**: merged per-task worktrees are removed once verified (branch kept), fixing the leaked-worktree bug on board-folder delete, and unblocking **Commit & push** when a board ran with isolation off (new **Review & commit** path against the live workspace).
- **P3 — Board UX**: kanban cards drag between lanes (with keyboard parity and a running-task confirm), **Requeue**/**Reset** replace a fake "Reopen" that left retry counters maxed out, an info lightbox explains the run settings, and entering Orchestrator resumes your last board instead of always showing the hub.
- **P4 — Finish report**: the report is reachable on the first final-test failure regardless of the mix of terminal task statuses (previously required every task to be `complete`), a new `board_add_tasks` tool lets **Fix integration failures** append a real follow-up task instead of reopening tasks that already passed, and "How to run" instructions come from what the final tester actually verified (or detected project manifests as a labelled fallback) instead of a hardcoded `npm install && npm start`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `node --import ./test/test-loader.mjs --import tsx --experimental-test-module-mocks --test --test-force-exit test/orchestrate/ test/state/orchestrate-board-*.test.mts test/tools/board-tools.test.mts test/server/validate-orchestrate-board.test.mjs` — 673 passing, 0 failing
- [x] New coverage: worktree release/requeue, drag→status-transition mapping, Requeue vs Reset, landing-target resolution, board_add_tasks validation, appendFinalTestFixTask, run-instructions round-trip
- [ ] Full in-app end-to-end (live model runs, real worktree dirs on disk) not exercised in this session — the full-stack dev server needs an interactive workspace pick that a headless session can't drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)