### PR TITLE
fix(terminal): preserve quoted args in Windows one-shot commands (MIN-269)

### DIFF
--- a/server/terminal/one-shot-spawn.js
+++ b/server/terminal/one-shot-spawn.js
@@ -149,10 +149,13 @@ export function resolveOneShotSpawn({
   }
 
   if (winOneShot) {
+    // Let Node build the cmd.exe /d /s /c line (shell:true). Passing the raw
+    // string as an argv element with shell:false lets libuv escape inner quotes
+    // as \" — which cmd.exe does not understand (MIN-269).
     return {
-      command: 'cmd.exe',
-      args: ['/d', '/s', '/c', command],
-      shell: false,
+      command,
+      args: [],
+      shell: true,
     };
   }
 

--- a/test/server/one-shot-spawn.test.mjs
+++ b/test/server/one-shot-spawn.test.mjs
@@ -46,15 +46,15 @@ describe('resolveOneShotSpawn', () => {
     }
   });
 
-  it('uses cmd.exe for Windows one-shot strings', () => {
+  it('passes Windows one-shot strings through shell:true (cmd-aware quoting)', () => {
     const win = resolveOneShotSpawn({
       command: 'echo MINNOW_WIN',
       args: [],
       platform: 'win32',
     });
-    assert.equal(win.command, 'cmd.exe');
-    assert.deepEqual(win.args, ['/d', '/s', '/c', 'echo MINNOW_WIN']);
-    assert.equal(win.shell, false);
+    assert.equal(win.command, 'echo MINNOW_WIN');
+    assert.deepEqual(win.args, []);
+    assert.equal(win.shell, true);
   });
 
   it('routes Windows one-shot strings through WSL when profile is wsl', () => {
@@ -123,7 +123,7 @@ describe('resolveOneShotSpawn', () => {
     assert.equal(resolved.shell, false);
   });
 
-  it('keeps PowerShell profile one-shots on cmd.exe', () => {
+  it('keeps PowerShell profile one-shots on the cmd shell', () => {
     const win = resolveOneShotSpawn({
       command: 'echo MINNOW_WIN',
       args: [],
@@ -137,8 +137,9 @@ describe('resolveOneShotSpawn', () => {
         runtime: 'native',
       },
     });
-    assert.equal(win.command, 'cmd.exe');
-    assert.deepEqual(win.args, ['/d', '/s', '/c', 'echo MINNOW_WIN']);
+    assert.equal(win.command, 'echo MINNOW_WIN');
+    assert.deepEqual(win.args, []);
+    assert.equal(win.shell, true);
   });
 
   it('passes argv invocations through unchanged', () => {
@@ -185,6 +186,31 @@ describe('executeCommandBlocking unix shell strings', () => {
 
     assert.match(output, new RegExp(marker));
     assert.doesNotMatch(output, /\(no output\)/);
+
+    await rmTestHome(homeDir);
+    homeDir = undefined;
+  });
+});
+describe('executeCommandBlocking windows one-shot quoting (MIN-269)', () => {
+  let homeDir;
+
+  it('preserves double-quoted args through the cmd.exe one-shot path', async () => {
+    if (process.platform !== 'win32') return;
+
+    homeDir = setTestHome(process.env, 'minnow-test-win-quoting');
+    await ensureMinnowLayout();
+    await initWorkspaceRoot();
+    await setWorkspaceRoot(repoRoot);
+
+    const output = await executeCommandBlocking({
+      command: 'echo A "x - y" B',
+      cwd: repoRoot,
+    });
+
+    // Before MIN-269 the libuv \" escaping reached cmd literally and the
+    // argument split at spaces (echo printed A \"x - y\" B).
+    assert.match(output, /A "x - y" B/);
+    assert.doesNotMatch(output, /\\"/);
 
     await rmTestHome(homeDir);
     homeDir = undefined;

--- a/test/terminal/sandbox/policy.test.mjs
+++ b/test/terminal/sandbox/policy.test.mjs
@@ -184,13 +184,13 @@ describe('wrapSandbox argv composition', () => {
       workspaceRoot: FAKE_WORKSPACE,
       platform: 'win32',
     });
-    // No WSL fixtures → honest unavailable; leave cmd.exe untouched (do not rewrite to bare wsl).
+    // No WSL fixtures → honest unavailable; leave the spawn target untouched (do not rewrite to bare wsl).
     const wrapped = wrapSandbox(resolved, policy, {
       platform: 'win32',
       wsl: { skipLiveProbe: true, wslFixtures: { listOutput: '' } },
     });
 
-    assert.equal(wrapped.command, 'cmd.exe');
+    assert.equal(wrapped.command, 'echo hi');
     assert.equal(wrapped.sandbox.applied, false);
     assert.equal(wrapped.sandbox.kind, 'wsl-landlock');
     assert.equal(

--- a/test/terminal/sandbox/wsl-landlock.test.mjs
+++ b/test/terminal/sandbox/wsl-landlock.test.mjs
@@ -177,13 +177,15 @@ describe('WSL argv split / ensure / recover', () => {
     assert.deepEqual(split.innerArgv, ['bash', '-l', '-c', 'echo hi']);
   });
 
-  it('recovers cmd.exe /c one-shots and routes through WSL', () => {
+  it('recovers Windows one-shot strings and routes through WSL', () => {
     const resolved = resolveOneShotSpawn({
       command: 'npm test',
       args: [],
       platform: 'win32',
     });
-    assert.equal(resolved.command, 'cmd.exe');
+    assert.equal(resolved.command, 'npm test');
+    assert.deepEqual(resolved.args, []);
+    assert.equal(resolved.shell, true);
     const recovered = recoverCommandFromWinSpawn(resolved);
     assert.equal(recovered.command, 'npm test');
     assert.deepEqual(recovered.args, []);


### PR DESCRIPTION
## What

Fixes one-shot `execute_command` on Windows mangling **double-quoted arguments** (MIN-269).

`resolveOneShotSpawn` passed the command string as an argv element to `cmd.exe /d /s /c` with `shell: false`. With `shell: false`, libuv escapes embedded `"` as `\"` (C-runtime style) — but cmd.exe doesn't understand `\"`, treating `\` literally and `"` as a quote toggle. Quoted arguments split at spaces.

Observed failures (all reproduced byte-for-byte via the real spawn path):

- `gh release create v0.1.1 --repo HenriGrimm/Minnow --title "v0.1.1 - Open Beta" --draft ...` → exit 1, `no matches found for \`-\`` — gh received `--title v0.1.1` then standalone `-`, `Open`, `Beta` tokens
- `git log v0.1.0..HEAD --pretty=format:"%h %ad %s" --date=short` → exit 128, `fatal: ambiguous argument '%ad'`
- `powershell -NoProfile -Command "Write-Output 'ps works'"` → exit 0, echoed the command text instead of running it

## Why

Every agent command with a quoted argument was silently corrupted on Windows — the primary agent shell surface (default shell profile is PowerShell, one-shots run through cmd). This made release tooling, `git log` formatting, and any PowerShell invocation unreliable. The workaround (temp `.cmd` files) is not viable for agents in general.

## Change

`server/terminal/one-shot-spawn.js` — the win32 one-shot branch now returns `{ command, args: [], shell: true }` instead of `{ command: 'cmd.exe', args: ['/d','/s','/c', command], shell: false }`. Node builds the cmd.exe invocation with its own cmd-aware quoting, so embedded `"` survive.

- **WSL-landlock sandbox:** unaffected — `recoverCommandFromWinSpawn` falls back to the bare command string, which is exactly the inner command for a `shell: true` one-shot.
- **Git Bash / WSL / Unix one-shot paths:** unchanged (POSIX shells understand `\"`; the bug was cmd-specific).
- **`node -e` / `python -c` rewrite:** still short-circuits before the cmd path.

## Tests

- Updated `test/server/one-shot-spawn.test.mjs`, `test/terminal/sandbox/policy.test.mjs`, `test/terminal/sandbox/wsl-landlock.test.mjs` to assert the new spawn shape.
- Added a win32 regression test that runs the real spawn path: `echo A "x - y" B` must print the quoted token intact (fails under the old code with `A \"x - y\" B`).
- 69/69 affected tests pass locally on Windows. Two unrelated terminal-suite failures are pre-existing environment issues (live WSL probes against a docker-desktop distro without `bash`) and don't touch the changed branch.

## Notes

- The fix takes effect after a dev-server restart (module cache).
- Plan: `documentation/plans/windows-execute-command-quoting.md`.