### PR TITLE
Fix context loss across turns, failed turns, and server restarts

### DIFF
--- a/server/generations/checkpoint.js
+++ b/server/generations/checkpoint.js
@@ -1,0 +1,323 @@
+/**
+ * Disk checkpoints for backend-owned generations.
+ *
+ * The generation store is a plain in-memory Map, so a server restart mid-stream
+ * used to lose the reply outright — the client came back, found no state, and got
+ * "This reply was lost when the server restarted." Persisted generations now append
+ * their raw SSE bytes to `~/.minnow/generations/<id>.sse` with an `<id>.json` sidecar,
+ * so the same stream can be replayed byte-for-byte from disk afterwards.
+ *
+ * Writes are throttled (time or size) — never one fsync per chunk.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getMinnowHome } from '../config/home.js';
+
+/** Flush no more often than this, however fast chunks arrive. */
+const FLUSH_INTERVAL_MS = 250;
+
+/** …unless this much is already queued, which forces an immediate flush. */
+const FLUSH_BYTES = 64 * 1024;
+
+/** Checkpoints older than this are swept on boot. */
+const RETENTION_MS = 24 * 60 * 60 * 1000;
+
+/** Total on-disk cap; oldest checkpoints are dropped first past this. */
+const MAX_DIR_BYTES = 256 * 1024 * 1024;
+
+/** Sidecar `status: streaming` after a restart means the process died mid-stream. */
+export const INTERRUPTED_BY_RESTART_MESSAGE =
+  'Reply interrupted when the server restarted.';
+
+/**
+ * @typedef {object} CheckpointWriter
+ * @property {Buffer[]} pending
+ * @property {number} pendingBytes
+ * @property {ReturnType<typeof setTimeout> | null} timer
+ * @property {boolean} broken a write failed; stop trying for this generation
+ */
+
+/** @type {Map<string, CheckpointWriter>} */
+const writers = new Map();
+
+/** Only a valid UUID may become a path segment. */
+const ID_RE = /^[0-9a-fA-F-]{36}$/;
+
+function checkpointDir() {
+  return path.join(getMinnowHome(), 'generations');
+}
+
+function ssePath(id) {
+  return path.join(checkpointDir(), `${id}.sse`);
+}
+
+function metaPath(id) {
+  return path.join(checkpointDir(), `${id}.json`);
+}
+
+function isCheckpointableId(id) {
+  return typeof id === 'string' && ID_RE.test(id);
+}
+
+/** True when this generation is worth checkpointing (main chat / resumable turns). */
+function shouldCheckpoint(state) {
+  return Boolean(state?.persist) && isCheckpointableId(state?.id);
+}
+
+function ensureDir() {
+  try {
+    fs.mkdirSync(checkpointDir(), { recursive: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {import('./store.js').GenerationState} state
+ * @returns {object}
+ */
+function sidecarPayload(state) {
+  return {
+    id: state.id,
+    status: state.status,
+    providerId: state.providerId,
+    chatId: state.chatId ?? null,
+    chosenProviderId: state.chosenProviderId ?? null,
+    chosenModelId: state.chosenModelId ?? null,
+    fallbackUsed: state.fallbackUsed === true,
+    errorMessage: state.errorMessage ?? null,
+    startedAt: state.startedAt,
+    finishedAt: state.finishedAt ?? null,
+  };
+}
+
+function writeSidecar(state) {
+  if (!ensureDir()) return;
+  try {
+    fs.writeFileSync(
+      metaPath(state.id),
+      `${JSON.stringify(sidecarPayload(state), null, 2)}\n`,
+      'utf8',
+    );
+  } catch {
+    /* checkpointing is best-effort; a failed write must never fail the stream */
+  }
+}
+
+/**
+ * @param {string} id
+ * @returns {CheckpointWriter}
+ */
+function getWriter(id) {
+  let w = writers.get(id);
+  if (!w) {
+    w = { pending: [], pendingBytes: 0, timer: null, broken: false };
+    writers.set(id, w);
+  }
+  return w;
+}
+
+/**
+ * Append queued bytes in one write. Synchronous on purpose: the throttle keeps this
+ * to a handful of calls per second, and a serialized append is far simpler to reason
+ * about than interleaved async writes to the same file.
+ *
+ * @param {string} id
+ */
+function flushWriter(id) {
+  const w = writers.get(id);
+  if (!w) return;
+  if (w.timer) {
+    clearTimeout(w.timer);
+    w.timer = null;
+  }
+  if (w.pending.length === 0 || w.broken) return;
+  const buf = Buffer.concat(w.pending, w.pendingBytes);
+  w.pending = [];
+  w.pendingBytes = 0;
+  if (!ensureDir()) {
+    w.broken = true;
+    return;
+  }
+  try {
+    fs.appendFileSync(ssePath(id), buf);
+  } catch {
+    w.broken = true;
+  }
+}
+
+/** Record the generation before any bytes arrive, so a crash still leaves a sidecar. */
+export function checkpointCreated(state) {
+  if (!shouldCheckpoint(state)) return;
+  writeSidecar(state);
+}
+
+/**
+ * Queue one SSE chunk. Flushes on {@link FLUSH_BYTES} immediately, otherwise after
+ * {@link FLUSH_INTERVAL_MS}.
+ *
+ * @param {import('./store.js').GenerationState} state
+ * @param {Buffer} buf
+ */
+export function checkpointAppend(state, buf) {
+  if (!shouldCheckpoint(state) || !buf?.length) return;
+  const w = getWriter(state.id);
+  if (w.broken) return;
+  w.pending.push(buf);
+  w.pendingBytes += buf.length;
+  if (w.pendingBytes >= FLUSH_BYTES) {
+    flushWriter(state.id);
+    return;
+  }
+  if (!w.timer) {
+    w.timer = setTimeout(() => flushWriter(state.id), FLUSH_INTERVAL_MS);
+    w.timer.unref?.();
+  }
+}
+
+/** Flush remaining bytes and stamp the terminal sidecar. */
+export function checkpointFinalize(state) {
+  if (!shouldCheckpoint(state)) return;
+  flushWriter(state.id);
+  writers.delete(state.id);
+  writeSidecar(state);
+}
+
+/** Flush every open writer without touching sidecars (process shutdown). */
+export function flushAllCheckpoints() {
+  for (const id of [...writers.keys()]) {
+    flushWriter(id);
+    writers.delete(id);
+  }
+}
+
+/**
+ * @typedef {object} ReadCheckpoint
+ * @property {string} id
+ * @property {'complete' | 'error' | 'cancelled'} status
+ * @property {Buffer} sse
+ * @property {object} meta
+ */
+
+/**
+ * Read one checkpoint back from disk.
+ *
+ * A sidecar still reading `pending`/`streaming` means the process died mid-stream;
+ * it comes back as `error` so the client stops waiting on a stream nothing will
+ * finish — the bytes it did produce are replayed first either way.
+ *
+ * @param {string} id
+ * @returns {ReadCheckpoint | null}
+ */
+export function readCheckpoint(id) {
+  if (!isCheckpointableId(id)) return null;
+  let meta;
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath(id), 'utf8'));
+  } catch {
+    return null;
+  }
+  let sse;
+  try {
+    sse = fs.readFileSync(ssePath(id));
+  } catch {
+    sse = Buffer.alloc(0);
+  }
+  const stored = typeof meta?.status === 'string' ? meta.status : '';
+  const interrupted = stored !== 'complete' && stored !== 'error' && stored !== 'cancelled';
+  if (sse.length === 0 && interrupted) {
+    // Nothing produced and nothing finished — no better than having no checkpoint.
+    return null;
+  }
+  return {
+    id,
+    status: interrupted ? 'error' : stored,
+    sse,
+    meta: {
+      ...meta,
+      errorMessage: interrupted
+        ? INTERRUPTED_BY_RESTART_MESSAGE
+        : (meta?.errorMessage ?? null),
+    },
+  };
+}
+
+/** Remove both files for one generation. */
+export function deleteCheckpoint(id) {
+  if (!isCheckpointableId(id)) return;
+  for (const file of [ssePath(id), metaPath(id)]) {
+    try {
+      fs.rmSync(file, { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * Drop checkpoints older than {@link RETENTION_MS}, then oldest-first until the
+ * directory fits {@link MAX_DIR_BYTES}. Cheap enough to run on every boot.
+ *
+ * @returns {{ removed: number, bytesAfter: number }}
+ */
+export function sweepCheckpoints() {
+  const dir = checkpointDir();
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return { removed: 0, bytesAfter: 0 };
+  }
+
+  /** @type {Map<string, { mtimeMs: number, bytes: number }>} */
+  const byId = new Map();
+  for (const name of names) {
+    const match = name.match(/^(.+)\.(sse|json)$/);
+    if (!match || !isCheckpointableId(match[1])) continue;
+    let stat;
+    try {
+      stat = fs.statSync(path.join(dir, name));
+    } catch {
+      continue;
+    }
+    const entry = byId.get(match[1]) ?? { mtimeMs: 0, bytes: 0 };
+    entry.mtimeMs = Math.max(entry.mtimeMs, stat.mtimeMs);
+    entry.bytes += stat.size;
+    byId.set(match[1], entry);
+  }
+
+  const now = Date.now();
+  let removed = 0;
+  let total = 0;
+  /** @type {Array<{ id: string, mtimeMs: number, bytes: number }>} */
+  const kept = [];
+  for (const [id, entry] of byId) {
+    if (now - entry.mtimeMs > RETENTION_MS) {
+      deleteCheckpoint(id);
+      removed += 1;
+      continue;
+    }
+    total += entry.bytes;
+    kept.push({ id, ...entry });
+  }
+
+  kept.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  for (const entry of kept) {
+    if (total <= MAX_DIR_BYTES) break;
+    deleteCheckpoint(entry.id);
+    removed += 1;
+    total -= entry.bytes;
+  }
+
+  return { removed, bytesAfter: total };
+}
+
+/** Clear in-process writer state (tests). */
+export function resetCheckpointWritersForTests() {
+  for (const w of writers.values()) {
+    if (w.timer) clearTimeout(w.timer);
+  }
+  writers.clear();
+}

--- a/server/generations/store.js
+++ b/server/generations/store.js
@@ -4,6 +4,13 @@
 
 import { randomUUID } from 'node:crypto';
 import { fireAndForget } from '../webhooks/emit.js';
+import {
+  checkpointAppend,
+  checkpointCreated,
+  checkpointFinalize,
+  flushAllCheckpoints,
+  readCheckpoint,
+} from './checkpoint.js';
 
 /** @typedef {'pending' | 'streaming' | 'complete' | 'error' | 'cancelled'} GenerationStatus */
 
@@ -306,6 +313,7 @@ export function createGenerationState({
     chatId: typeof chatId === 'string' && chatId.trim() ? chatId.trim() : null,
   };
   generations.set(id, state);
+  checkpointCreated(state);
   return state;
 }
 
@@ -314,7 +322,52 @@ export function createGenerationState({
  * @returns {GenerationState | undefined}
  */
 export function getGenerationState(id) {
-  return generations.get(id);
+  return generations.get(id) ?? rehydrateFromCheckpoint(id);
+}
+
+/**
+ * Rebuild a terminal generation from its disk checkpoint after a server restart.
+ *
+ * The replayed state is inert — no upstream, no writer — but `addSubscriber` treats
+ * it like any other finished generation: buffered chunks first, then the `end`
+ * sentinel. That is the whole point; the client needs no restart-specific path.
+ *
+ * @param {string} id
+ * @returns {GenerationState | undefined}
+ */
+function rehydrateFromCheckpoint(id) {
+  const saved = readCheckpoint(id);
+  if (!saved) return undefined;
+  const meta = saved.meta ?? {};
+  const chunks = saved.sse.length > 0 ? [saved.sse] : [];
+  /** @type {GenerationState} */
+  const state = {
+    id,
+    providerId: typeof meta.providerId === 'string' ? meta.providerId : '',
+    requestBody: Buffer.alloc(0),
+    chunks,
+    totalBytes: saved.sse.length,
+    status: saved.status,
+    upstreamController: null,
+    subscribers: new Set(),
+    evictTimer: null,
+    // Already on disk; re-checkpointing a replay would append its own bytes back.
+    persist: false,
+    startedAt: typeof meta.startedAt === 'string' ? meta.startedAt : new Date().toISOString(),
+    finishedAt: typeof meta.finishedAt === 'string' ? meta.finishedAt : null,
+    errorMessage: typeof meta.errorMessage === 'string' ? meta.errorMessage : null,
+    candidates: [],
+    activeCandidateIndex: 0,
+    failoverDisabled: true,
+    fallbackUsed: meta.fallbackUsed === true,
+    chosenProviderId: typeof meta.chosenProviderId === 'string' ? meta.chosenProviderId : '',
+    chosenModelId: typeof meta.chosenModelId === 'string' ? meta.chosenModelId : '',
+    fallbackRole: null,
+    chatId: typeof meta.chatId === 'string' ? meta.chatId : null,
+  };
+  generations.set(id, state);
+  scheduleEviction(state);
+  return state;
 }
 
 /**
@@ -352,6 +405,7 @@ export function appendChunk(state, buf) {
 
   state.chunks.push(buf);
   state.totalBytes += buf.length;
+  checkpointAppend(state, buf);
 
   for (const res of [...state.subscribers]) {
     writeToSubscriber(state, res, buf);
@@ -409,6 +463,7 @@ export function markComplete(state) {
   }
   state.status = 'complete';
   state.finishedAt = new Date().toISOString();
+  checkpointFinalize(state);
   broadcastTerminalEvent(state);
   fireAndForget('chat.completed', {
     generationId: state.id,
@@ -434,6 +489,7 @@ export function markError(state, message) {
   state.status = 'error';
   state.errorMessage = message;
   state.finishedAt = new Date().toISOString();
+  checkpointFinalize(state);
   broadcastTerminalEvent(state);
   scheduleEviction(state);
 }
@@ -447,6 +503,7 @@ export function markCancelled(state) {
   }
   state.status = 'cancelled';
   state.finishedAt = new Date().toISOString();
+  checkpointFinalize(state);
   broadcastTerminalEvent(state);
   scheduleEviction(state);
 }
@@ -500,6 +557,7 @@ export function deleteGenerationsForProviderShutdown() {
     }
   }
   generations.clear();
+  flushAllCheckpoints();
 }
 
 

--- a/server/runtime/bootstrap.js
+++ b/server/runtime/bootstrap.js
@@ -9,6 +9,7 @@ import { ensureChatsWorkspace } from '../chats-workspace/paths.js';
 import { ensureDesktopWorkspace, initDesktopWorkspacePath } from '../desktop-workspace/paths.js';
 import { ensureSchedulerWorkspace } from '../scheduler-workspace/paths.js';
 import { ensureMinnowLayout, getMinnowHome } from '../config/home.js';
+import { sweepCheckpoints } from '../generations/checkpoint.js';
 import { initLspConfig } from '../lsp/middleware.js';
 import { initMcpApi } from '../mcp/middleware.js';
 import { initServersApi } from '../servers/index.js';
@@ -40,6 +41,8 @@ export async function bootstrapMinnowRuntime() {
   await initServersApi();
   await initPluginsApi();
   await recomputeAllNextRuns();
+  // Replayable generations are only useful for as long as a client might come back.
+  sweepCheckpoints();
   const homePath = getMinnowHome();
   return {
     workspacePath,

--- a/server/settings/registry-manifest.json
+++ b/server/settings/registry-manifest.json
@@ -1743,6 +1743,44 @@
     ]
   },
   {
+    "key": "agents.rules.reasoningReplay",
+    "label": "Prior reasoning replay",
+    "keywords": [
+      "thinking",
+      "reasoning",
+      "chain of thought",
+      "replay",
+      "context"
+    ],
+    "category": "agents",
+    "area": "rules",
+    "storage": "section",
+    "type": "string",
+    "sensitivity": "normal",
+    "writable": false,
+    "refreshAreas": [
+      "rules"
+    ]
+  },
+  {
+    "key": "agents.rules.reasoningReplay.enabled",
+    "label": "Replay prior reasoning",
+    "keywords": [
+      "thinking",
+      "reasoning",
+      "replay"
+    ],
+    "category": "agents",
+    "area": "rules",
+    "storage": "section",
+    "type": "string",
+    "sensitivity": "normal",
+    "writable": false,
+    "refreshAreas": [
+      "rules"
+    ]
+  },
+  {
     "key": "integrations.search",
     "label": "Web search provider",
     "keywords": [

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -72,6 +72,7 @@ import {
   isUiOnlyTranscriptMessage,
 } from '../chat/context/injection-notice';
 import { resolveOutboundSystemMessages } from '../chat/prompts/compose-context';
+import { resolveContextLimit } from '../chat/context-usage';
 import {
   recordAssistantReplyOnChat,
   setSidebarStreamPhase,
@@ -565,6 +566,7 @@ export async function sendMessage(): Promise<void> {
     userMessagePreview: text,
     routeUserText: text,
     firstUserSend,
+    modelContextLimit: modelId ? resolveContextLimit(modelId, chat) : null,
   });
 
   const injectionAdded = appendInjectionNoticesForTurn(

--- a/src/chat/context/injection-replay.ts
+++ b/src/chat/context/injection-replay.ts
@@ -1,0 +1,101 @@
+/**
+ * Replay first-turn prompt injections from persisted transcript rows.
+ *
+ * Injections only run on the first user turn, but the prompt is recomposed on
+ * every send — so from turn 2 onward the Brain-notes / code-map / context-document
+ * blocks were rebuilt as `null` and the model simply stopped seeing them. The
+ * `injection` rows already hold the exact retrieved text, so replay reads them back
+ * instead of re-deriving (and re-persisting) anything.
+ */
+
+import type { Message, PromptInjectionKind } from '../../types';
+import { estimateTokensFromText } from '../prompts/token-estimate-core';
+import { isInjectionNoticeMessage } from './injection-notice';
+
+/** Latest stored body per injection kind. */
+export type InjectionReplayBodies = Partial<Record<PromptInjectionKind, string>>;
+
+/**
+ * Replayed blocks land as pinned system content that `applyContextPolicy` never
+ * trims, so they get a hard share of the window rather than the whole thing.
+ */
+export const INJECTION_REPLAY_CONTEXT_SHARE = 0.2;
+
+/** Cap used when the model context window is unknown. */
+export const INJECTION_REPLAY_FALLBACK_TOKEN_CAP = 8_000;
+
+/**
+ * Priority order when the cap cannot hold everything. Workspace docs are the
+ * user's own authored context (AGENTS.md and friends) and matter most; the code
+ * map is the most re-derivable, so it is dropped first.
+ */
+export const INJECTION_REPLAY_PRIORITY: PromptInjectionKind[] = [
+  'context-documents',
+  'brain-notes',
+  'code-map',
+];
+
+/**
+ * Last persisted body per injection kind. Injections only ever run on the first
+ * user turn, so there is at most one row per kind — but take the last anyway so a
+ * forked or re-seeded transcript replays what it actually last sent.
+ */
+export function latestInjectionBodies(history: Message[]): InjectionReplayBodies {
+  const bodies: InjectionReplayBodies = {};
+  for (const msg of history) {
+    if (!isInjectionNoticeMessage(msg)) continue;
+    const body = msg.body?.trim();
+    if (!body) continue;
+    bodies[msg.kind] = body;
+  }
+  return bodies;
+}
+
+export interface CapInjectionReplayOptions {
+  /** Model context window in tokens; null/undefined falls back to a fixed cap. */
+  modelContextLimit?: number | null;
+}
+
+/** Token budget a replay may occupy for this model. */
+export function resolveInjectionReplayTokenCap(
+  modelContextLimit?: number | null,
+): number {
+  if (
+    typeof modelContextLimit === 'number' &&
+    Number.isFinite(modelContextLimit) &&
+    modelContextLimit > 0
+  ) {
+    return Math.floor(modelContextLimit * INJECTION_REPLAY_CONTEXT_SHARE);
+  }
+  return INJECTION_REPLAY_FALLBACK_TOKEN_CAP;
+}
+
+/**
+ * Trim a replay set to the token cap. A kind that does not fit is dropped whole —
+ * a half-truncated code map or context document is worse than none at all.
+ */
+export function capInjectionReplay(
+  bodies: InjectionReplayBodies,
+  options?: CapInjectionReplayOptions,
+): InjectionReplayBodies {
+  const cap = resolveInjectionReplayTokenCap(options?.modelContextLimit);
+  const out: InjectionReplayBodies = {};
+  let used = 0;
+  for (const kind of INJECTION_REPLAY_PRIORITY) {
+    const body = bodies[kind]?.trim();
+    if (!body) continue;
+    const cost = estimateTokensFromText(body);
+    if (used + cost > cap) continue;
+    out[kind] = body;
+    used += cost;
+  }
+  return out;
+}
+
+/** Latest stored injection bodies for this history, capped for the model. */
+export function resolveInjectionReplay(
+  history: Message[],
+  options?: CapInjectionReplayOptions,
+): InjectionReplayBodies {
+  return capInjectionReplay(latestInjectionBodies(history), options);
+}

--- a/src/chat/context/reasoning-replay-config.ts
+++ b/src/chat/context/reasoning-replay-config.ts
@@ -1,0 +1,49 @@
+/**
+ * `features.replayPriorReasoning`: send prior-turn reasoning back on plain assistant rows.
+ *
+ * Tool-call rows already replay their thinking (Anthropic requires the signature to
+ * pair with `tool_use`), but a finished prose turn drops it — so a model that reasoned
+ * its way to an answer on turn 3 cannot see that reasoning on turn 4. Replaying costs
+ * real tokens on every later turn and some providers reject the fields outright, so
+ * this is opt-in and defaults to off.
+ */
+
+const CONFIG_URL = '/api/config/file?key=config.json';
+
+export const DEFAULT_REPLAY_PRIOR_REASONING = false;
+
+/** Read the flag from config.json (false on any read/parse failure). */
+export async function fetchReplayPriorReasoningEnabled(): Promise<boolean> {
+  try {
+    const res = await fetch(CONFIG_URL, { cache: 'no-store' });
+    if (!res.ok) return DEFAULT_REPLAY_PRIOR_REASONING;
+    const config = (await res.json()) as {
+      features?: { replayPriorReasoning?: boolean };
+    };
+    return typeof config.features?.replayPriorReasoning === 'boolean'
+      ? config.features.replayPriorReasoning
+      : DEFAULT_REPLAY_PRIOR_REASONING;
+  } catch {
+    return DEFAULT_REPLAY_PRIOR_REASONING;
+  }
+}
+
+export async function saveReplayPriorReasoningEnabled(enabled: boolean): Promise<boolean> {
+  try {
+    const res = await fetch(CONFIG_URL);
+    if (!res.ok) return false;
+    const config = (await res.json()) as { features?: Record<string, boolean> };
+    const features =
+      config.features && typeof config.features === 'object' ? { ...config.features } : {};
+    features.replayPriorReasoning = enabled;
+    config.features = features;
+    const put = await fetch(CONFIG_URL, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+    });
+    return put.ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/chat/prompts/compose-context.ts
+++ b/src/chat/prompts/compose-context.ts
@@ -28,6 +28,7 @@ import { fetchBrainCodeConfig } from '../../brain/client';
 import { loadContextDocumentsSettings, shouldInjectContextDocuments } from '../../chat/context-documents/config';
 import { retrieveContextDocumentsBlock } from '../../chat/context-documents/injection';
 import { shouldRunFirstTurnInjections } from './first-turn-injection';
+import { resolveInjectionReplay } from '../context/injection-replay';
 import { loadPromptConfig } from './prompt-configs';
 import { chatHistoryHasBrowserToolUse } from './browser-allowlist-gate';
 import { getWorkspacePath } from '../../state/workspace';
@@ -61,6 +62,8 @@ export interface BuildComposeContextOptions {
   routeUserText?: string;
   /** First user message send (set before history.push); gates first-turn injections. */
   firstUserSend?: boolean;
+  /** Model context window; sizes the replay cap for stored injection bodies. */
+  modelContextLimit?: number | null;
   overrides?: Partial<ComposeContext>;
 }
 
@@ -102,12 +105,30 @@ export async function buildComposeContext(
     meta.activeInfoPresetId ??
     'general-assistant';
 
-  let memoryBlock: string | null = null;
   const runFirstTurn = shouldRunFirstTurnInjections(chat, {
     firstUserSend: options?.firstUserSend,
   });
-  const injectMemory = runFirstTurn && (await shouldInjectMemory(chat));
-  if (injectMemory) {
+  /*
+   * The prompt is recomposed on every send (mode, agent, skill, tools and cwd all
+   * move mid-chat), but retrieval only runs on turn 1. Replaying the persisted
+   * bodies keeps turn 20 carrying the same durable context turn 1 had — and keeps
+   * the leading system message byte-stable, so local KV prefixes still hit.
+   */
+  const replayBodies = runFirstTurn
+    ? {}
+    : resolveInjectionReplay(chat.history, {
+        modelContextLimit: options?.modelContextLimit,
+      });
+  let injectionsReplayed = false;
+
+  let memoryBlock: string | null = null;
+  const replayBrainNotes = replayBodies['brain-notes'] ?? null;
+  const injectMemory =
+    (runFirstTurn || Boolean(replayBrainNotes)) && (await shouldInjectMemory(chat));
+  if (injectMemory && !runFirstTurn) {
+    memoryBlock = replayBrainNotes;
+    injectionsReplayed = true;
+  } else if (injectMemory) {
     const query =
       options?.routeUserText ??
       options?.userMessagePreview ??
@@ -127,8 +148,13 @@ export async function buildComposeContext(
   const worktreeCwd = resolveChatToolWorkspaceRoot(chat, sessionState?.groups);
 
   let codeMapBlock: string | null = null;
-  const injectCodeMap = runFirstTurn && (await shouldInjectCodeMap(chat));
-  if (injectCodeMap) {
+  const replayCodeMap = replayBodies['code-map'] ?? null;
+  const injectCodeMap =
+    (runFirstTurn || Boolean(replayCodeMap)) && (await shouldInjectCodeMap(chat));
+  if (injectCodeMap && !runFirstTurn) {
+    codeMapBlock = replayCodeMap;
+    injectionsReplayed = true;
+  } else if (injectCodeMap) {
     const codeConfig = await fetchBrainCodeConfig();
     const preview =
       options?.routeUserText ?? options?.userMessagePreview ?? '';
@@ -155,9 +181,14 @@ export async function buildComposeContext(
   }
 
   let contextDocumentsBlock: string | null = null;
+  const replayContextDocuments = replayBodies['context-documents'] ?? null;
   const injectContextDocuments =
-    runFirstTurn && (await shouldInjectContextDocuments(chat));
-  if (injectContextDocuments) {
+    (runFirstTurn || Boolean(replayContextDocuments)) &&
+    (await shouldInjectContextDocuments(chat));
+  if (injectContextDocuments && !runFirstTurn) {
+    contextDocumentsBlock = replayContextDocuments;
+    injectionsReplayed = true;
+  } else if (injectContextDocuments) {
     const { documents } = await loadContextDocumentsSettings();
     contextDocumentsBlock =
       (await retrieveContextDocumentsBlock({
@@ -182,6 +213,7 @@ export async function buildComposeContext(
     codeMapInjectionEnabled: injectCodeMap,
     contextDocumentsBlock,
     contextDocumentsInjectionEnabled: injectContextDocuments,
+    injectionsReplayed,
     enabledToolIds,
     infoPresetId,
     planGranularity: meta.planGranularity ?? 'medium',
@@ -321,14 +353,21 @@ export async function resolveOutboundSystemMessages(
     const { composeSystemPrompt } = await import('./prompt-composer');
     const ctx = await resolveComposeContextForSend(chat, options);
     composedRaw = composeSystemPrompt(ctx);
-    const brain = ctx.memoryBlock?.trim() ?? '';
-    const codeMap = ctx.codeMapBlock?.trim() ?? '';
-    const contextDocuments = ctx.contextDocumentsBlock?.trim() ?? '';
-    injectionBlocks = {
-      brainNotes: brain || null,
-      codeMap: codeMap || null,
-      contextDocuments: contextDocuments || null,
-    };
+    /*
+     * Replayed blocks came *from* the transcript, so re-announcing them would push a
+     * fresh `injection` row on every single turn. Only freshly retrieved bodies get a
+     * notice; the prompt still carries the text either way.
+     */
+    if (!ctx.injectionsReplayed) {
+      const brain = ctx.memoryBlock?.trim() ?? '';
+      const codeMap = ctx.codeMapBlock?.trim() ?? '';
+      const contextDocuments = ctx.contextDocumentsBlock?.trim() ?? '';
+      injectionBlocks = {
+        brainNotes: brain || null,
+        codeMap: codeMap || null,
+        contextDocuments: contextDocuments || null,
+      };
+    }
   } catch {
     composedRaw = '';
   }

--- a/src/chat/prompts/token-estimate-core.ts
+++ b/src/chat/prompts/token-estimate-core.ts
@@ -2,10 +2,40 @@
  * Pure token estimate helpers (no DOM or compose imports — safe for Node tests).
  */
 
-import type { ApiMessage, AssistantToolCallMessage, Message } from '../../types';
+import type {
+  ApiMessage,
+  AssistantMessage,
+  AssistantToolCallMessage,
+  Message,
+} from '../../types';
 import type { OpenAIFunctionDefinition } from '../../tools/definitions';
+import { outboundReasoningReplayFields } from '../../api/reasoning';
 import { isUiOnlyTranscriptMessage } from '../context/injection-notice';
 import { toolImageFollowUpUserMessage } from '../tool-image-follow-up';
+
+/** Shared knobs for history estimators that must mirror `buildApiMessages`. */
+export interface HistoryEstimateOptions {
+  /** Mirrors `BuildApiMessagesOptions.replayPriorReasoning`. */
+  replayPriorReasoning?: boolean;
+  /** Active model id — some providers reject reasoning replay outright. */
+  modelId?: string;
+}
+
+/**
+ * Reasoning fields a plain assistant row would carry outbound, or null when replay
+ * is off (or the provider rejects it). Mirrors the non-tool branch of
+ * `buildApiMessages` so the context ring never under-reports the payload.
+ */
+function replayedReasoningFields(
+  m: Pick<AssistantMessage, 'thinking'>,
+  options: HistoryEstimateOptions | undefined,
+): ReturnType<typeof outboundReasoningReplayFields> | null {
+  if (!options?.replayPriorReasoning) return null;
+  const reasoningText = m.thinking?.join('\n\n').trim() ?? '';
+  if (!reasoningText) return null;
+  const fields = outboundReasoningReplayFields(options.modelId ?? '', reasoningText);
+  return Object.keys(fields).length > 0 ? fields : null;
+}
 
 /** Rough token proxy for English-ish text; not model-accurate. */
 export function estimateTokensFromText(text: string): number {
@@ -47,7 +77,10 @@ export const SETTINGS_PROMPT_CONFIG_ESTIMATE_TOOLTIP =
  * Map persisted chat history to API messages for token estimate.
  * Mirrors `buildApiMessages` history rows — assistant `thinking` is UI-only and excluded.
  */
-export function historyToApiMessagesForEstimate(history: Message[]): ApiMessage[] {
+export function historyToApiMessagesForEstimate(
+  history: Message[],
+  options?: HistoryEstimateOptions,
+): ApiMessage[] {
   const messages: ApiMessage[] = [];
   for (const m of history) {
     if (isUiOnlyTranscriptMessage(m)) continue;
@@ -92,7 +125,12 @@ export function historyToApiMessagesForEstimate(history: Message[]): ApiMessage[
           tool_calls: withTools.tool_calls,
         });
       } else {
-        messages.push({ role: 'assistant', content: m.content });
+        const replayed = replayedReasoningFields(m, options);
+        messages.push({
+          role: 'assistant',
+          content: m.content,
+          ...(replayed ?? {}),
+        });
       }
     }
   }
@@ -100,7 +138,10 @@ export function historyToApiMessagesForEstimate(history: Message[]): ApiMessage[
 }
 
 /** Serialize one history row the same way outbound API messages count payload size. */
-export function serializeMessageContentForEstimate(m: Message): string {
+export function serializeMessageContentForEstimate(
+  m: Message,
+  options?: HistoryEstimateOptions,
+): string {
   if (m.role === 'user') {
     const imageCount = m.images?.length ?? 0;
     if (imageCount === 0) return m.content;
@@ -114,17 +155,21 @@ export function serializeMessageContentForEstimate(m: Message): string {
       const content = withTools.content ?? '';
       return content + JSON.stringify(withTools.tool_calls);
     }
-    return m.content ?? '';
+    const replayed = replayedReasoningFields(m, options);
+    return (m.content ?? '') + (replayed ? JSON.stringify(replayed) : '');
   }
   return '';
 }
 
 /** Sum token estimate across all persisted chat turns (excludes context notices). */
-export function estimateHistoryTokens(history: Message[]): number {
+export function estimateHistoryTokens(
+  history: Message[],
+  options?: HistoryEstimateOptions,
+): number {
   let total = 0;
   for (const m of history) {
     if (isUiOnlyTranscriptMessage(m)) continue;
-    total += estimateTokensFromText(serializeMessageContentForEstimate(m));
+    total += estimateTokensFromText(serializeMessageContentForEstimate(m, options));
   }
   return total;
 }

--- a/src/chat/prompts/token-estimate.ts
+++ b/src/chat/prompts/token-estimate.ts
@@ -42,8 +42,10 @@ import {
   formatTokenEstimateLabel,
   historyToApiMessagesForEstimate,
   TOKEN_ESTIMATE_TOOLTIP,
+  type HistoryEstimateOptions,
   type OutboundPromptEstimate,
 } from './token-estimate-core';
+import { fetchReplayPriorReasoningEnabled } from '../context/reasoning-replay-config';
 
 export {
   ESTIMATE_IMAGE_URL_TOKENS,
@@ -55,6 +57,7 @@ export {
   historyToApiMessagesForEstimate,
   serializeMessageContentForEstimate,
   TOKEN_ESTIMATE_TOOLTIP,
+  type HistoryEstimateOptions,
   type OutboundPromptEstimate,
 } from './token-estimate-core';
 
@@ -111,6 +114,7 @@ function buildOutboundApiMessagesForEstimate(
   chat: Chat,
   systemText: string,
   userRulesText: string,
+  historyOptions?: HistoryEstimateOptions,
 ): ApiMessage[] {
   const messages: ApiMessage[] = [];
   pushOutboundSystemMessages(messages, {
@@ -118,7 +122,7 @@ function buildOutboundApiMessagesForEstimate(
     legacySysPrompt: '',
     userRulesContent: userRulesText || undefined,
   });
-  messages.push(...historyToApiMessagesForEstimate(chat.history));
+  messages.push(...historyToApiMessagesForEstimate(chat.history, historyOptions));
   return messages;
 }
 
@@ -138,8 +142,14 @@ function applyBudgetTrimToHistoryTokens(
   systemText: string,
   userRulesText: string,
   rawHistoryTokens: number,
+  historyOptions?: HistoryEstimateOptions,
 ): { history: number; compressedEstimate: number; wouldCompress: boolean } {
-  const apiMessages = buildOutboundApiMessagesForEstimate(chat, systemText, userRulesText);
+  const apiMessages = buildOutboundApiMessagesForEstimate(
+    chat,
+    systemText,
+    userRulesText,
+    historyOptions,
+  );
   const workAgent = resolveActiveWorkAgent(chat);
   const agentConfig = workAgent
     ? agentContextBudgetFromWorkAgent(workAgent)
@@ -192,6 +202,10 @@ async function resolveOutboundComposeForEstimate(
     ...options?.composeOptions,
     routeUserText,
     userMessagePreview: routeUserText,
+    // Same replay cap the send path uses, so the ring counts what actually ships.
+    modelContextLimit:
+      options?.composeOptions?.modelContextLimit ??
+      resolveModelLimitForEstimate(options?.modelId, chat),
     overrides: {
       expertId: expertCtx.routeSource === 'orphaned' ? null : expertCtx.expertId,
       expertLabel: expertCtx.expertLabel,
@@ -323,7 +337,12 @@ export async function resolveOutboundPromptEstimate(
   const chat = options?.chat ?? getActiveChat();
 
   const staticPart = await resolveCachedStaticOutboundEstimate(chat, options);
-  const historyTokens = estimateHistoryTokens(chat.history);
+  // Mirrors what the send path will actually put on the wire (Phase 4 replay).
+  const historyOptions: HistoryEstimateOptions = {
+    replayPriorReasoning: await fetchReplayPriorReasoningEnabled(),
+    modelId: options?.modelId,
+  };
+  const historyTokens = estimateHistoryTokens(chat.history, historyOptions);
 
   const estimate: OutboundPromptEstimate = {
     total:
@@ -348,6 +367,7 @@ export async function resolveOutboundPromptEstimate(
     staticPart.composed,
     staticPart.userRules ?? '',
     estimate.history,
+    historyOptions,
   );
 
   if (!trimResult.wouldCompress && trimResult.history === estimate.history) {

--- a/src/chat/prompts/types.ts
+++ b/src/chat/prompts/types.ts
@@ -102,6 +102,12 @@ export interface ComposeContext {
   contextDocumentsBlock: string | null;
   /** True when context document injection is resolved on for this send. */
   contextDocumentsInjectionEnabled?: boolean;
+  /**
+   * True when the injected blocks above were rehydrated from persisted `injection`
+   * rows rather than retrieved fresh. Suppresses a duplicate transcript notice —
+   * see `resolveOutboundSystemMessages`.
+   */
+  injectionsReplayed?: boolean;
   enabledToolIds: string[];
   infoPresetId: string | null;
   userMessagePreview?: string;

--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -269,6 +269,14 @@
   margin-bottom: 4px;
 }
 
+.msg.assistant.msg--failed .msg-failed-chip {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--mn-danger, var(--mn-fg-muted));
+  margin-bottom: 4px;
+}
+
 .msg.assistant.msg--truncated .msg-truncated-chip {
   display: flex;
   align-items: center;

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -80,6 +80,7 @@ import {
   type RoutedContentPart,
 } from '../api/inline-thinking';
 import { extractReasoningDelta, extractReasoningSignatureDelta, outboundReasoningReplayFields } from '../api/reasoning';
+import { fetchReplayPriorReasoningEnabled } from '../chat/context/reasoning-replay-config';
 import { resolveModelInfo } from '../api/models';
 import {
   chatTurnNeedsModelLoad,
@@ -390,6 +391,7 @@ import {
   logTurnDebug,
   MAX_PROSE_QUESTION_RETRIES,
   PROSE_QUESTION_RETRY_INSTRUCTION,
+  resolveFailedTurnPartialRow,
   resolveFinalAssistantContent,
   resolveTurnContinuation,
 } from './turn-continuation';
@@ -419,6 +421,11 @@ export interface BuildApiMessagesOptions {
    * so the composer strip can be emptied at send time instead of at turn end (MIN-650).
    */
   attachments?: Attachment[];
+  /**
+   * Replay prior-turn reasoning on plain assistant rows (`features.replayPriorReasoning`).
+   * Resolved once per turn by the caller so this stays synchronous.
+   */
+  replayPriorReasoning?: boolean;
 }
 
 interface ChatCompletionBody extends CompletionBodyWithResponseFormat {
@@ -859,7 +866,19 @@ export function buildApiMessages(
           i,
         );
       } else {
-        pushFromHistory({ role: 'assistant', content: m.content }, i);
+        const reasoningText = options?.replayPriorReasoning
+          ? ((m as AssistantMessage).thinking?.join('\n\n').trim() ?? '')
+          : '';
+        pushFromHistory(
+          {
+            role: 'assistant',
+            content: m.content,
+            ...(reasoningText
+              ? outboundReasoningReplayFields(modelId ?? '', reasoningText)
+              : {}),
+          },
+          i,
+        );
       }
     }
   }
@@ -1329,6 +1348,32 @@ function syncTurnContextUsage(
       : null,
   );
   scheduleContextUsageRefresh({ duringStream: true });
+}
+
+/**
+ * Append a failed turn's streamed output as a `failed: true` assistant row.
+ * Returns true when a row was persisted (see {@link resolveFailedTurnPartialRow}).
+ */
+function persistFailedTurnPartial(params: {
+  chat: Chat;
+  turnRunId: TurnRunId | undefined;
+  skip: boolean;
+  partialText: string;
+  thinking: string[];
+}): boolean {
+  if (params.skip) return false;
+  const row = resolveFailedTurnPartialRow({
+    partialText: params.partialText,
+    thinking: params.thinking,
+  });
+  if (!row) return false;
+
+  params.chat.history.push(row);
+  trackRunHistoryPush(params.chat, params.turnRunId);
+  recordAssistantReplyOnChat(params.chat);
+  recordChatMessage(params.chat);
+  scheduleSaveSessions();
+  return true;
 }
 
 interface FinalizedThinkingRound {
@@ -1879,6 +1924,9 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
     skillBody = augmentSkillBodyForUiDesigner(skillBody, uiDesignerCtx);
   }
 
+  // Resolved once per turn so buildApiMessages stays synchronous (no sync config cache).
+  const replayPriorReasoning = await fetchReplayPriorReasoningEnabled();
+
   const outbound = await resolveOutboundSystemMessages(chat, legacySysPrompt, {
     userMessagePreview: userText || rawText,
     routeUserText: userText || rawText,
@@ -1886,6 +1934,7 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
       .map((a) => a.workspacePath?.trim())
       .filter((p): p is string => Boolean(p)),
     firstUserSend: firstUserSendForInjections,
+    modelContextLimit: sendModelId ? resolveContextLimit(sendModelId, chat) : null,
     overrides: { skillBody },
   });
   const sysPrompt =
@@ -2097,6 +2146,7 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
         ephemeralContinueInstruction: ephemeralPostToolInstruction,
         ephemeralContext,
         attachments: validAttachments,
+        replayPriorReasoning,
       });
 
       let preMessages = rawMessages;
@@ -2219,6 +2269,14 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
 
       thoughtController.setAssistantWrap(wrap);
       const domVisible = isStreamDomVisible(chat.id);
+
+      /*
+       * Round-scoped: the previous round's prose is already on its own history row.
+       * `onPartialText` does not fire until this round's first content delta, so
+       * without the reset a round that throws before streaming anything would let
+       * the failure path persist the earlier round's text a second time.
+       */
+      livePartialText = '';
 
       const runStreamTurn = (
         turnBody: ChatCompletionBody,
@@ -2907,6 +2965,23 @@ export async function runChatTurn(options: RunChatTurnOptions): Promise<void> {
     const failedRun = turnRunId ? findRunById(chat, turnRunId) : undefined;
     const failedForkIndex =
       failedRun?.forkHistoryIndex ?? resolveForkHistoryIndex(chat, pushUser);
+
+    /*
+     * A user-stopped turn keeps what it streamed; a failed one used to throw it away,
+     * because nothing had been appended yet and `rollbackFailedTurnHistory` slices
+     * back to the user row. Persist the partial first so `turnProducedOutput` below
+     * takes the preserve branch and the error bubble lands underneath it.
+     * Retry is unaffected: `forkFromUserIndex` truncates inclusive at the user row.
+     */
+    persistFailedTurnPartial({
+      chat,
+      turnRunId,
+      // The server forgot this generation across a restart — nothing streamed here.
+      skip: e.message === GENERATION_LOST_ON_RESTART_MESSAGE,
+      partialText: livePartialText,
+      thinking: thoughtController?.getSegmentsNormalized() ?? [],
+    });
+
     let rolledBack = false;
     let preservedTurnOutput = false;
     /*

--- a/src/tools/turn-continuation.ts
+++ b/src/tools/turn-continuation.ts
@@ -3,7 +3,8 @@
  * orphan tool-tail detection, and optional dev turn logging.
  */
 
-import type { AssistantToolCallMessage, Message } from '../types';
+import type { AssistantMessage, AssistantToolCallMessage, Message } from '../types';
+import { stripXmlToolCallBlocks } from '../providers/xml-tool-calls';
 
 /** localStorage key: set to `1` to log per-round tool-loop decisions in the console. */
 export const TURN_DEBUG_STORAGE_KEY = 'minnowDebugTurns';
@@ -108,4 +109,35 @@ export function resolveFinalAssistantContent(
     content: 'The model returned no text.',
     usedThinkingAsContent: false,
   };
+}
+
+export interface FailedTurnPartialInput {
+  /** Prose streamed before the turn threw. */
+  partialText: string;
+  /** Reasoning segments captured for the same round. */
+  thinking: string[];
+}
+
+/**
+ * The assistant row a failed turn should leave behind, or null when there is
+ * nothing worth keeping.
+ *
+ * A user-stopped turn already persists what it streamed; a failed one used to
+ * discard it, because nothing had been appended and the rollback slices back to
+ * the user message. Tool-call markup the router never closed is dropped — replaying
+ * half a `<tool_call>` as prose is worse than losing it.
+ */
+export function resolveFailedTurnPartialRow(
+  input: FailedTurnPartialInput,
+): AssistantMessage | null {
+  const thinking = input.thinking.filter((seg) => seg.trim().length > 0);
+  const prose = stripXmlToolCallBlocks(input.partialText.trim()).trim();
+  if (!prose && thinking.length === 0) return null;
+
+  const { content } = resolveFinalAssistantContent(prose, thinking);
+  const row: AssistantMessage = { role: 'assistant', content, failed: true };
+  if (thinking.length > 0) {
+    row.thinking = thinking;
+  }
+  return row;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,8 @@ export interface AssistantMessage {
   thinkingDurationMs?: number;
   /** User stopped generation before the model finished. */
   stopped?: boolean;
+  /** Turn errored mid-stream; this row is the partial output that was kept. */
+  failed?: true;
   /** Model hit max_tokens; user can continue the reply. */
   truncated?: true;
   stats?: Stats;

--- a/src/ui/composer-pinned-skill.ts
+++ b/src/ui/composer-pinned-skill.ts
@@ -72,7 +72,9 @@ function ensureStrip(): HTMLDivElement {
   const host = document.getElementById('composerControls');
   const anchor = document.getElementById('workAgentDev');
   if (host) {
-    if (anchor) {
+    // The anchor is parked in the compact cog sheet at times, so it is not
+    // always a child of the toolbar — insertBefore would throw NotFoundError.
+    if (anchor?.parentNode === host) {
       host.insertBefore(stripEl, anchor);
     } else {
       host.appendChild(stripEl);

--- a/src/ui/composer-run-target.ts
+++ b/src/ui/composer-run-target.ts
@@ -259,7 +259,9 @@ function ensureControls(): HTMLDivElement {
   const host = document.getElementById('composerControls');
   const anchor = document.getElementById('composerThinkingWrap');
   if (host) {
-    if (anchor) {
+    // The anchor is parked in the compact cog sheet at times, so it is not
+    // always a child of the toolbar — insertBefore would throw NotFoundError.
+    if (anchor?.parentNode === host) {
       host.insertBefore(wrapEl, anchor);
     } else {
       host.appendChild(wrapEl);

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -100,7 +100,7 @@ import { syncTodoPanel } from './todo-panel';
 import { renderThoughtsToggle } from './thought-bubbles';
 import { renderToolCall, renderToolResult } from './tool-messages';
 import { attachShellKillUi } from './shell-run-ui';
-import { markMessageStopped } from './stopped-affordance';
+import { markMessageFailed, markMessageStopped } from './stopped-affordance';
 import { markMessageTruncated } from './truncated-affordance';
 import { markMessageSteered } from './steer-affordance';
 import { restoreGoalAchievedAffordance } from './goal-affordance';
@@ -564,6 +564,9 @@ export function renderChatFromHistory(chat: Chat, mount?: string | HTMLElement):
     }
     if (withThinking.stopped) {
       markMessageStopped(wrap);
+    }
+    if (withThinking.failed) {
+      markMessageFailed(wrap);
     }
     if (withThinking.truncated) {
       markMessageTruncated(wrap, chat);

--- a/src/ui/orchestrate-plan-selector.ts
+++ b/src/ui/orchestrate-plan-selector.ts
@@ -51,9 +51,16 @@ function getComposerControls(): HTMLElement | null {
 /** Home in toolbar: after thinking toggle, before work-agent dev strip. */
 function insertPlanStripInToolbar(strip: HTMLElement): void {
   const toolbar = getComposerControls();
-  const anchor = document.getElementById('workAgentDev');
   if (!toolbar) return;
-  if (anchor) {
+  // Compact parks the strip (and the work-agent anchor) in the cog sheet;
+  // pulling it back here would undo that parking.
+  if (toolbar.classList.contains('composer-controls--compact') && !toolbar.contains(strip)) {
+    return;
+  }
+  const anchor = document.getElementById('workAgentDev');
+  // The anchor is parked in the cog sheet while compact, so it is not always
+  // a child of the toolbar — insertBefore would throw NotFoundError.
+  if (anchor?.parentNode === toolbar) {
     toolbar.insertBefore(strip, anchor);
   } else {
     toolbar.appendChild(strip);

--- a/src/ui/settings-catalog.ts
+++ b/src/ui/settings-catalog.ts
@@ -427,6 +427,12 @@ const SETTINGS_FIELD_CATALOG_ALL: SettingsFieldEntry[] = [
   field('agents.rules.contextDocuments.default', 'Inject context documents by default', 'agents', 'rules'),
   field('agents.rules.contextDocuments.presets', 'Context document presets', 'agents', 'rules'),
   field('agents.rules.contextDocuments.custom', 'Custom context document paths', 'agents', 'rules'),
+  field('agents.rules.reasoningReplay', 'Prior reasoning replay', 'agents', 'rules', {
+    keywords: ['thinking', 'reasoning', 'chain of thought', 'replay', 'context'],
+  }),
+  field('agents.rules.reasoningReplay.enabled', 'Replay prior reasoning', 'agents', 'rules', {
+    keywords: ['thinking', 'reasoning', 'replay'],
+  }),
 
   // —— Integrations ——
   field('integrations.search', 'Web search provider', 'integrations', 'search', {

--- a/src/ui/settings-rules.ts
+++ b/src/ui/settings-rules.ts
@@ -25,6 +25,10 @@ import {
   type UserRulePopoverDraft,
 } from './settings-rules-popover';
 import { renderContextDocumentsRulesSection } from './settings-context-documents';
+import {
+  fetchReplayPriorReasoningEnabled,
+  saveReplayPriorReasoningEnabled,
+} from '../chat/context/reasoning-replay-config';
 
 type StatusFn = (kind: 'ok' | 'err' | 'spin', message: string) => void;
 
@@ -292,6 +296,45 @@ function renderGroupToolbar(
 }
 
 /** Render user rules controls into a settings content mount. */
+/**
+ * Prior-turn reasoning replay. Off by default: it costs tokens on every later turn,
+ * and several providers reject the fields outright (handled per model on send).
+ */
+async function renderReasoningReplaySection(
+  mount: HTMLElement,
+  setStatus: StatusFn,
+): Promise<void> {
+  const enabled = await fetchReplayPriorReasoningEnabled();
+
+  const groupBody = appendSettingsGroup(
+    mount,
+    'Prior reasoning replay',
+    'Send a reply’s reasoning back with it on later turns, so the model can see how it reached earlier answers.',
+    'agents.rules.reasoningReplay',
+    { emphasis: true },
+  );
+
+  const { row, input } = createSettingsToggleRow('Replay prior reasoning', {
+    id: 'settingsReplayPriorReasoning',
+    checked: enabled,
+    searchKey: 'agents.rules.reasoningReplay.enabled',
+    description:
+      'Costs extra tokens on every turn after the first. Tool-call turns already replay their reasoning.',
+    onChange: (checked) => {
+      void (async () => {
+        const ok = await saveReplayPriorReasoningEnabled(checked);
+        if (!ok) {
+          input.checked = enabled;
+          setStatus('err', 'Could not save reasoning replay setting');
+          return;
+        }
+        setStatus('ok', 'Reasoning replay saved');
+      })();
+    },
+  });
+  groupBody.appendChild(row);
+}
+
 export async function renderRulesSettingsSection(
   mount: HTMLElement,
   setStatus: StatusFn,
@@ -311,6 +354,7 @@ export async function renderRulesSettingsSection(
   let settings = normalizeUserRules(await loadUserRules());
 
   await renderContextDocumentsRulesSection(mount, setStatus);
+  await renderReasoningReplaySection(mount, setStatus);
 
   const group = appendSettingsGroup(
     mount,

--- a/src/ui/stopped-affordance.ts
+++ b/src/ui/stopped-affordance.ts
@@ -1,14 +1,33 @@
-/** User-stopped label on an assistant message row (live stream or history reload). */
-export function markMessageStopped(wrap: HTMLElement): void {
-  wrap.classList.add('msg--stopped');
-  if (wrap.querySelector('.msg-stopped-chip')) return;
+/** Chip inserted above an assistant bubble's body (stopped / failed states). */
+function insertMessageChip(
+  wrap: HTMLElement,
+  modifier: string,
+  chipClass: string,
+  text: string,
+): void {
+  wrap.classList.add(modifier);
+  if (wrap.querySelector(`.${chipClass}`)) return;
   const chip = document.createElement('div');
-  chip.className = 'msg-stopped-chip';
-  chip.textContent = 'Generation stopped';
+  chip.className = chipClass;
+  chip.textContent = text;
   const label = wrap.querySelector('.msg-label');
   if (label?.parentElement === wrap) {
     label.insertAdjacentElement('afterend', chip);
   } else {
     wrap.prepend(chip);
   }
+}
+
+/** User-stopped label on an assistant message row (live stream or history reload). */
+export function markMessageStopped(wrap: HTMLElement): void {
+  insertMessageChip(wrap, 'msg--stopped', 'msg-stopped-chip', 'Generation stopped');
+}
+
+/**
+ * Partial-reply label on an assistant row the turn errored out of. The text was
+ * already produced, so it stays in the transcript instead of being rolled back —
+ * the chip is what tells the user the reply is incomplete.
+ */
+export function markMessageFailed(wrap: HTMLElement): void {
+  insertMessageChip(wrap, 'msg--failed', 'msg-failed-chip', 'Partial reply — turn failed');
 }

--- a/test/chat/failed-turn-partial.test.mts
+++ b/test/chat/failed-turn-partial.test.mts
@@ -1,0 +1,95 @@
+/**
+ * A failed turn keeps what it already streamed (partial prose + reasoning).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+import { resolveFailedTurnPartialRow } from '../../src/tools/turn-continuation.ts';
+import { markMessageFailed } from '../../src/ui/stopped-affordance.ts';
+
+function setupDom(): void {
+  const window = new Window();
+  globalThis.document = window.document;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.Node = window.Node;
+}
+
+describe('resolveFailedTurnPartialRow', () => {
+  test('keeps partial prose and reasoning on a failed row', () => {
+    const row = resolveFailedTurnPartialRow({
+      partialText: 'Here is what I found so f',
+      thinking: ['Checking the config first.', '  '],
+    });
+    assert.deepEqual(row, {
+      role: 'assistant',
+      content: 'Here is what I found so f',
+      failed: true,
+      thinking: ['Checking the config first.'],
+    });
+  });
+
+  test('falls back to reasoning when no prose was streamed', () => {
+    const row = resolveFailedTurnPartialRow({
+      partialText: '   ',
+      thinking: ['First thought', 'Second thought'],
+    });
+    assert.equal(row?.failed, true);
+    assert.equal(row?.content, 'First thought\n\nSecond thought');
+  });
+
+  test('stores nothing when the turn produced no output', () => {
+    assert.equal(
+      resolveFailedTurnPartialRow({ partialText: '  ', thinking: [] }),
+      null,
+    );
+    assert.equal(resolveFailedTurnPartialRow({ partialText: '', thinking: ['']}), null);
+  });
+
+  test('stores nothing when the only partial output was tool-call markup', () => {
+    const row = resolveFailedTurnPartialRow({
+      partialText: '<tool_call>{"name":"read_file","arguments":{}}</tool_call>',
+      thinking: [],
+    });
+    assert.equal(row, null);
+  });
+
+  test('keeps prose that accompanied a tool call', () => {
+    const row = resolveFailedTurnPartialRow({
+      partialText: 'Let me look at the file.\n<tool_call>{"name":"read_file","arguments":{}}</tool_call>',
+      thinking: [],
+    });
+    assert.equal(row?.content, 'Let me look at the file.');
+    assert.equal(row?.failed, true);
+  });
+});
+
+describe('failed assistant affordance', () => {
+  test('markMessageFailed adds chip to assistant row', () => {
+    setupDom();
+    const wrap = document.createElement('div');
+    wrap.className = 'msg assistant';
+    const label = document.createElement('div');
+    label.className = 'msg-label';
+    wrap.appendChild(label);
+
+    markMessageFailed(wrap);
+
+    assert.ok(wrap.classList.contains('msg--failed'));
+    assert.equal(
+      wrap.querySelector('.msg-failed-chip')?.textContent,
+      'Partial reply — turn failed',
+    );
+  });
+
+  test('markMessageFailed is idempotent across a re-render', () => {
+    setupDom();
+    const wrap = document.createElement('div');
+    wrap.className = 'msg assistant';
+
+    markMessageFailed(wrap);
+    markMessageFailed(wrap);
+
+    assert.equal(wrap.querySelectorAll('.msg-failed-chip').length, 1);
+  });
+});

--- a/test/chat/first-turn-injection.test.mts
+++ b/test/chat/first-turn-injection.test.mts
@@ -3,8 +3,24 @@
  */
 
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
+import { afterEach, beforeEach, describe, test } from 'node:test';
 import { shouldRunFirstTurnInjections } from '../../src/chat/prompts/first-turn-injection.ts';
+import {
+  buildComposeContext,
+  resolveOutboundSystemMessages,
+} from '../../src/chat/prompts/compose-context.ts';
+import { composeSystemPrompt } from '../../src/chat/prompts/prompt-composer.ts';
+import { appendInjectionNoticesForTurn } from '../../src/chat/context/injection-notice.ts';
+import {
+  DEFAULT_PROMPT_META,
+  resetPromptMetaCache,
+  setPromptMetaCacheForTests,
+} from '../../src/config/prompt-meta.ts';
+import { setSessionStateForTests } from '../../src/state/sessions.ts';
+import {
+  resetWorkspaceStateForTests,
+  setWorkspaceFromServer,
+} from '../../src/state/workspace.ts';
 import type { Chat } from '../../src/types.ts';
 
 function chatWithHistory(roles: Array<'user' | 'assistant'>): Chat {
@@ -49,5 +65,98 @@ describe('shouldRunFirstTurnInjections', () => {
       messageCount: 4,
     };
     assert.equal(shouldRunFirstTurnInjections(chat), false);
+  });
+});
+
+describe('injection replay on later turns', () => {
+  const CHAT_ID = '22222222-2222-2222-2222-222222222222';
+  const WORKSPACE = 'C:/Users/dukky/Documents/Development/Minnow';
+  const STORED_DOCS = 'AGENTS.md says: never re-add repetition_penalty.';
+
+  function chatWithStoredInjection(overrides: Partial<Chat> = {}): Chat {
+    return {
+      id: CHAT_ID,
+      name: 'Test',
+      modeId: 'build',
+      history: [
+        { role: 'user', content: 'first question' },
+        { role: 'injection', kind: 'context-documents', body: STORED_DOCS, createdAt: 1 },
+        { role: 'assistant', content: 'first answer' },
+        { role: 'user', content: 'second question' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+      ...overrides,
+    };
+  }
+
+  let realFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    // No config server here: 404 makes every loader take its documented default,
+    // and stops experts-config rethrowing on the relative URL.
+    realFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(null, { status: 404 })) as typeof globalThis.fetch;
+    resetPromptMetaCache();
+    setPromptMetaCacheForTests({ ...DEFAULT_PROMPT_META });
+    resetWorkspaceStateForTests();
+    setWorkspaceFromServer({ path: WORKSPACE, label: 'Minnow', isDefault: false });
+    setSessionStateForTests(null);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    resetPromptMetaCache();
+    resetWorkspaceStateForTests();
+    setSessionStateForTests(null);
+  });
+
+  test('turn 2 rehydrates the stored body into the composed prompt', async () => {
+    const ctx = await buildComposeContext(chatWithStoredInjection());
+    assert.equal(ctx.contextDocumentsBlock, STORED_DOCS);
+    assert.equal(ctx.contextDocumentsInjectionEnabled, true);
+    assert.equal(ctx.injectionsReplayed, true);
+    assert.ok(composeSystemPrompt(ctx).includes(STORED_DOCS));
+  });
+
+  test('a source switched off mid-chat is not rehydrated', async () => {
+    const ctx = await buildComposeContext(
+      chatWithStoredInjection({ contextDocumentsInjection: 'off' }),
+    );
+    assert.equal(ctx.contextDocumentsBlock, null);
+    assert.equal(ctx.contextDocumentsInjectionEnabled, false);
+    assert.equal(ctx.injectionsReplayed, false);
+  });
+
+  test('a replayed turn reports no injection blocks, so no duplicate transcript row', async () => {
+    const chat = chatWithStoredInjection();
+    const outbound = await resolveOutboundSystemMessages(chat, '');
+    assert.ok(outbound.composed.includes(STORED_DOCS));
+    assert.deepEqual(outbound.injectionBlocks, {
+      brainNotes: null,
+      codeMap: null,
+      contextDocuments: null,
+    });
+    assert.deepEqual(appendInjectionNoticesForTurn(chat, outbound.injectionBlocks), []);
+    assert.equal(chat.history.filter((m) => m.role === 'injection').length, 1);
+  });
+
+  test('the replay cap drops a body too large for the model window', async () => {
+    const chat = chatWithStoredInjection({
+      history: [
+        { role: 'user', content: 'first question' },
+        {
+          role: 'injection',
+          kind: 'context-documents',
+          body: 'x'.repeat(40_000),
+          createdAt: 1,
+        },
+        { role: 'assistant', content: 'first answer' },
+      ],
+    });
+    const ctx = await buildComposeContext(chat, { modelContextLimit: 8_000 });
+    assert.equal(ctx.contextDocumentsBlock, null);
+    assert.equal(ctx.injectionsReplayed, false);
   });
 });

--- a/test/chat/injection-replay.test.mts
+++ b/test/chat/injection-replay.test.mts
@@ -1,0 +1,125 @@
+/**
+ * Replaying first-turn prompt injections from persisted transcript rows.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  capInjectionReplay,
+  INJECTION_REPLAY_FALLBACK_TOKEN_CAP,
+  latestInjectionBodies,
+  resolveInjectionReplay,
+  resolveInjectionReplayTokenCap,
+} from '../../src/chat/context/injection-replay.ts';
+import type { Message, PromptInjectionKind } from '../../src/types.ts';
+
+function injection(kind: PromptInjectionKind, body: string): Message {
+  return { role: 'injection', kind, body, createdAt: 1 };
+}
+
+/** Text that estimates to roughly `tokens` (estimator is chars ÷ 4). */
+function bodyOfTokens(tokens: number): string {
+  return 'x'.repeat(tokens * 4);
+}
+
+describe('latestInjectionBodies', () => {
+  test('picks the last stored body per kind', () => {
+    const history: Message[] = [
+      { role: 'user', content: 'hi' },
+      injection('code-map', 'map v1'),
+      injection('context-documents', 'docs'),
+      { role: 'assistant', content: 'ok' },
+      injection('code-map', 'map v2'),
+    ];
+    assert.deepEqual(latestInjectionBodies(history), {
+      'code-map': 'map v2',
+      'context-documents': 'docs',
+    });
+  });
+
+  test('ignores non-injection rows and blank bodies', () => {
+    const history: Message[] = [
+      { role: 'context', kind: 'compress', body: 'summary', createdAt: 1 } as Message,
+      injection('brain-notes', '   '),
+      { role: 'assistant', content: 'ok' },
+    ];
+    assert.deepEqual(latestInjectionBodies(history), {});
+  });
+
+  test('returns nothing for a transcript with no injections', () => {
+    assert.deepEqual(latestInjectionBodies([{ role: 'user', content: 'hi' }]), {});
+  });
+});
+
+describe('resolveInjectionReplayTokenCap', () => {
+  test('uses a fifth of the model window', () => {
+    assert.equal(resolveInjectionReplayTokenCap(100_000), 20_000);
+  });
+
+  test('falls back to a fixed cap when the window is unknown', () => {
+    assert.equal(
+      resolveInjectionReplayTokenCap(null),
+      INJECTION_REPLAY_FALLBACK_TOKEN_CAP,
+    );
+    assert.equal(
+      resolveInjectionReplayTokenCap(undefined),
+      INJECTION_REPLAY_FALLBACK_TOKEN_CAP,
+    );
+    assert.equal(resolveInjectionReplayTokenCap(0), INJECTION_REPLAY_FALLBACK_TOKEN_CAP);
+  });
+});
+
+describe('capInjectionReplay', () => {
+  test('keeps everything when it fits', () => {
+    const bodies = {
+      'brain-notes': 'notes',
+      'code-map': 'map',
+      'context-documents': 'docs',
+    };
+    assert.deepEqual(capInjectionReplay(bodies, { modelContextLimit: 100_000 }), bodies);
+  });
+
+  test('fills in priority order: context documents, then brain notes, then code map', () => {
+    // Cap is 1,000 tokens; docs (600) + notes (300) fit, the map (600) does not.
+    const capped = capInjectionReplay(
+      {
+        'context-documents': bodyOfTokens(600),
+        'brain-notes': bodyOfTokens(300),
+        'code-map': bodyOfTokens(600),
+      },
+      { modelContextLimit: 5_000 },
+    );
+    assert.deepEqual(Object.keys(capped).sort(), ['brain-notes', 'context-documents']);
+  });
+
+  test('drops a kind whole rather than truncating it', () => {
+    const capped = capInjectionReplay(
+      { 'code-map': bodyOfTokens(5_000) },
+      { modelContextLimit: 5_000 },
+    );
+    assert.deepEqual(capped, {});
+  });
+
+  test('a later kind still fits after an oversized one is skipped', () => {
+    const capped = capInjectionReplay(
+      {
+        'context-documents': bodyOfTokens(2_000),
+        'code-map': bodyOfTokens(10),
+      },
+      { modelContextLimit: 5_000 },
+    );
+    assert.deepEqual(Object.keys(capped), ['code-map']);
+  });
+});
+
+describe('resolveInjectionReplay', () => {
+  test('reads the transcript and applies the cap in one pass', () => {
+    const history: Message[] = [
+      { role: 'user', content: 'hi' },
+      injection('context-documents', 'docs body'),
+      injection('code-map', bodyOfTokens(10_000)),
+    ];
+    const replay = resolveInjectionReplay(history, { modelContextLimit: 8_000 });
+    assert.deepEqual(replay, { 'context-documents': 'docs body' });
+  });
+});

--- a/test/config/sessions-restart-context-fidelity.test.mts
+++ b/test/config/sessions-restart-context-fidelity.test.mts
@@ -1,0 +1,164 @@
+/**
+ * What the model sees after a restart must equal what it saw before one.
+ *
+ * The storage layer is the half that has to be byte-exact: every field the prompt
+ * builder reads back — `thinking`, `thinkingSignature`, `tool_calls`, the UI-only
+ * `injection` rows that Phase 1 replays, and the `failed` partial a broken turn
+ * leaves behind — has to survive the SQLite round-trip untouched.
+ */
+
+import assert from 'node:assert/strict';
+import { after, before, describe, test } from 'node:test';
+
+import { closeSessionsDb } from '../../server/config/sessions-db.js';
+import {
+  readChatHistory,
+  readWholeSessionState,
+  writeWholeSessionState,
+} from '../../server/config/sessions-repo.js';
+// @ts-expect-error - JS helper without type declarations
+import { rmTestHome, setTestHome } from './test-helpers.js';
+
+const CHAT_ID = '33333333-3333-3333-3333-333333333333';
+
+/** Every persisted message shape the send path reads back on a later turn. */
+const HISTORY: unknown[] = [
+  { role: 'user', content: 'What does AGENTS.md say about samplers?' },
+  {
+    role: 'injection',
+    kind: 'context-documents',
+    body: '# AGENTS.md\n\nLoop control uses presence_penalty, never repetition_penalty.',
+    createdAt: 1_700_000_000_000,
+  },
+  {
+    role: 'injection',
+    kind: 'code-map',
+    body: 'src/chat/prompts/compose-context.ts — buildComposeContext',
+    createdAt: 1_700_000_000_001,
+  },
+  {
+    role: 'assistant',
+    content: null,
+    tool_calls: [
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'read_file', arguments: '{"path":"AGENTS.md"}' },
+      },
+    ],
+    thinking: ['I should read the file first.', 'Then quote the sampler rule.'],
+    thinkingSignature: 'sig_abc123',
+    thinkingDurationMs: 1_450,
+  },
+  { role: 'tool', tool_call_id: 'call_1', content: '# AGENTS.md\n…' },
+  {
+    role: 'assistant',
+    content: 'It says loop control goes through presence_penalty.',
+    thinking: ['The answer is in the sampler section.'],
+    thinkingDurationMs: 300,
+    stats: { tokensPerSecond: 42 },
+  },
+  { role: 'user', content: 'And the second turn?' },
+  {
+    role: 'assistant',
+    content: 'Partial answer before the provi',
+    failed: true,
+    thinking: ['Starting to draft the comparison.'],
+  },
+];
+
+function stateWithHistory(): Record<string, unknown> {
+  return {
+    version: 6,
+    activeId: CHAT_ID,
+    sidebarCollapsed: false,
+    groups: [],
+    chats: [
+      {
+        id: CHAT_ID,
+        name: 'Restart fidelity',
+        workspacePath: '',
+        modelId: 'test-model',
+        history: structuredClone(HISTORY),
+        lastStats: null,
+        modelInfo: {},
+        updatedAt: 1_700_000_000_002,
+        lastMessageAt: 1_700_000_000_002,
+      },
+    ],
+  };
+}
+
+describe('restart context fidelity', () => {
+  let homeDir: string;
+  let savedHome: string | undefined;
+  let savedStore: string | undefined;
+
+  before(() => {
+    savedHome = process.env.MINNOW_HOME;
+    savedStore = process.env.MINNOW_SESSIONS_STORE;
+    delete process.env.MINNOW_SESSIONS_STORE;
+    homeDir = setTestHome(process.env, `minnow-restart-fidelity-${Date.now()}`);
+    writeWholeSessionState(stateWithHistory());
+  });
+
+  after(() => {
+    closeSessionsDb();
+    if (savedHome === undefined) delete process.env.MINNOW_HOME;
+    else process.env.MINNOW_HOME = savedHome;
+    if (savedStore === undefined) delete process.env.MINNOW_SESSIONS_STORE;
+    else process.env.MINNOW_SESSIONS_STORE = savedStore;
+    return rmTestHome(homeDir);
+  });
+
+  test('every message payload round-trips byte-for-byte', () => {
+    const restored = readChatHistory(CHAT_ID);
+    assert.deepEqual(restored, JSON.parse(JSON.stringify(HISTORY)));
+  });
+
+  test('the whole-state read returns the full unpaged transcript', () => {
+    const state = readWholeSessionState() as { chats: Array<{ id: string; history: unknown[] }> };
+    const chat = state.chats.find((c) => c.id === CHAT_ID);
+    assert.ok(chat, 'chat missing after restart');
+    assert.equal(chat.history.length, HISTORY.length);
+  });
+
+  test('injection rows survive, so Phase 1 has bodies to replay', () => {
+    const restored = readChatHistory(CHAT_ID) as Array<{
+      role: string;
+      kind?: string;
+      body?: string;
+    }>;
+    const injections = restored.filter((m) => m.role === 'injection');
+    assert.deepEqual(
+      injections.map((m) => m.kind),
+      ['context-documents', 'code-map'],
+    );
+    assert.ok(injections[0].body?.includes('presence_penalty'));
+  });
+
+  test('assistant reasoning and tool-call signatures survive', () => {
+    const restored = readChatHistory(CHAT_ID) as Array<Record<string, unknown>>;
+    const toolTurn = restored.find((m) => Array.isArray(m.tool_calls));
+    assert.ok(toolTurn, 'tool-call turn missing after restart');
+    assert.equal(toolTurn.thinkingSignature, 'sig_abc123');
+    assert.deepEqual(toolTurn.thinking, [
+      'I should read the file first.',
+      'Then quote the sampler rule.',
+    ]);
+  });
+
+  test('a failed turn keeps its partial text, reasoning, and chip flag', () => {
+    const restored = restoredFailedRow();
+    assert.equal(restored.failed, true);
+    assert.equal(restored.content, 'Partial answer before the provi');
+    assert.deepEqual(restored.thinking, ['Starting to draft the comparison.']);
+  });
+
+  function restoredFailedRow(): Record<string, unknown> {
+    const restored = readChatHistory(CHAT_ID) as Array<Record<string, unknown>>;
+    const row = restored.find((m) => m.failed === true);
+    assert.ok(row, 'failed partial row missing after restart');
+    return row;
+  }
+});

--- a/test/server/generation-checkpoint.test.mjs
+++ b/test/server/generation-checkpoint.test.mjs
@@ -1,0 +1,189 @@
+/**
+ * Generation checkpoints: an in-flight stream survives losing the in-memory state.
+ */
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { after, afterEach, before, describe, test } from 'node:test';
+
+import { resetMinnowHomeCache } from '../../server/config/home.js';
+import {
+  INTERRUPTED_BY_RESTART_MESSAGE,
+  checkpointAppend,
+  checkpointCreated,
+  deleteCheckpoint,
+  flushAllCheckpoints,
+  readCheckpoint,
+  resetCheckpointWritersForTests,
+  sweepCheckpoints,
+} from '../../server/generations/checkpoint.js';
+import {
+  addSubscriber,
+  appendChunk,
+  createGenerationState,
+  deleteGenerationsForProviderShutdown,
+  getGenerationState,
+  markComplete,
+} from '../../server/generations/store.js';
+import { rmTestHome, setTestHome } from '../config/test-helpers.js';
+
+/** Minimal ServerResponse stand-in that records everything written to it. */
+function fakeResponse() {
+  const chunks = [];
+  return {
+    writableEnded: false,
+    destroyed: false,
+    write(buf) {
+      chunks.push(Buffer.from(buf));
+      return true;
+    },
+    end() {
+      this.writableEnded = true;
+    },
+    destroy() {
+      this.destroyed = true;
+    },
+    once() {},
+    on() {},
+    text() {
+      return Buffer.concat(chunks).toString('utf8');
+    },
+  };
+}
+
+function sseChunk(text) {
+  return Buffer.from(
+    `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`,
+    'utf8',
+  );
+}
+
+/** Forget every in-memory generation without touching disk. */
+function dropInMemoryState() {
+  deleteGenerationsForProviderShutdown();
+  resetCheckpointWritersForTests();
+}
+
+describe('generation checkpoints', () => {
+  let homeDir;
+  let savedHome;
+
+  before(() => {
+    savedHome = process.env.MINNOW_HOME;
+    homeDir = setTestHome(process.env, `minnow-generation-checkpoint-${Date.now()}`);
+    fs.mkdirSync(homeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    resetCheckpointWritersForTests();
+  });
+
+  after(() => {
+    resetMinnowHomeCache();
+    if (savedHome === undefined) delete process.env.MINNOW_HOME;
+    else process.env.MINNOW_HOME = savedHome;
+    return rmTestHome(homeDir);
+  });
+
+  test('a completed generation replays from disk after the state is dropped', () => {
+    const state = createGenerationState({ providerId: 'p1', body: {}, persist: true });
+    const id = state.id;
+    appendChunk(state, sseChunk('Hello'));
+    appendChunk(state, sseChunk(' world'));
+    markComplete(state);
+
+    dropInMemoryState();
+    assert.equal(readCheckpoint(id)?.status, 'complete');
+
+    const rehydrated = getGenerationState(id);
+    assert.ok(rehydrated, 'checkpoint did not rehydrate');
+    assert.equal(rehydrated.status, 'complete');
+
+    const res = fakeResponse();
+    addSubscriber(rehydrated, res);
+    const replayed = res.text();
+    assert.ok(replayed.includes('Hello'));
+    assert.ok(replayed.includes(' world'));
+    assert.match(replayed, /event: end\ndata: \{"status":"complete"\}/);
+
+    deleteCheckpoint(id);
+  });
+
+  test('a stream killed mid-flight comes back as an error carrying its bytes', () => {
+    // A killed process leaves a sidecar still reading `streaming` next to whatever
+    // bytes were already flushed. Build exactly that pair — a graceful shutdown
+    // would instead mark the generation cancelled.
+    const id = randomUUID();
+    const state = {
+      id,
+      persist: true,
+      status: 'streaming',
+      providerId: 'p1',
+      chatId: 'chat-1',
+      chosenProviderId: 'p1',
+      chosenModelId: 'm1',
+      fallbackUsed: false,
+      errorMessage: null,
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+    };
+    checkpointCreated(state);
+    checkpointAppend(state, sseChunk('Half a rep'));
+    flushAllCheckpoints();
+
+    const saved = readCheckpoint(id);
+    assert.equal(saved?.status, 'error');
+    assert.equal(saved.meta.errorMessage, INTERRUPTED_BY_RESTART_MESSAGE);
+
+    const rehydrated = getGenerationState(id);
+    assert.ok(rehydrated, 'interrupted checkpoint did not rehydrate');
+    assert.equal(rehydrated.status, 'error');
+    assert.equal(rehydrated.errorMessage, INTERRUPTED_BY_RESTART_MESSAGE);
+    assert.equal(rehydrated.chatId, 'chat-1');
+
+    const res = fakeResponse();
+    addSubscriber(rehydrated, res);
+    const replayed = res.text();
+    assert.ok(replayed.includes('Half a rep'));
+    assert.match(replayed, /event: end\ndata: \{"status":"error"/);
+    assert.ok(replayed.includes(INTERRUPTED_BY_RESTART_MESSAGE));
+
+    dropInMemoryState();
+    deleteCheckpoint(id);
+  });
+
+  test('an ephemeral generation writes nothing to disk', () => {
+    const state = createGenerationState({ providerId: 'p1', body: {}, persist: false });
+    const id = state.id;
+    appendChunk(state, sseChunk('ignored'));
+    markComplete(state);
+    dropInMemoryState();
+
+    assert.equal(readCheckpoint(id), null);
+    assert.equal(getGenerationState(id), undefined);
+  });
+
+  test('an unknown id still rehydrates to nothing', () => {
+    assert.equal(getGenerationState(randomUUID()), undefined);
+  });
+
+  test('the boot sweep drops checkpoints past the retention window', () => {
+    const state = createGenerationState({ providerId: 'p1', body: {}, persist: true });
+    const id = state.id;
+    appendChunk(state, sseChunk('old reply'));
+    markComplete(state);
+    dropInMemoryState();
+
+    const dir = path.join(homeDir, 'generations');
+    const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    for (const name of [`${id}.sse`, `${id}.json`]) {
+      fs.utimesSync(path.join(dir, name), twoDaysAgo, twoDaysAgo);
+    }
+
+    const swept = sweepCheckpoints();
+    assert.ok(swept.removed >= 1, 'sweep removed nothing');
+    assert.equal(readCheckpoint(id), null);
+  });
+});

--- a/test/tools/install-dom-before-imports.mts
+++ b/test/tools/install-dom-before-imports.mts
@@ -1,0 +1,19 @@
+/**
+ * Side-effect module: put a happy-dom `window` on globalThis before anything else.
+ *
+ * `dompurify` builds its sanitizer against `globalThis.window` at module eval, so a
+ * suite that installs the DOM inside a test gets a DOMPurify with no `sanitize` —
+ * every markdown render then throws. ESM evaluates imports in source order, so
+ * importing this first makes the window exist by the time the renderer loads.
+ */
+
+import { Window } from 'happy-dom';
+
+const window = new Window();
+const g = globalThis as unknown as Record<string, unknown>;
+g.window = window;
+g.document = window.document;
+g.HTMLElement = window.HTMLElement;
+g.Node = window.Node;
+g.Element = window.Element;
+g.DocumentFragment = window.DocumentFragment;

--- a/test/tools/loop-resume.test.mts
+++ b/test/tools/loop-resume.test.mts
@@ -2,6 +2,10 @@
  * MIN-187: boot resume must subscribe once; post-tool rounds POST new generations.
  */
 
+// Must come first: dompurify binds to globalThis.window at module eval, and the
+// tool loop renders assistant markdown on both the success and failure paths.
+import './install-dom-before-imports.mts';
+
 import assert from 'node:assert/strict';
 import { afterEach, describe, test } from 'node:test';
 import { Window } from 'happy-dom';

--- a/test/tools/reasoning-replay.test.mts
+++ b/test/tools/reasoning-replay.test.mts
@@ -1,0 +1,128 @@
+/**
+ * Opt-in replay of prior-turn reasoning on plain assistant rows.
+ *
+ * Tool-call rows always replay their reasoning (Anthropic pairs it with the
+ * signature); a finished prose turn only does so when `features.replayPriorReasoning`
+ * is on, and never for providers that reject the fields.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { buildApiMessages } from '../../src/tools/loop.ts';
+import {
+  estimateHistoryTokens,
+  historyToApiMessagesForEstimate,
+} from '../../src/chat/prompts/token-estimate-core.ts';
+import type { ApiAssistantMessage, ApiMessage, Chat, Message } from '../../src/types.ts';
+
+const THINKING = ['First I checked the sampler defaults.', 'They use presence_penalty.'];
+const JOINED = THINKING.join('\n\n');
+
+const HISTORY: Message[] = [
+  { role: 'user', content: 'Which penalty do we use?' },
+  { role: 'assistant', content: 'presence_penalty.', thinking: THINKING },
+  { role: 'user', content: 'Why?' },
+];
+
+function chat(): Chat {
+  return {
+    id: 'chat-reasoning-1',
+    name: 'Reasoning replay',
+    workspacePath: '/tmp/ws',
+    modelId: 'test-model',
+    modeId: 'build',
+    history: [...HISTORY],
+    lastStats: null,
+    modelInfo: {},
+    updatedAt: 1,
+  };
+}
+
+function firstAssistant(messages: ApiMessage[]): ApiAssistantMessage {
+  const found = messages.find((m) => m.role === 'assistant');
+  assert.ok(found, 'no assistant message in payload');
+  return found as ApiAssistantMessage;
+}
+
+describe('buildApiMessages prior-reasoning replay', () => {
+  test('is omitted by default', () => {
+    const messages = buildApiMessages(chat(), '', { modelId: 'gpt-4o', attachments: [] });
+    const assistant = firstAssistant(messages);
+    assert.equal(assistant.reasoning, undefined);
+    assert.equal(assistant.reasoning_content, undefined);
+  });
+
+  test('replays reasoning when the feature is on', () => {
+    const messages = buildApiMessages(chat(), '', {
+      modelId: 'gpt-4o',
+      attachments: [],
+      replayPriorReasoning: true,
+    });
+    const assistant = firstAssistant(messages);
+    assert.equal(assistant.content, 'presence_penalty.');
+    assert.equal(assistant.reasoning, JOINED);
+  });
+
+  test('uses reasoning_content for DeepSeek', () => {
+    const messages = buildApiMessages(chat(), '', {
+      modelId: 'deepseek-chat',
+      attachments: [],
+      replayPriorReasoning: true,
+    });
+    const assistant = firstAssistant(messages);
+    assert.equal(assistant.reasoning_content, JOINED);
+    assert.equal(assistant.reasoning, undefined);
+  });
+
+  test('sends nothing for providers that reject the fields', () => {
+    const messages = buildApiMessages(chat(), '', {
+      modelId: 'kimi-k2',
+      attachments: [],
+      replayPriorReasoning: true,
+    });
+    const assistant = firstAssistant(messages);
+    assert.equal(assistant.reasoning, undefined);
+    assert.equal(assistant.reasoning_content, undefined);
+  });
+
+  test('a reply with no reasoning is unchanged', () => {
+    const plain = chat();
+    plain.history = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ];
+    const messages = buildApiMessages(plain, '', {
+      modelId: 'gpt-4o',
+      attachments: [],
+      replayPriorReasoning: true,
+    });
+    assert.deepEqual(firstAssistant(messages), { role: 'assistant', content: 'hello' });
+  });
+});
+
+describe('token estimate mirrors the replay', () => {
+  test('estimate payload carries the same reasoning field', () => {
+    const messages = historyToApiMessagesForEstimate(HISTORY, {
+      replayPriorReasoning: true,
+      modelId: 'gpt-4o',
+    });
+    assert.equal(firstAssistant(messages).reasoning, JOINED);
+  });
+
+  test('replayed reasoning raises the history token count', () => {
+    const base = estimateHistoryTokens(HISTORY);
+    const withReplay = estimateHistoryTokens(HISTORY, {
+      replayPriorReasoning: true,
+      modelId: 'gpt-4o',
+    });
+    assert.ok(withReplay > base, 'replay did not add tokens to the estimate');
+  });
+
+  test('a rejecting provider does not inflate the estimate', () => {
+    assert.equal(
+      estimateHistoryTokens(HISTORY, { replayPriorReasoning: true, modelId: 'kimi-k2' }),
+      estimateHistoryTokens(HISTORY),
+    );
+  });
+});

--- a/test/ui/orchestrate-plan-selector.test.mts
+++ b/test/ui/orchestrate-plan-selector.test.mts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
-import { shouldMountOrchestratePlanInInputRow } from '../../src/ui/orchestrate-plan-selector.ts';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+import { installHappyDomGlobals } from '../os/dom-helpers.mts';
+import {
+  shouldMountOrchestratePlanInInputRow,
+  syncOrchestratePlanStripFromActiveChat,
+} from '../../src/ui/orchestrate-plan-selector.ts';
+import { createEmptyChatObject, setSessionStateForTests } from '../../src/state/sessions.ts';
 
 describe('shouldMountOrchestratePlanInInputRow', () => {
   test('false outside Orchestrate mode', () => {
@@ -30,5 +36,61 @@ describe('shouldMountOrchestratePlanInInputRow', () => {
       }),
       false,
     );
+  });
+});
+
+describe('plan strip toolbar placement', () => {
+  let windowInstance: Window | null = null;
+
+  afterEach(() => {
+    windowInstance?.close();
+    windowInstance = null;
+    setSessionStateForTests(null);
+  });
+
+  // Regression: compact parks both the plan strip and its `#workAgentDev`
+  // anchor in the cog sheet, so insertBefore against the toolbar threw
+  // NotFoundError when a new chat synced the strip.
+  test('compact-parked strip is left in the cog sheet, not re-inserted', async () => {
+    windowInstance = new Window();
+    installHappyDomGlobals(windowInstance);
+
+    const bar = document.createElement('div');
+    bar.className = 'input-bar';
+    const row = document.createElement('div');
+    row.id = 'composerControls';
+    row.className = 'composer-controls composer-controls--compact';
+    const wrap = document.createElement('div');
+    wrap.className = 'input-wrap';
+    const page = document.createElement('div');
+    page.id = 'composerOverflowSettingsPage';
+
+    const strip = document.createElement('div');
+    strip.id = 'orchestratePlanStrip';
+    const select = document.createElement('select');
+    select.id = 'orchestratePlanSelect';
+    const hint = document.createElement('span');
+    hint.id = 'orchestratePlanHint';
+    strip.append(select, hint);
+    const workAgentDev = document.createElement('div');
+    workAgentDev.id = 'workAgentDev';
+    page.append(strip, workAgentDev);
+
+    bar.append(row, wrap);
+    document.body.append(bar, page);
+
+    const chat = createEmptyChatObject('');
+    chat.modeId = 'build';
+    setSessionStateForTests({
+      version: 2,
+      activeId: chat.id,
+      sidebarCollapsed: false,
+      chats: [chat],
+    });
+
+    await syncOrchestratePlanStripFromActiveChat();
+
+    assert.equal(strip.parentElement?.id, 'composerOverflowSettingsPage');
+    assert.equal(strip.classList.contains('hidden'), true);
   });
 });


### PR DESCRIPTION
## Summary

A verification pass proved storage/rehydration is sound (message payloads round-trip byte-for-byte, history endpoint returns the full transcript, both send paths await history load, `buildApiMessages` is stable across a restart). The actual context losses were elsewhere:

- **Injected context dropped after turn 1.** The prompt is rebuilt from live settings on every send (correct), but Brain-notes / code-map / context-document retrieval only ever runs on the first user turn — so turn 2 onward silently carried none of it. Injections now replay from the persisted `injection` transcript rows, capped at 20% of the model context window (these land as pinned system content the context policy can't trim), priority context-documents → brain-notes → code-map, dropping a kind whole rather than truncating it.
- **A failed turn discarded its streamed output**, while a user-stopped turn kept it. A turn that errors mid-stream now persists the partial as a `failed: true` assistant row with a "Partial reply — turn failed" chip, same as the existing stopped-turn behavior. Half-parsed tool-call markup is dropped rather than replayed as prose.
- **In-flight generations lived only in a memory `Map`.** Persisted generations now checkpoint their raw SSE bytes to `~/.minnow/generations/<id>.{sse,json}` (throttled, never per-chunk); a restart can rehydrate and replay a terminal generation, or surface an "interrupted" error carrying whatever bytes it did produce if the process died mid-stream. Boot sweep drops checkpoints past 24h or past a total size cap.
- **Prior-turn reasoning is never replayed** on plain assistant rows (tool-call rows already do, since Anthropic requires the signature to pair with `tool_use`). Added opt-in `features.replayPriorReasoning` (default off — costs tokens on every later turn, and some providers reject the fields) with a settings toggle under Agents → Rules.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] New unit/integration coverage: `test/chat/injection-replay.test.mts`, `test/chat/failed-turn-partial.test.mts`, `test/server/generation-checkpoint.test.mjs`, `test/tools/reasoning-replay.test.mts`, extended `test/chat/first-turn-injection.test.mts` and `test/config/sessions-restart-context-fidelity.test.mts`
- [x] Full `npm test` — no new failures vs. a stashed baseline (remaining failures are pre-existing worktree artifacts: Electron build needs `node_modules` this worktree doesn't have, plus 3 suites that fail on clean `main`)
- [ ] Manual: could not run the desktop shell from this worktree (no local `node_modules` → Electron build fails). Needs a manual pass from the main checkout: turn-2 context-ring non-zero, mid-stream server kill + restart replay, forced provider error leaves a failed-chip partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)