### PR TITLE
Refresh product wiki catalog hashes

### DIFF
--- a/server/product-wiki/catalog.json
+++ b/server/product-wiki/catalog.json
@@ -54,7 +54,7 @@
         "Related"
       ],
       "section": "Get started",
-      "hash": "d5bbe1367870018c7c76f16b32a08b4b98b9dcd40b0029d8147b5426db1a04ab"
+      "hash": "5ffb28861b628764840c413f77e1103c40021e318b95c9e8966cd75810222624"
     },
     {
       "path": "documentation/manual/get-started/first-chat.md",
@@ -163,7 +163,7 @@
         "Related"
       ],
       "section": "Chat",
-      "hash": "06f8922a60a952f3e824b39c9f5ae53bf5225a6df037b7dcc6fffe8b9cfdd3f7"
+      "hash": "c8e8c3f8be6c0f83c5ddab581f919e1c3dcef52a2c396b785483afeeebc2fdb9"
     },
     {
       "path": "documentation/manual/chat/skills-and-commands.md",
@@ -217,7 +217,7 @@
         "Related"
       ],
       "section": "Apps",
-      "hash": "c096d27f160a5e07f948eaf05b7740eae662d1dd24d59ea44d802f9ca9a4a287"
+      "hash": "c8ccf53ebf0577a9a936a460599b85d6e25ee04514d8be1cae946fe578ef146f"
     },
     {
       "path": "documentation/manual/apps/research.md",
@@ -256,6 +256,7 @@
       "title": "Models",
       "summary": "This is where you set up what the agents run on: what your machine can handle, what you have downloaded, what is serving, which endpoints Minnow talks to, which model does which job, and what it all costs. You come here to configure, then go back to Code and work. Open it from th",
       "headings": [
+        "Local Server",
         "Recommendations",
         "Library and Installed",
         "MLX on Apple Silicon",
@@ -270,7 +271,7 @@
         "Related"
       ],
       "section": "Apps",
-      "hash": "97704b3175fa0f815d7b5e07ad552f1254d67461a57d47a935c0750733e31956"
+      "hash": "23427027d6503c919b4716d125a8592088f4f53e0e93aa4eef6c2f9a64e641dd"
     },
     {
       "path": "documentation/manual/apps/issues.md",
@@ -286,7 +287,7 @@
         "Related"
       ],
       "section": "Apps",
-      "hash": "48bebf8bfc47dbc226ac851b8531bcc4354a70ef52a963a59dfcd5ca10a30253"
+      "hash": "11777fa60b247c2d422fa0b398a35616b847254fa2b3f892311105fb89d1d68a"
     },
     {
       "path": "documentation/manual/apps/scheduler.md",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`npm run test:product-wiki` compares the committed `server/product-wiki/catalog.json` to a freshly generated catalog. After recent manual edits on `main` (including the MIN-627 merge), a few page hashes and one Models heading (`Local Server`) drifted.

## What

Regenerated the catalog with `node scripts/generate-product-wiki-catalog.mjs`. No manual page content changes in this PR.

## Verify

- `test/product-wiki/product-wiki.test.mjs` passes locally and the **product wiki** CI job is green on this PR.
- Other red CI jobs on this run (`typecheck + tests` eager-graph CodeMirror imports, **performance budgets**) reproduce on latest `main` with the same failures and are unrelated to `catalog.json` (server-only, not in the Vite bundle). Fix those on dedicated PRs; do not ratchet budgets or rewrite the editor boot graph here.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MIN-627](https://linear.app/minnowai/issue/MIN-627/cant-delete-rule-groups)

<div><a href="https://cursor.com/agents/bc-6fc8158e-d2ef-4e55-bbdc-393ca5c6f8df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fc8158e-d2ef-4e55-bbdc-393ca5c6f8df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

