### PR TITLE
Keep the in-flight tool call visible across a chat switch

### DIFF
--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -914,7 +914,7 @@ async function streamCompletionTurn(
   getStreamDom: () => { bubble: HTMLDivElement; cursor: HTMLDivElement },
   signal: AbortSignal,
   thoughtController: ThoughtBubbleController | null,
-  domVisible: boolean,
+  isDomVisible: () => boolean,
   onFirstProseDelta?: () => void,
   onPartialText?: (fullText: string) => void,
   onToolCallStreaming?: (toolName: string) => void,
@@ -968,7 +968,7 @@ async function streamCompletionTurn(
     // Re-render what the aborted attempt already showed so the bubble never blanks.
     onFirstProseDelta?.();
     onPartialText?.(fullText);
-    if (domVisible) {
+    if (isDomVisible()) {
       const { bubble, cursor } = getStreamDom();
       scheduleAssistantBubbleRender(bubble, fullText, cursor);
     }
@@ -1022,7 +1022,7 @@ async function streamCompletionTurn(
     onFirstProseDelta?.();
     fullText += text;
     onPartialText?.(fullText);
-    if (domVisible) {
+    if (isDomVisible()) {
       const { bubble, cursor } = getStreamDom();
       scheduleAssistantBubbleRender(bubble, fullText, cursor);
     }
@@ -1113,7 +1113,9 @@ async function streamCompletionTurn(
       }
       thoughtController?.endReasoningPhase();
     }
-    if (domVisible && onToolCallStreaming) {
+    // Not gated on visibility: the name is announced once per round, and a chat the
+    // user returns to mid-call still needs it. The listener decides what to paint.
+    if (onToolCallStreaming) {
       const streamingName = getLatestStreamingToolName(toolAcc);
       if (streamingName && streamingName !== lastAnnouncedToolName) {
         lastAnnouncedToolName = streamingName;
@@ -1121,7 +1123,7 @@ async function streamCompletionTurn(
       }
     }
     emitStreamProgress();
-    if (domVisible) {
+    if (isDomVisible()) {
       scrollChatIfPinned();
     }
   }
@@ -1151,7 +1153,7 @@ async function streamCompletionTurn(
   // Decode and the renderer share one GPU, and a CSS animation costs a compositor frame
   // every vsync for as long as it runs — several tok/s, measurably, on a local serve. Step
   // the working indicators down to 8 Hz for the length of the stream. Not gated on
-  // `domVisible`: a background chat still spins a ring in the rail. No-op for cloud
+  // `isDomVisible()`: a background chat still spins a ring in the rail. No-op for cloud
   // providers, where there is no local decode to protect.
   const releaseTickedMotion = isLocalProvider(provider) ? acquireTickedMotion() : null;
 
@@ -1782,9 +1784,35 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
   // Track prose-awaiting without DOM class — stub rows in board view omit msg--awaiting-prose.
   let awaitingProse = true;
   let toolStartIndicator: ToolStartIndicatorHandle | null = null;
+  /**
+   * Tool whose arguments are still streaming, kept for the remount path.
+   *
+   * The stream announces a tool name once per round (`lastAnnouncedToolName`), so a
+   * shell that mounts after the announcement has no second chance to learn it — and a
+   * long argument stream (a file write carries the whole file) leaves the user staring
+   * at a bare caret for the rest of the call.
+   */
+  let streamingToolName: string | null = null;
+  const showToolStartIndicator = (toolName: string): void => {
+    if (!toolName.trim()) return;
+    // Remember it even while hidden — this is what the remount path replays.
+    streamingToolName = toolName;
+    if (!isStreamDomVisible(chat.id)) return;
+    if (!toolStartIndicator) {
+      toolStartIndicator = attachToolStartIndicator({
+        wrap,
+        bubble,
+        cursor,
+        streamStatus,
+      });
+    }
+    toolStartIndicator.show(toolName);
+  };
+  /** Round boundary: the pending call is finished, so drop the name with the row. */
   const resetToolStartIndicator = (): void => {
     toolStartIndicator?.dispose();
     toolStartIndicator = null;
+    streamingToolName = null;
   };
   let revealProse = (): void => {
     awaitingProse = false;
@@ -1806,7 +1834,9 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
     streamCtx.wrap = wrap;
     streamCtx.streamStatus = streamStatus;
     lastWrap = wrap;
-    resetToolStartIndicator();
+    // The handle died with the previous shell; the name is re-applied below.
+    toolStartIndicator?.dispose();
+    toolStartIndicator = null;
     awaitingProse = true;
     revealProse = (): void => {
       awaitingProse = false;
@@ -1819,6 +1849,10 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
       // left on an empty revealed bubble while tokens keep painting a detached node.
       revealProse();
       scheduleAssistantBubbleRender(bubble, livePartialText, cursor);
+    }
+    // Last, so it wins over the caret and stream-status the replay above reveals.
+    if (streamingToolName) {
+      showToolStartIndicator(streamingToolName);
     }
   });
 
@@ -2218,7 +2252,6 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
       }
 
       thoughtController.setAssistantWrap(wrap);
-      const domVisible = isStreamDomVisible(chat.id);
 
       const runStreamTurn = (
         turnBody: ChatCompletionBody,
@@ -2232,7 +2265,9 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
           () => ({ bubble, cursor }),
           chatSignal,
           thoughtController,
-          domVisible,
+          // Live check, not a per-round snapshot: the user can leave and come back
+          // mid-round, and the shell they come back to is a different one.
+          () => isStreamDomVisible(chat.id),
           () => {
             revealProse();
           },
@@ -2240,16 +2275,7 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
             livePartialText = text;
           },
           (toolName) => {
-            if (!domVisible) return;
-            if (!toolStartIndicator) {
-              toolStartIndicator = attachToolStartIndicator({
-                wrap,
-                bubble,
-                cursor,
-                streamStatus,
-              });
-            }
-            toolStartIndicator.show(toolName);
+            showToolStartIndicator(toolName);
           },
           undefined,
           () => {

--- a/src/tools/stream-chat-dom.ts
+++ b/src/tools/stream-chat-dom.ts
@@ -2,6 +2,7 @@
  * Remount in-flight stream rows when the user returns to a chat that is still streaming.
  */
 
+import { getMainTurnActivity } from '../chat/main-turn-activity';
 import { isChatStreaming, isStreamDomVisible } from '../chat/streaming-state';
 import { getSidebarStreamPhase } from '../ui/chat-item-dot';
 import type { StreamingAssistantRow } from '../ui/messages';
@@ -35,6 +36,14 @@ export function registerStreamDomRemount(
 /** After switchChat, attach a fresh stream shell if this chat is still in-flight. */
 export function remountStreamDomForChat(chatId: string): void {
   if (!isChatStreaming(chatId) || !isStreamDomVisible(chatId)) return;
+
+  /*
+   * Tool execution has no live stream shell by design: the loop drops the orphan
+   * row before running the batch, and the tool cards repaint from history on the
+   * way back. A caret here claims the model is generating while it is not, and
+   * reads as the tool card having been replaced by one (MIN-649 follow-up).
+   */
+  if (getMainTurnActivity(chatId)?.phase === 'tools') return;
 
   const listener = remountListeners.get(chatId);
   if (!listener) {

--- a/test/tools/tool-start-indicator-remount.test.mts
+++ b/test/tools/tool-start-indicator-remount.test.mts
@@ -1,0 +1,338 @@
+/**
+ * Switching chats mid-tool-call must not lose the "Calling {tool}…" indicator.
+ *
+ * The stream announces a tool name once per round, and a file write streams the whole
+ * file as arguments — so a shell mounted after the announcement used to sit on a bare
+ * "Generating response…" caret for the rest of the call.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+import type { Chat } from '../../src/types.ts';
+import { setSessionStateForTests } from '../../src/state/sessions.ts';
+import { endChatTurnSetup } from '../../src/chat/chat-turn-guard.ts';
+import { getChatAbort, setChatAbort, setStreaming } from '../../src/app-state.ts';
+import {
+  defaultToolConfig,
+  setToolConfigForTests,
+} from '../../src/tools/config.ts';
+
+const OTHER_CHAT_ID = '33333333-3333-4333-8333-333333333333';
+const TOOL_CALL_ID = 'call_indicator_remount';
+
+/** Each case gets its own chat and generation ids — the stores behind both are global. */
+interface TurnIds {
+  chatId: string;
+  genResume: string;
+  genRound2: string;
+}
+
+const VISIBLE: TurnIds = {
+  chatId: '22222222-2222-4222-8222-222222222222',
+  genResume: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  genRound2: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+};
+
+const HIDDEN: TurnIds = {
+  chatId: '44444444-4444-4444-8444-444444444444',
+  genResume: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+  genRound2: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+};
+
+function makeChat(ids: TurnIds): Chat {
+  return {
+    id: ids.chatId,
+    name: 'indicator-remount',
+    workspacePath: '',
+    modelId: 'm1',
+    history: [{ role: 'user', content: 'What time is it?' }],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1710000000000,
+    currentGenerationId: ids.genResume,
+  };
+}
+
+/** Mirror loop-resume.test.mts DOM so runChatTurn reaches the tool loop. */
+function installDom(): void {
+  const window = new Window();
+  globalThis.document = window.document;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.Node = window.Node;
+  globalThis.performance = window.performance;
+  globalThis.localStorage = window.localStorage;
+  globalThis.window = window as unknown as Window & typeof globalThis;
+
+  const modelSelect = document.createElement('select');
+  modelSelect.id = 'modelSelect';
+  const opt = document.createElement('option');
+  opt.value = 'm1';
+  modelSelect.appendChild(opt);
+  modelSelect.value = 'm1';
+  document.body.appendChild(modelSelect);
+
+  for (const [id, value] of [
+    ['temperature', '0.7'],
+    ['maxTokens', '512'],
+  ] as const) {
+    const el = document.createElement('input');
+    el.id = id;
+    el.value = value;
+    document.body.appendChild(el);
+  }
+
+  const systemPrompt = document.createElement('textarea');
+  systemPrompt.id = 'systemPrompt';
+  document.body.appendChild(systemPrompt);
+
+  const area = document.createElement('div');
+  area.id = 'chatArea';
+  document.body.appendChild(area);
+
+  for (const id of ['sDot', 'sText']) {
+    const el = document.createElement('span');
+    el.id = id;
+    document.body.appendChild(el);
+  }
+}
+
+/** Stream the test drives chunk by chunk, so assertions can land mid-tool-call. */
+function scriptedSseResponse(): {
+  response: Response;
+  push: (chunk: string) => void;
+  close: () => void;
+} {
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    }),
+    push: (chunk) => controller?.enqueue(encoder.encode(chunk)),
+    close: () => controller?.close(),
+  };
+}
+
+function dataChunk(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+/** Let the SSE reader drain everything queued so far. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 80; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+function chatArea(): HTMLElement | null {
+  return document.getElementById('chatArea');
+}
+
+function toolIndicatorLabel(): string | null {
+  return chatArea()?.querySelector('.tool-start-indicator__label')?.textContent ?? null;
+}
+
+interface PendingToolCallTurn {
+  toolRound: ReturnType<typeof scriptedSseResponse>;
+  postToolRound: ReturnType<typeof scriptedSseResponse>;
+  turn: Promise<void>;
+}
+
+/** Start a turn and stream a tool name, leaving its arguments unfinished. */
+async function startTurnWithPendingToolCall(
+  chat: Chat,
+  ids: TurnIds,
+): Promise<PendingToolCallTurn> {
+  const toolConfig = defaultToolConfig();
+  toolConfig.permissions.default.get_datetime = 'full';
+  setToolConfigForTests(toolConfig);
+
+  const toolRound = scriptedSseResponse();
+  // The post-tool round parks on an open stream; each case ends by aborting the turn.
+  const postToolRound = scriptedSseResponse();
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes('/api/models/cached')) return Response.json({ models: [] });
+    if (url.includes('/api/models/serve')) return Response.json({ serves: [] });
+    if (url.includes('/api/memory/')) return Response.json({ enabled: false });
+    if (url.includes('/api/config/ping')) return Response.json({ ok: true });
+    if (url.includes('/models/load')) return Response.json({ ok: true });
+    if (url.includes(ids.genResume) && url.includes('/stream')) return toolRound.response;
+    if (url.endsWith('/api/generations') && init?.method === 'POST') {
+      return Response.json({ generationId: ids.genRound2 });
+    }
+    if (url.includes(ids.genRound2) && url.includes('/stream')) {
+      return postToolRound.response;
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  const { runChatTurn } = await import('../../src/tools/loop.ts');
+
+  const turn = runChatTurn({
+    chat,
+    pushUser: false,
+    rawText: '',
+    userText: '',
+    skillId: null,
+    displayText: '',
+    historyContent: '',
+    validAttachments: [],
+    resumeGenerationId: ids.genResume,
+    ownsGlobalStreaming: true,
+  });
+
+  // The model names the tool, then streams its arguments — the long window for a file write.
+  toolRound.push(
+    dataChunk({
+      choices: [
+        {
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: TOOL_CALL_ID,
+                type: 'function',
+                function: { name: 'get_datetime', arguments: '' },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  );
+  await settle();
+
+  return { toolRound, postToolRound, turn };
+}
+
+describe('tool-start indicator survives a chat switch', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    for (const { chatId } of [VISIBLE, HIDDEN]) {
+      getChatAbort(chatId)?.abort();
+      setChatAbort(chatId, null);
+      setStreaming(false, chatId);
+      endChatTurnSetup(chatId);
+    }
+    globalThis.fetch = originalFetch;
+    setSessionStateForTests(null);
+  });
+
+  test('remount re-shows "Calling {tool}…" while arguments are still streaming', async () => {
+    installDom();
+
+    const chat = makeChat(VISIBLE);
+    setSessionStateForTests({
+      version: 2,
+      activeId: VISIBLE.chatId,
+      sidebarCollapsed: false,
+      chats: [chat],
+    });
+
+    const { remountStreamDomForChat } = await import('../../src/tools/stream-chat-dom.ts');
+    const { toolRound, postToolRound, turn } = await startTurnWithPendingToolCall(
+      chat,
+      VISIBLE,
+    );
+
+    const beforeSwitch = toolIndicatorLabel();
+    assert.ok(
+      beforeSwitch?.startsWith('Calling '),
+      `expected a tool-start indicator while args stream, got ${beforeSwitch}`,
+    );
+
+    // Switching away wipes the transcript; switching back rebuilds it from history
+    // and remounts the live shell.
+    chatArea()!.innerHTML = '';
+    remountStreamDomForChat(VISIBLE.chatId);
+
+    assert.equal(
+      toolIndicatorLabel(),
+      beforeSwitch,
+      'the remounted shell should keep showing the in-flight tool call',
+    );
+
+    toolRound.push(
+      dataChunk({
+        choices: [
+          { delta: { tool_calls: [{ index: 0, function: { arguments: '{}' } }] } },
+        ],
+      }),
+    );
+    toolRound.push(dataChunk({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] }));
+    toolRound.push('event: end\ndata: {"status":"complete"}\n\n');
+    toolRound.close();
+    await settle();
+
+    assert.equal(
+      chatArea()?.querySelectorAll('.tool-call-msg').length,
+      1,
+      'the finalized call should render as a tool card',
+    );
+    assert.equal(
+      toolIndicatorLabel(),
+      null,
+      'the indicator should be gone once the call is finalized',
+    );
+
+    getChatAbort(VISIBLE.chatId)?.abort();
+    postToolRound.close();
+    await turn.catch(() => {});
+    // Let the aborted turn finish unwinding before the session state is torn down.
+    await settle();
+  });
+
+  test('a round that starts in another chat still shows the call on return', async () => {
+    installDom();
+
+    const chat = makeChat(HIDDEN);
+    const other: Chat = {
+      ...makeChat(HIDDEN),
+      id: OTHER_CHAT_ID,
+      name: 'elsewhere',
+      history: [],
+    };
+    // The user is reading another chat when the round begins, so the turn opens on a
+    // stub shell and paints nothing.
+    setSessionStateForTests({
+      version: 2,
+      activeId: OTHER_CHAT_ID,
+      sidebarCollapsed: false,
+      chats: [chat, other],
+    });
+
+    const { remountStreamDomForChat } = await import('../../src/tools/stream-chat-dom.ts');
+    const { postToolRound, turn } = await startTurnWithPendingToolCall(chat, HIDDEN);
+
+    assert.equal(toolIndicatorLabel(), null, 'nothing paints while the chat is hidden');
+
+    setSessionStateForTests({
+      version: 2,
+      activeId: HIDDEN.chatId,
+      sidebarCollapsed: false,
+      chats: [chat, other],
+    });
+    remountStreamDomForChat(HIDDEN.chatId);
+
+    assert.ok(
+      toolIndicatorLabel()?.startsWith('Calling '),
+      'returning mid-call should pick up the tool the stream already named',
+    );
+
+    getChatAbort(HIDDEN.chatId)?.abort();
+    postToolRound.close();
+    await turn.catch(() => {});
+    // Let the aborted turn finish unwinding before the session state is torn down.
+    await settle();
+  });
+});

--- a/test/ui/stream-chat-dom-remount.test.mjs
+++ b/test/ui/stream-chat-dom-remount.test.mjs
@@ -11,6 +11,9 @@ const { registerStreamDomRemount, remountStreamDomForChat } = await import(
   '../../src/tools/stream-chat-dom.ts'
 );
 const { setSidebarStreamPhase } = await import('../../src/ui/chat-item-dot.ts');
+const { emitMainTurnActivity, resetMainTurnActivity } = await import(
+  '../../src/chat/main-turn-activity.ts'
+);
 const { renderChatFromHistory } = await import('../../src/ui/messages.ts');
 const { STREAM_LABEL_GENERATING, STREAM_LABEL_THINKING } = await import(
   '../../src/ui/stream-status.ts'
@@ -73,6 +76,7 @@ function setupDom() {
 describe('stream-chat-dom remount', { concurrency: false }, () => {
   afterEach(async () => {
     appState.setStreaming(false);
+    resetMainTurnActivity();
     registerStreamDomRemount('chat-streaming', null);
     setSessionStateForTests(null);
     if (activeWindow) {
@@ -170,6 +174,40 @@ describe('stream-chat-dom remount', { concurrency: false }, () => {
       area?.querySelector('.stream-status__label')?.textContent,
       STREAM_LABEL_GENERATING,
     );
+  });
+
+  test('tools phase does not remount a caret row over the tool cards', () => {
+    setupDom();
+    const streaming = createEmptyChatObject('');
+    streaming.id = 'chat-streaming';
+    streaming.history.push({ role: 'user', content: 'write a file' });
+
+    setSessionStateForTests({
+      version: 2,
+      activeId: streaming.id,
+      sidebarCollapsed: false,
+      chats: [streaming],
+    });
+
+    appState.setStreaming(true, streaming.id);
+    // The sidebar dot has no `tools` phase, so it still reads `generating` here.
+    setSidebarStreamPhase('generating', streaming.id);
+    emitMainTurnActivity({
+      chatId: streaming.id,
+      phase: 'tools',
+      currentTool: 'write_file',
+      workAgentLabel: '',
+      modelId: 'm1',
+      providerId: 'p1',
+      startedAtMs: Date.now(),
+    });
+    registerStreamDomRemount(streaming.id, () => {});
+
+    remountStreamDomForChat(streaming.id);
+
+    const area = document.getElementById('chatArea');
+    assert.equal(area?.querySelectorAll('.msg.assistant').length, 0);
+    assert.equal(area?.querySelectorAll('.stream-status').length, 0);
   });
 
   test('remountStreamDomForChat without a listener does not insert an orphan caret row', () => {


### PR DESCRIPTION
## What

Leaving a chat and coming back while a tool call was in flight replaced the tool display with a bare "Generating response…" caret. This fixes the two windows where that happened, and a related staleness bug in the same code path.

## Why

**Arguments-streaming window.** While the model streams a tool call's arguments — for a file write, that's the entire file body, so the window is long — nothing is in `chat.history` yet. The assistant `tool_calls` row is pushed only after the round finalizes, and the tool cards render only when the batch starts. The one piece of UI during that stretch is `attachToolStartIndicator` ("Calling Write file…"), a pure-DOM node on the live stream row with no history backing.

Switching away wipes `#chatArea` and destroys it. Switching back re-rendered a history that knew nothing about the pending call, then mounted a fresh caret row — and the indicator never returned, because the stream announces a tool name once per round (`lastAnnouncedToolName`) and the remount listener disposed the handle outright.

**Tool-execution window.** The tool cards did survive here (history re-render redraws them, and `resolveLiveToolWrap` re-attaches results by `tool_call_id`), but the remount still appended a caret row underneath them, claiming the model was generating while it was actually running tools. The loop deliberately drops the orphan stream row before a batch; the caret came back because the sidebar phase vocabulary has no `tools` state and still read `generating`.

**Stale visibility snapshot.** `streamCompletionTurn` took `domVisible` as a boolean captured once per round, so a round that *began* while the user was in another chat never painted prose deltas after they returned — the bubble sat frozen at whatever the remount replayed until the turn ended.

## What changed

- `src/tools/loop.ts`
  - `domVisible: boolean` → `isDomVisible: () => boolean`, matching the `getStreamDom` closure that was already there for the same reason.
  - New `showToolStartIndicator` helper records `streamingToolName` **before** the visibility check; the remount listener replays it onto the new shell instead of only disposing the handle. It runs last in the listener so it wins over the caret and stream-status that the prose replay reveals. `resetToolStartIndicator` clears the name at round boundaries, where the call really is over.
  - The announce site is no longer visibility-gated — the name is announced once per round, so a chat entered mid-call has no second chance to learn it. The listener decides what to paint.
- `src/tools/stream-chat-dom.ts` — `remountStreamDomForChat` returns early when `getMainTurnActivity(chatId)?.phase === 'tools'`. The activity row is cleared in `runChatTurn`'s `finally`, so the guard cannot go stale.

## Tests

New `test/tools/tool-start-indicator-remount.test.mts` drives the real `runChatTurn` against a scripted SSE stream held open mid-tool-call:

- switch away and back while arguments stream → the indicator comes back, and the finalized call still renders as one tool card
- the round *starts* in another chat → returning picks up the tool the stream already named

Both were confirmed to fail with the respective fix reverted. Plus a case in `test/ui/stream-chat-dom-remount.test.mjs` asserting the tools phase mounts no caret row.

Green: the two new suites, every suite that imports the loop (59 tests), the board headless e2e (35), the existing remount / stream-row / tool-indicator suites, `tsc --noEmit`, and `check-test-coverage` (the new file is auto-discovered on `tsx-mocks-loader`).

## Reviewer notes

- The frozen-prose half of the `isDomVisible` change has no test of its own: happy-dom has no working `DOMPurify.sanitize`, so assistant prose cannot render in the harness.
- Verified at the unit level against the real loop, not in the running app — reproducing it live needs a provider streaming a slow tool call.
- The tools-phase remount skip means the loop's DOM handles stay pointed at the stranded row for the duration of the batch. That is safe: `prepareNextStreamRound` appends a fresh row when the next round begins, and a turn that ends after the tools renders from history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
