### PR TITLE
Fix orchestrate board display-wake poll killing live task chats

### DIFF
--- a/src/chat/orchestrate/board-display-wake.ts
+++ b/src/chat/orchestrate/board-display-wake.ts
@@ -5,11 +5,24 @@
 
 import { reportBackgroundError } from '../../boot/report-background-error.ts';
 import { hasIncompleteOrchestrateWork } from './plan-complete.ts';
+import { isOomPauseActive } from './oom-recovery.ts';
 import { reconcileRunningBoardsAfterDisplayWake } from '../../state/orchestrate-board-actions.ts';
 import { sessionState } from '../../state/sessions.ts';
 
 /** Safety net when visibility / unlock IPC is missed during lock. */
 const BOARD_LIVENESS_INTERVAL_MS = 20_000;
+
+/**
+ * How long a task chat must be silent before this poll may treat it as stalled.
+ *
+ * The poll is a backstop for a wake notification that never arrived, not a
+ * supervisor — stall detection proper belongs to the heartbeat. Without a quiet
+ * period it fired every 20s regardless of what the chats were doing and walked
+ * live Builders through nudge → nudge → fail → quarantine in about a minute.
+ * Comfortably longer than a slow tool round; the supervision clock this is
+ * measured against freezes while the display is asleep.
+ */
+const BOARD_LIVENESS_MIN_QUIET_MS = 180_000;
 
 let wakeListenerBound = false;
 let wakeReconcileInFlight: Promise<void> | null = null;
@@ -18,10 +31,14 @@ let boardLivenessTimer: ReturnType<typeof setInterval> | null = null;
 function shouldRunBoardLivenessPoll(): boolean {
   const groups = sessionState?.groups;
   if (!groups?.length) return false;
+  // A board paused after an OOM crash waits for the user to press Start; polling
+  // it forever would spin a wake every 20s with nothing to reconcile.
+  const oomPaused = isOomPauseActive();
   for (const group of groups) {
     const board = group.orchestrateBoard;
     if (!board || !hasIncompleteOrchestrateWork(board)) continue;
-    if (board.autoRunning === true || board.systemPaused === true) return true;
+    if (board.autoRunning === true) return true;
+    if (board.systemPaused === true && !oomPaused) return true;
   }
   return false;
 }
@@ -31,7 +48,7 @@ function syncBoardLivenessPoll(): void {
   if (shouldRunBoardLivenessPoll()) {
     if (boardLivenessTimer != null) return;
     boardLivenessTimer = setInterval(() => {
-      scheduleBoardWakeReconcile(true);
+      scheduleBoardWakeReconcile(true, BOARD_LIVENESS_MIN_QUIET_MS);
     }, BOARD_LIVENESS_INTERVAL_MS);
     return;
   }
@@ -41,9 +58,15 @@ function syncBoardLivenessPoll(): void {
   }
 }
 
-function scheduleBoardWakeReconcile(allowStalledRestart: boolean): void {
+function scheduleBoardWakeReconcile(
+  allowStalledRestart: boolean,
+  minQuietMs = 0,
+): void {
   if (wakeReconcileInFlight) return;
-  wakeReconcileInFlight = reconcileRunningBoardsAfterDisplayWake({ allowStalledRestart })
+  wakeReconcileInFlight = reconcileRunningBoardsAfterDisplayWake({
+    allowStalledRestart,
+    minQuietMs,
+  })
     .catch((err) => reportBackgroundError('board-display-wake-reconcile', err))
     .finally(() => {
       wakeReconcileInFlight = null;

--- a/src/state/orchestrate-board-actions.ts
+++ b/src/state/orchestrate-board-actions.ts
@@ -65,7 +65,8 @@ import {
 } from '../chat/orchestrate/board-afk-power.ts';
 import { runChatTurn } from '../tools/loop.ts';
 import { reportBackgroundError } from '../boot/report-background-error.ts';
-import { setStreaming } from '../app-state.ts';
+import { getChatAbort, setStreaming } from '../app-state.ts';
+import { getMainTurnActivity } from '../chat/main-turn-activity.ts';
 import { normalizeVerdict } from '../tools/board-tools.ts';
 import { schedulePostTurnSynthesis } from '../synthesis/client.ts';
 import { buildSynthesisMessages, buildSynthesisExcerpt } from '../synthesis/post-turn.ts';
@@ -1551,6 +1552,50 @@ function isTaskChatStreaming(chatId: string): boolean {
   );
 }
 
+/**
+ * Positive proof that a task chat still has a turn in flight.
+ *
+ * The two signals the wake sweep used to rely on cannot tell "finished" from
+ * "mid-turn": `isChatStreaming` is a UI flag the sweep itself is allowed to
+ * clear, and {@link resolveTaskChatStreamOutcome} only reads persisted history,
+ * where a live chat between tool rounds looks exactly like a completed one
+ * (last entry = an ordinary assistant message = `completed`). The 20s liveness
+ * poll therefore finalized live Builders as "ended without board_report" while
+ * their generation kept running — the board relaunched the task while the
+ * orphaned chat carried on editing the same worktree.
+ *
+ * Both signals are owned by `runChatTurn` and cleared in its `finally`, so they
+ * span the whole turn including long tool runs. (`chat.currentGenerationId`
+ * looks like a third signal but is not cleared on every completion path — boot
+ * even has a heuristic to tidy it up — so it would report dead chats as live.)
+ */
+function isTaskChatGenerationLive(chatId: string): boolean {
+  const id = chatId.trim();
+  if (!id) return false;
+  return Boolean(getMainTurnActivity(id)) || Boolean(getChatAbort(id));
+}
+
+/**
+ * True when the chat emitted stream / tool / terminal output within `minQuietMs`.
+ * Uses the supervision clock, which freezes while the page is hidden, so time
+ * spent with the display asleep never counts toward the quiet period.
+ */
+function isRecentlyActiveTaskChat(chatId: string, minQuietMs: number): boolean {
+  if (minQuietMs <= 0) return false;
+  const age = getProgressAgeMs(chatTaskRunId(chatId.trim()));
+  return age !== null && age < minQuietMs;
+}
+
+/**
+ * Stall predicate for the interval-driven liveness poll: a chat that produced
+ * output moments ago is not a stuck slot, even if every other flag says idle.
+ */
+function stallCheckWithQuietPeriod(minQuietMs: number): (chatId: string) => boolean {
+  if (minQuietMs <= 0) return isTaskChatActiveForStallCheck;
+  return (chatId: string) =>
+    isTaskChatActiveForStallCheck(chatId) || isRecentlyActiveTaskChat(chatId, minQuietMs);
+}
+
 /** Provider/model for board chats — board override, then planner / top bar / settings default. */
 function resolvePlannerModelBinding(
   plannerChat: Chat,
@@ -1617,17 +1662,42 @@ function getOrCreateBoardChat(input: {
   if (input.taskId) chat.boardTaskId = input.taskId;
   requireSession().chats.unshift(chat);
   if (input.taskId && input.taskChatField) {
+    const field = input.taskChatField;
+    const replaced = input.group.orchestrateBoard?.tasks
+      .find((t) => t.id === input.taskId)?.[field]
+      ?.trim();
     updateTask(
       input.group,
       input.taskId,
-      { [input.taskChatField]: chat.id },
+      { [field]: chat.id },
       input.plannerChat,
     );
+    if (replaced) stopReplacedBoardTaskChat(replaced, chat.id);
   }
   assignChatToGroup(chat.id, folderId);
   const board = input.group.orchestrateBoard;
   if (board) applyBoardReasoningToChat(chat, board);
   return chat;
+}
+
+/**
+ * Stop a phase chat the board just stopped pointing at.
+ *
+ * Replacing `chatId` / `testChatId` / `fixerChatId` orphans the previous chat:
+ * nothing on the board holds its id any more, so neither Stop nor
+ * {@link stopBoardAutoRun} can ever reach it, while its generation keeps running
+ * tools against the same worktree. One overnight board accumulated five live
+ * Builders on a single task this way. Called after the new id is committed, so
+ * the resulting stream-end matches no task and cannot move the card.
+ */
+function stopReplacedBoardTaskChat(previousChatId: string, nextChatId: string): void {
+  const previous = previousChatId.trim();
+  if (!previous || previous === nextChatId.trim()) return;
+  // Only a chat still holding a turn needs stopping. An already-settled chat is
+  // left untouched so replacement keeps its existing stream-end / retry routing.
+  if (!isTaskChatGenerationLive(previous) && !isTaskChatActive(previous)) return;
+  stopTaskChatSupervision(previous);
+  stopGeneration(previous, 'system');
 }
 
 function ensureStreamEndSubscription(): void {
@@ -1908,6 +1978,8 @@ export function isTaskChatActive(chatId: string): boolean {
  * not healthy occupancy — treat them as idle so auto-pilot can recover.
  */
 export function isTaskChatActiveForStallCheck(chatId: string): boolean {
+  // A turn in flight is never a leaked reservation, whatever the UI flags say.
+  if (isTaskChatGenerationLive(chatId)) return true;
   if (
     isLaunchReserved(chatId) &&
     !isChatStreaming(chatId) &&
@@ -5305,6 +5377,8 @@ export type AutoDelegateNextOptions = {
    * for a leaked slot before streaming/turn-setup begins.
    */
   allowStalledRestart?: boolean;
+  /** Quiet period a chat must exceed before counting as stalled (poll safety net). */
+  stallQuietMs?: number;
 };
 
 /** Start all ready planned tasks up to the concurrency cap (auto-pilot / sequential). */
@@ -5320,13 +5394,13 @@ export async function autoDelegateNext(
   if (!board || !isBoardRunning(group)) return;
 
   const allowStalledRestart = options.allowStalledRestart !== false;
+  const stallCheck = stallCheckWithQuietPeriod(Math.max(0, options.stallQuietMs ?? 0));
   const waveOrder = new Map(board.waves.map((w, i) => [String(w.id), i]));
   const ready = board.tasks
     .filter(
       (t) =>
         isTaskReadyForAuto(board, t) ||
-        (allowStalledRestart &&
-          isTaskStalledForRestart(board, t, isTaskChatActiveForStallCheck)),
+        (allowStalledRestart && isTaskStalledForRestart(board, t, stallCheck)),
     )
     .sort((a, b) => {
       const wa = waveOrder.get(String(a.wave)) ?? 999;
@@ -5351,14 +5425,18 @@ function isBoardCandidateForWakeReconcile(group: ChatGroup): boolean {
   return (
     board.systemPaused === true &&
     board.userStopped !== true &&
+    // An OOM pause is deliberate ("press Start when ready"); resuming it here
+    // put the board straight back into the crash loop 20s after recovery.
+    !isOomPauseActive() &&
     hasIncompleteOrchestrateWork(board)
   );
 }
 
-/** Restore auto-run after sleep/lock system pause (not user Stop). */
+/** Restore auto-run after sleep/lock system pause (not user Stop or OOM pause). */
 function resumeSystemPausedBoardAfterWake(group: ChatGroup, plannerChat: Chat): void {
   const board = group.orchestrateBoard;
   if (!board?.systemPaused || board.userStopped === true) return;
+  if (isOomPauseActive()) return;
   if (!hasIncompleteOrchestrateWork(board)) return;
   if (isUserStoppedChat(plannerChat)) return;
   const wasRunning = board.autoRunning === true;
@@ -5373,10 +5451,20 @@ function resumeSystemPausedBoardAfterWake(group: ChatGroup, plannerChat: Chat): 
  * Clear leaked streaming / launch flags when the task chat transcript already ended
  * (common after macOS display sleep throttling).
  */
-function reconcileStaleBoardTaskChatActivity(chatId: string): boolean {
+function reconcileStaleBoardTaskChatActivity(
+  chatId: string,
+  minQuietMs = 0,
+): boolean {
   const trimmed = chatId.trim();
   if (!trimmed) return false;
   const chat = findChatById(trimmed);
+
+  // Never clear flags for — or finalize — a chat whose turn is still running.
+  // `setStreaming(false)` below only drops a UI flag; it does not abort the
+  // generation, so treating a live chat as stale forks a second chat onto the
+  // same task while the first keeps writing.
+  if (isTaskChatGenerationLive(trimmed)) return false;
+  if (isRecentlyActiveTaskChat(trimmed, minQuietMs)) return false;
 
   if (isTaskChatActiveForStallCheck(trimmed)) {
     if (!chat) return false;
@@ -5413,21 +5501,25 @@ function boardTimerContextForWake(
   };
 }
 
-async function reconcileBoardTasksAfterWake(group: ChatGroup, planner: Chat): Promise<void> {
+async function reconcileBoardTasksAfterWake(
+  group: ChatGroup,
+  planner: Chat,
+  minQuietMs = 0,
+): Promise<void> {
   const board = group.orchestrateBoard;
   if (!board) return;
 
   for (const task of board.tasks) {
     if (task.status === 'in_progress') {
       const chatId = task.chatId?.trim();
-      if (chatId && reconcileStaleBoardTaskChatActivity(chatId)) {
+      if (chatId && reconcileStaleBoardTaskChatActivity(chatId, minQuietMs)) {
         finalizeBoardTaskOnStreamEnd(group, task, planner);
       }
       continue;
     }
     if (task.status === 'testing') {
       const testId = task.testChatId?.trim();
-      if (testId && reconcileStaleBoardTaskChatActivity(testId)) {
+      if (testId && reconcileStaleBoardTaskChatActivity(testId, minQuietMs)) {
         await finalizeTaskTestingOnStreamEnd(group, task, planner).catch((err) =>
           reportBackgroundError('wake-finalize-task-testing', err),
         );
@@ -5437,7 +5529,7 @@ async function reconcileBoardTasksAfterWake(group: ChatGroup, planner: Chat): Pr
 
   const finalChatId = board.finalTest?.chatId?.trim();
   if (board.finalTest?.status === 'in_progress' && finalChatId) {
-    if (reconcileStaleBoardTaskChatActivity(finalChatId)) {
+    if (reconcileStaleBoardTaskChatActivity(finalChatId, minQuietMs)) {
       finalizeFinalTestOnStreamEnd(group, planner);
     }
   }
@@ -5449,6 +5541,13 @@ async function reconcileBoardTasksAfterWake(group: ChatGroup, planner: Chat): Pr
  */
 export type DisplayWakeReconcileOptions = {
   allowStalledRestart?: boolean;
+  /**
+   * Minimum quiet period before a chat may be treated as stale/stalled. The
+   * interval-driven liveness poll sets this so a plain 20s tick can never
+   * finalize or restart a chat that is still producing output; real wake events
+   * (visibility / screen unlock) leave it at 0 and reconcile immediately.
+   */
+  minQuietMs?: number;
 };
 
 export async function reconcileRunningBoardsAfterDisplayWake(
@@ -5457,19 +5556,21 @@ export async function reconcileRunningBoardsAfterDisplayWake(
   if (!sessionState?.groups?.length) return;
   ensureStreamEndSubscription();
   const allowStalledRestart = options.allowStalledRestart === true;
+  const minQuietMs = Math.max(0, options.minQuietMs ?? 0);
+  const stallCheck = stallCheckWithQuietPeriod(minQuietMs);
   for (const group of sessionState.groups) {
     if (!isBoardCandidateForWakeReconcile(group)) continue;
     const planner = getPlannerChatForGroup(group);
     if (!planner) continue;
 
     resumeSystemPausedBoardAfterWake(group, planner);
-    await reconcileBoardTasksAfterWake(group, planner);
+    await reconcileBoardTasksAfterWake(group, planner, minQuietMs);
 
     await reconcileMergingTasks(group, planner, {
-      isFixerChatActive: isTaskChatActiveForStallCheck,
+      isFixerChatActive: stallCheck,
     });
     if (isBoardRunning(group)) {
-      await autoDelegateNext(group, planner, { allowStalledRestart });
+      await autoDelegateNext(group, planner, { allowStalledRestart, stallQuietMs: minQuietMs });
     }
     syncOrchestrateBoardTimer(group, planner, boardTimerContextForWake(group.orchestrateBoard!, planner));
     emitBoardChange(group.id);

--- a/src/ui/composer-pinned-skill.ts
+++ b/src/ui/composer-pinned-skill.ts
@@ -72,7 +72,9 @@ function ensureStrip(): HTMLDivElement {
   const host = document.getElementById('composerControls');
   const anchor = document.getElementById('workAgentDev');
   if (host) {
-    if (anchor) {
+    // The anchor is parked in the compact cog sheet at times, so it is not
+    // always a child of the toolbar — insertBefore would throw NotFoundError.
+    if (anchor?.parentNode === host) {
       host.insertBefore(stripEl, anchor);
     } else {
       host.appendChild(stripEl);

--- a/src/ui/composer-run-target.ts
+++ b/src/ui/composer-run-target.ts
@@ -259,7 +259,9 @@ function ensureControls(): HTMLDivElement {
   const host = document.getElementById('composerControls');
   const anchor = document.getElementById('composerThinkingWrap');
   if (host) {
-    if (anchor) {
+    // The anchor is parked in the compact cog sheet at times, so it is not
+    // always a child of the toolbar — insertBefore would throw NotFoundError.
+    if (anchor?.parentNode === host) {
       host.insertBefore(wrapEl, anchor);
     } else {
       host.appendChild(wrapEl);

--- a/src/ui/orchestrate-plan-selector.ts
+++ b/src/ui/orchestrate-plan-selector.ts
@@ -51,9 +51,16 @@ function getComposerControls(): HTMLElement | null {
 /** Home in toolbar: after thinking toggle, before work-agent dev strip. */
 function insertPlanStripInToolbar(strip: HTMLElement): void {
   const toolbar = getComposerControls();
-  const anchor = document.getElementById('workAgentDev');
   if (!toolbar) return;
-  if (anchor) {
+  // Compact parks the strip (and the work-agent anchor) in the cog sheet;
+  // pulling it back here would undo that parking.
+  if (toolbar.classList.contains('composer-controls--compact') && !toolbar.contains(strip)) {
+    return;
+  }
+  const anchor = document.getElementById('workAgentDev');
+  // The anchor is parked in the cog sheet while compact, so it is not always
+  // a child of the toolbar — insertBefore would throw NotFoundError.
+  if (anchor?.parentNode === toolbar) {
     toolbar.insertBefore(strip, anchor);
   } else {
     toolbar.appendChild(strip);

--- a/test/orchestrate/board-display-wake.test.mts
+++ b/test/orchestrate/board-display-wake.test.mts
@@ -17,6 +17,19 @@ import {
 } from '../../src/state/orchestrate-board-actions.ts';
 import { resetBoardDisplayWakeLivenessForTests } from '../../src/chat/orchestrate/board-display-wake.ts';
 import { registerOrchestrateBoardShutdownHandler, resetOrchestrateBoardShutdownRegistrationForTests } from '../../src/chat/orchestrate/board-shutdown.ts';
+import {
+  bindRunSupervision,
+  bumpProgress,
+  chatTaskRunId,
+  createRunSupervision,
+  resetWrapperState,
+} from '../../src/agents/controller/wrapper.ts';
+import {
+  clearMainTurnActivity,
+  emitMainTurnActivity,
+} from '../../src/chat/main-turn-activity.ts';
+import { setOomPauseActiveForBoot } from '../../src/chat/orchestrate/oom-recovery.ts';
+import { isChatStreaming } from '../../src/chat/streaming-state.ts';
 import { setStreaming } from '../../src/app-state.ts';
 import { initBoard } from '../../src/state/orchestrate-board-store.ts';
 import { setSessionStateForTests } from '../../src/state/sessions.ts';
@@ -117,6 +130,9 @@ describe('board display wake reconcile', () => {
     resetAfkBoardPowerGuardForTests();
     resetOrchestrateBoardShutdownRegistrationForTests();
     resetBoardDisplayWakeLivenessForTests();
+    clearMainTurnActivity(TASK_CHAT_ID);
+    resetWrapperState();
+    setOomPauseActiveForBoot(false);
     setStreaming(false);
     happyDomWindow?.close();
     happyDomWindow = undefined;
@@ -228,6 +244,89 @@ describe('board display wake reconcile', () => {
 
     assert.equal(group.orchestrateBoard!.autoRunning, false);
     assert.equal(group.orchestrateBoard!.systemPaused, true);
+  });
+
+  test('reconcile leaves a task chat with a turn still in flight alone', async () => {
+    const planner = makePlanner();
+    const taskChat = makeTaskChat();
+    const group = makeGroup();
+
+    setSessionStateForTests({
+      version: 5,
+      activeId: PLANNER_ID,
+      chats: [planner, taskChat],
+      groups: [group],
+    });
+
+    // Mid-turn: history's last entry is an ordinary assistant message (which
+    // reads as `completed`), but the turn is still running tools.
+    setStreaming(true, TASK_CHAT_ID);
+    emitMainTurnActivity({
+      chatId: TASK_CHAT_ID,
+      phase: 'tools',
+      currentTool: 'run_terminal_command',
+      workAgentLabel: 'Builder',
+      modelId: 'm1',
+      providerId: 'p1',
+      startedAtMs: Date.now(),
+    });
+
+    await reconcileRunningBoardsAfterDisplayWake({ allowStalledRestart: true });
+
+    const task = group.orchestrateBoard!.tasks[0]!;
+    assert.equal(task.status, 'in_progress');
+    assert.equal(task.chatId, TASK_CHAT_ID);
+    assert.equal(isChatStreaming(TASK_CHAT_ID), true);
+  });
+
+  test('liveness poll quiet period spares a chat that just produced output', async () => {
+    const planner = makePlanner();
+    const taskChat = makeTaskChat();
+    const group = makeGroup();
+
+    setSessionStateForTests({
+      version: 5,
+      activeId: PLANNER_ID,
+      chats: [planner, taskChat],
+      groups: [group],
+    });
+
+    bindRunSupervision(chatTaskRunId(TASK_CHAT_ID), createRunSupervision());
+    bumpProgress(chatTaskRunId(TASK_CHAT_ID));
+
+    await reconcileRunningBoardsAfterDisplayWake({
+      allowStalledRestart: true,
+      minQuietMs: 180_000,
+    });
+
+    assert.equal(group.orchestrateBoard!.tasks[0]!.status, 'in_progress');
+
+    // Same board, no quiet period (a real wake): the finished chat advances.
+    await reconcileRunningBoardsAfterDisplayWake();
+    assert.equal(group.orchestrateBoard!.tasks[0]!.status, 'testing');
+  });
+
+  test('reconcile does not auto-resume a board paused after an OOM crash', async () => {
+    const planner = makePlanner();
+    const taskChat = makeTaskChat();
+    const group = makeGroup();
+    const board = group.orchestrateBoard!;
+    board.autoRunning = false;
+    board.systemPaused = true;
+    setOomPauseActiveForBoot(true);
+
+    setSessionStateForTests({
+      version: 5,
+      activeId: PLANNER_ID,
+      chats: [planner, taskChat],
+      groups: [group],
+    });
+
+    await reconcileRunningBoardsAfterDisplayWake({ allowStalledRestart: true });
+
+    assert.equal(board.autoRunning, false);
+    assert.equal(board.systemPaused, true);
+    assert.equal(board.tasks[0]!.status, 'in_progress');
   });
 
   test('AFK power guard ref-count tracks board start/stop', () => {

--- a/test/ui/orchestrate-plan-selector.test.mts
+++ b/test/ui/orchestrate-plan-selector.test.mts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
-import { shouldMountOrchestratePlanInInputRow } from '../../src/ui/orchestrate-plan-selector.ts';
+import { afterEach, describe, test } from 'node:test';
+import { Window } from 'happy-dom';
+import { installHappyDomGlobals } from '../os/dom-helpers.mts';
+import {
+  shouldMountOrchestratePlanInInputRow,
+  syncOrchestratePlanStripFromActiveChat,
+} from '../../src/ui/orchestrate-plan-selector.ts';
+import { createEmptyChatObject, setSessionStateForTests } from '../../src/state/sessions.ts';
 
 describe('shouldMountOrchestratePlanInInputRow', () => {
   test('false outside Orchestrate mode', () => {
@@ -30,5 +36,61 @@ describe('shouldMountOrchestratePlanInInputRow', () => {
       }),
       false,
     );
+  });
+});
+
+describe('plan strip toolbar placement', () => {
+  let windowInstance: Window | null = null;
+
+  afterEach(() => {
+    windowInstance?.close();
+    windowInstance = null;
+    setSessionStateForTests(null);
+  });
+
+  // Regression: compact parks both the plan strip and its `#workAgentDev`
+  // anchor in the cog sheet, so insertBefore against the toolbar threw
+  // NotFoundError when a new chat synced the strip.
+  test('compact-parked strip is left in the cog sheet, not re-inserted', async () => {
+    windowInstance = new Window();
+    installHappyDomGlobals(windowInstance);
+
+    const bar = document.createElement('div');
+    bar.className = 'input-bar';
+    const row = document.createElement('div');
+    row.id = 'composerControls';
+    row.className = 'composer-controls composer-controls--compact';
+    const wrap = document.createElement('div');
+    wrap.className = 'input-wrap';
+    const page = document.createElement('div');
+    page.id = 'composerOverflowSettingsPage';
+
+    const strip = document.createElement('div');
+    strip.id = 'orchestratePlanStrip';
+    const select = document.createElement('select');
+    select.id = 'orchestratePlanSelect';
+    const hint = document.createElement('span');
+    hint.id = 'orchestratePlanHint';
+    strip.append(select, hint);
+    const workAgentDev = document.createElement('div');
+    workAgentDev.id = 'workAgentDev';
+    page.append(strip, workAgentDev);
+
+    bar.append(row, wrap);
+    document.body.append(bar, page);
+
+    const chat = createEmptyChatObject('');
+    chat.modeId = 'build';
+    setSessionStateForTests({
+      version: 2,
+      activeId: chat.id,
+      sidebarCollapsed: false,
+      chats: [chat],
+    });
+
+    await syncOrchestratePlanStripFromActiveChat();
+
+    assert.equal(strip.parentElement?.id, 'composerOverflowSettingsPage');
+    assert.equal(strip.classList.contains('hidden'), true);
   });
 });


### PR DESCRIPTION
## Summary

Overnight orchestrate boards were breaking down almost entirely: tasks quarantined and relaunched repeatedly for hours, with multiple orphaned agents ending up concurrently editing the same worktree. Root-caused from a board's `orchestrate/grp_*.jsonl` run log.

**Root cause:** the display-wake liveness poll (`src/chat/orchestrate/board-display-wake.ts`) is armed after any reload or wake event and re-fires every 20 seconds while a board is running. It decides whether a task chat "finished" using only persisted transcript history (`resolveTaskChatStreamOutcome`), which cannot distinguish a chat that is genuinely done from one that's mid-turn between tool calls — both read as an ordinary trailing assistant message. When the poll judged a live chat "stale" it cleared the streaming flag (a UI-only `Set`, not an abort — the generation kept running) and finalized the task as "ended without board_report," which nudged, failed, and quarantined it, then relaunched a fresh chat on the same task. The original chat kept running unsupervised against the same worktree. On the board I inspected, this produced up to 7 concurrent orphaned Builder chats on a single task before it was manually stopped.

The bug required a reload/wake to arm (boot or the `.finally` of a wake reconcile), which is why wave 1 of that board — run without any intervening reload — completed cleanly while wave 2, after an OOM-crash reload, degenerated over ~4.5 hours.

## Changes

- `isTaskChatGenerationLive()`: positive proof a task chat's turn is still in flight, via main-turn activity + the chat's abort controller — both owned by `runChatTurn` and cleared only in its `finally`. (`chat.currentGenerationId` was tried as a third signal but isn't reliably cleared on every completion path, so it was dropped — caught by e2e test regressions.) Live chats are now never treated as stale or stalled by the wake/poll path.
- 180s quiet-period floor specific to the interval-driven liveness poll — a plain 20s tick can no longer finalize or restart a chat producing output, measured on a clock that freezes while the display is asleep. Real wake events (visibility change, screen unlock) still reconcile immediately with no quiet period.
- Replacing a task's `chatId` / `testChatId` / `fixerChatId` now stops the chat being replaced if it's still live, instead of silently orphaning it (nothing on the board holds that id anymore, so neither Stop nor `stopBoardAutoRun` could ever reach it).
- OOM-paused boards ("press Start when ready") are no longer auto-resumed by the wake/poll path.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `test/orchestrate/board-display-wake.test.mts` — 9/9 pass, including 3 new regression tests that fail on the pre-fix code and pass after
- [x] `test/orchestrate/*.test.{mts,mjs}` — 465/465 pass
- [x] `test/chat/orchestrate/*.test.mts` — 48/48 pass
- [x] `test/ui/orchestrate*.test.*` + `test/agents/*.test.*` — 232/232 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)